### PR TITLE
docs: README에 브랜치 보호 및 코드 소유자 규칙 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,18 @@ sdk install java 21.0.7-tem
 
 ---
 
-## 브랜치 전략
+## 브랜치 & PR 규칙
 
 - `main` — 보호 브랜치, 직접 push 금지
-- PR + CODEOWNERS 리뷰 승인 + CI 통과 필수
+- PR 머지 조건:
+  - **코드 소유자 최소 1명 승인** 필요
+  - CI 테스트 통과
+  - 승인 후 코드 변경 시 승인 초기화 (dismiss stale reviews)
+
+### 코드 소유자
+
+모든 파일에 대해 다음 5명이 코드 소유자:
+
+`@cjang3285` `@xihxxn` `@xhae123` `@Suuunz` `@sunwoo1256`
+
+이 중 1명 이상이 승인해야 PR 머지 가능.


### PR DESCRIPTION
## Summary
- 브랜치 보호 규칙 (코드 소유자 승인 필수, stale review dismiss) 내용 추가
- 코드 소유자 5명 명시

## Test plan
- [x] README 내용 확인