### PR TITLE
refactor: 세션보드 엔티티를 common 모듈로 이동

### DIFF
--- a/common/src/main/java/com/study/common/entity/Comment.java
+++ b/common/src/main/java/com/study/common/entity/Comment.java
@@ -1,4 +1,4 @@
-package com.study.sessionboard.entity;
+package com.study.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -17,23 +17,28 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "session_note")
+@Table(name = "comment")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SessionNote {
+public class Comment {
 
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "session_id", nullable = false)
-  private Session session;
+  @JoinColumn(name = "post_id", nullable = false)
+  private EventPost post;
 
   @Column(name = "author_id", nullable = false)
   private UUID authorId;
 
-  private String body;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "parent_id")
+  private Comment parent;
+
+  @Column(nullable = false)
+  private String content;
 
   @Column(name = "created_at", nullable = false, updatable = false)
   private OffsetDateTime createdAt;
@@ -43,10 +48,17 @@ public class SessionNote {
     createdAt = OffsetDateTime.now();
   }
 
-  public static SessionNote of(Session session, UUID authorId) {
-    SessionNote note = new SessionNote();
-    note.session = session;
-    note.authorId = authorId;
-    return note;
+  public static Comment of(EventPost post, UUID authorId, String content) {
+    Comment comment = new Comment();
+    comment.post = post;
+    comment.authorId = authorId;
+    comment.content = content;
+    return comment;
+  }
+
+  public static Comment ofReply(EventPost post, UUID authorId, Comment parent, String content) {
+    Comment comment = of(post, authorId, content);
+    comment.parent = parent;
+    return comment;
   }
 }

--- a/common/src/main/java/com/study/common/entity/EventPost.java
+++ b/common/src/main/java/com/study/common/entity/EventPost.java
@@ -1,4 +1,4 @@
-package com.study.sessionboard.entity;
+package com.study.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/common/src/main/java/com/study/common/entity/Like.java
+++ b/common/src/main/java/com/study/common/entity/Like.java
@@ -1,4 +1,4 @@
-package com.study.sessionboard.entity;
+package com.study.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -8,8 +8,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -17,30 +19,35 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(
-    name = "session_speaker",
-    uniqueConstraints = @UniqueConstraint(columnNames = {"session_id", "user_id"}))
+    name = "\"like\"",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "post_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SessionSpeaker {
+public class Like {
 
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "session_id", nullable = false)
-  private Session session;
-
   @Column(name = "user_id", nullable = false)
   private UUID userId;
 
-  @Column
-  private String role;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "post_id", nullable = false)
+  private EventPost post;
 
-  public static SessionSpeaker of(Session session, UUID userId) {
-    SessionSpeaker speaker = new SessionSpeaker();
-    speaker.session = session;
-    speaker.userId = userId;
-    return speaker;
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private OffsetDateTime createdAt;
+
+  @PrePersist
+  void prePersist() {
+    createdAt = OffsetDateTime.now();
+  }
+
+  public static Like of(UUID userId, EventPost post) {
+    Like like = new Like();
+    like.userId = userId;
+    like.post = post;
+    return like;
   }
 }

--- a/common/src/main/java/com/study/common/entity/NoteLink.java
+++ b/common/src/main/java/com/study/common/entity/NoteLink.java
@@ -1,4 +1,4 @@
-package com.study.sessionboard.entity;
+package com.study.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -8,27 +8,27 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
-import java.time.OffsetDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "post_image")
+@Table(name = "note_link")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PostImage {
+public class NoteLink {
 
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "post_id", nullable = false)
-  private EventPost post;
+  @JoinColumn(name = "note_id", nullable = false)
+  private SessionNote note;
+
+  private String label;
 
   @Column(nullable = false)
   private String url;
@@ -36,18 +36,10 @@ public class PostImage {
   @Column(name = "\"order\"", nullable = false)
   private int order = 0;
 
-  @Column(name = "created_at", nullable = false, updatable = false)
-  private OffsetDateTime createdAt;
-
-  @PrePersist
-  void prePersist() {
-    createdAt = OffsetDateTime.now();
-  }
-
-  public static PostImage of(EventPost post, String url) {
-    PostImage image = new PostImage();
-    image.post = post;
-    image.url = url;
-    return image;
+  public static NoteLink of(SessionNote note, String url) {
+    NoteLink link = new NoteLink();
+    link.note = note;
+    link.url = url;
+    return link;
   }
 }

--- a/common/src/main/java/com/study/common/entity/PostImage.java
+++ b/common/src/main/java/com/study/common/entity/PostImage.java
@@ -1,4 +1,4 @@
-package com.study.sessionboard.entity;
+package com.study.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -8,27 +8,27 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "note_link")
+@Table(name = "post_image")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class NoteLink {
+public class PostImage {
 
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "note_id", nullable = false)
-  private SessionNote note;
-
-  private String label;
+  @JoinColumn(name = "post_id", nullable = false)
+  private EventPost post;
 
   @Column(nullable = false)
   private String url;
@@ -36,10 +36,18 @@ public class NoteLink {
   @Column(name = "\"order\"", nullable = false)
   private int order = 0;
 
-  public static NoteLink of(SessionNote note, String url) {
-    NoteLink link = new NoteLink();
-    link.note = note;
-    link.url = url;
-    return link;
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private OffsetDateTime createdAt;
+
+  @PrePersist
+  void prePersist() {
+    createdAt = OffsetDateTime.now();
+  }
+
+  public static PostImage of(EventPost post, String url) {
+    PostImage image = new PostImage();
+    image.post = post;
+    image.url = url;
+    return image;
   }
 }

--- a/common/src/main/java/com/study/common/entity/PostStatus.java
+++ b/common/src/main/java/com/study/common/entity/PostStatus.java
@@ -1,4 +1,4 @@
-package com.study.sessionboard.entity;
+package com.study.common.entity;
 
 public enum PostStatus {
   draft,

--- a/common/src/main/java/com/study/common/entity/Resource.java
+++ b/common/src/main/java/com/study/common/entity/Resource.java
@@ -1,4 +1,4 @@
-package com.study.sessionboard.entity;
+package com.study.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/common/src/main/java/com/study/common/entity/ResourceVisibility.java
+++ b/common/src/main/java/com/study/common/entity/ResourceVisibility.java
@@ -1,4 +1,4 @@
-package com.study.sessionboard.entity;
+package com.study.common.entity;
 
 public enum ResourceVisibility {
   PUBLIC,

--- a/common/src/main/java/com/study/common/entity/ResourceVisibilityConverter.java
+++ b/common/src/main/java/com/study/common/entity/ResourceVisibilityConverter.java
@@ -1,4 +1,4 @@
-package com.study.sessionboard.entity;
+package com.study.common.entity;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;

--- a/common/src/main/java/com/study/common/entity/Retro.java
+++ b/common/src/main/java/com/study/common/entity/Retro.java
@@ -1,4 +1,4 @@
-package com.study.sessionboard.entity;
+package com.study.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -10,7 +10,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -18,23 +17,26 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(
-    name = "\"like\"",
-    uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "post_id"}))
+@Table(name = "retro")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Like {
+public class Retro {
 
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
-  @Column(name = "user_id", nullable = false)
-  private UUID userId;
-
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "post_id", nullable = false)
-  private EventPost post;
+  @JoinColumn(name = "session_id", nullable = false)
+  private Session session;
+
+  @Column(name = "author_id", nullable = false)
+  private UUID authorId;
+
+  /** 1 ~ 5 */
+  private Integer rating;
+
+  private String body;
 
   @Column(name = "created_at", nullable = false, updatable = false)
   private OffsetDateTime createdAt;
@@ -44,10 +46,10 @@ public class Like {
     createdAt = OffsetDateTime.now();
   }
 
-  public static Like of(UUID userId, EventPost post) {
-    Like like = new Like();
-    like.userId = userId;
-    like.post = post;
-    return like;
+  public static Retro of(Session session, UUID authorId) {
+    Retro retro = new Retro();
+    retro.session = session;
+    retro.authorId = authorId;
+    return retro;
   }
 }

--- a/common/src/main/java/com/study/common/entity/Session.java
+++ b/common/src/main/java/com/study/common/entity/Session.java
@@ -1,4 +1,4 @@
-package com.study.sessionboard.entity;
+package com.study.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/common/src/main/java/com/study/common/entity/SessionBoardTest.java
+++ b/common/src/main/java/com/study/common/entity/SessionBoardTest.java
@@ -1,4 +1,4 @@
-package com.study.sessionboard.entity;
+package com.study.common.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/common/src/main/java/com/study/common/entity/SessionNote.java
+++ b/common/src/main/java/com/study/common/entity/SessionNote.java
@@ -1,4 +1,4 @@
-package com.study.sessionboard.entity;
+package com.study.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -17,28 +17,23 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "comment")
+@Table(name = "session_note")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Comment {
+public class SessionNote {
 
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "post_id", nullable = false)
-  private EventPost post;
+  @JoinColumn(name = "session_id", nullable = false)
+  private Session session;
 
   @Column(name = "author_id", nullable = false)
   private UUID authorId;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "parent_id")
-  private Comment parent;
-
-  @Column(nullable = false)
-  private String content;
+  private String body;
 
   @Column(name = "created_at", nullable = false, updatable = false)
   private OffsetDateTime createdAt;
@@ -48,17 +43,10 @@ public class Comment {
     createdAt = OffsetDateTime.now();
   }
 
-  public static Comment of(EventPost post, UUID authorId, String content) {
-    Comment comment = new Comment();
-    comment.post = post;
-    comment.authorId = authorId;
-    comment.content = content;
-    return comment;
-  }
-
-  public static Comment ofReply(EventPost post, UUID authorId, Comment parent, String content) {
-    Comment comment = of(post, authorId, content);
-    comment.parent = parent;
-    return comment;
+  public static SessionNote of(Session session, UUID authorId) {
+    SessionNote note = new SessionNote();
+    note.session = session;
+    note.authorId = authorId;
+    return note;
   }
 }

--- a/common/src/main/java/com/study/common/entity/SessionSpeaker.java
+++ b/common/src/main/java/com/study/common/entity/SessionSpeaker.java
@@ -1,4 +1,4 @@
-package com.study.sessionboard.entity;
+package com.study.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -8,19 +8,20 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
-import java.time.OffsetDateTime;
+import jakarta.persistence.UniqueConstraint;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "retro")
+@Table(
+    name = "session_speaker",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"session_id", "user_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Retro {
+public class SessionSpeaker {
 
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
@@ -30,26 +31,16 @@ public class Retro {
   @JoinColumn(name = "session_id", nullable = false)
   private Session session;
 
-  @Column(name = "author_id", nullable = false)
-  private UUID authorId;
+  @Column(name = "user_id", nullable = false)
+  private UUID userId;
 
-  /** 1 ~ 5 */
-  private Integer rating;
+  @Column
+  private String role;
 
-  private String body;
-
-  @Column(name = "created_at", nullable = false, updatable = false)
-  private OffsetDateTime createdAt;
-
-  @PrePersist
-  void prePersist() {
-    createdAt = OffsetDateTime.now();
-  }
-
-  public static Retro of(Session session, UUID authorId) {
-    Retro retro = new Retro();
-    retro.session = session;
-    retro.authorId = authorId;
-    return retro;
+  public static SessionSpeaker of(Session session, UUID userId) {
+    SessionSpeaker speaker = new SessionSpeaker();
+    speaker.session = session;
+    speaker.userId = userId;
+    return speaker;
   }
 }

--- a/common/src/main/java/com/study/common/entity/SessionStatus.java
+++ b/common/src/main/java/com/study/common/entity/SessionStatus.java
@@ -1,4 +1,4 @@
-package com.study.sessionboard.entity;
+package com.study.common.entity;
 
 public enum SessionStatus {
   scheduled,


### PR DESCRIPTION
## Why (Context)

단일 DB 환경에서 엔티티를 팀 모듈별로 분리하면 구조적 모순이 생긴다. 이 PR은 그 모순을 해소하기 위한 것.

### 지금 구조의 문제

- 4개 팀 모듈(blog, qna, profile, session-board)이 **하나의 DB**를 공유한다
- 그런데 엔티티는 팀 모듈 내부에 위치해 있다
- `User`, `Generation` 같은 공유 엔티티는 결국 어딘가에 한 번 정의되어야 하는데, 어느 팀에 둘지 결정 자체가 자의적이다
- 세션보드팀이 PR #7에서 `User`/`Generation`을 선제적으로 만들었다가, 프로필팀 소관임을 인지하고 제거하는 우회를 거쳐야 했다
- 그 결과 세션보드 엔티티가 `UUID authorId`, `Integer generationId` 같은 raw FK를 들고 있게 됐는데, 프로필팀이 PK 타입을 바꾸면 모든 팀이 따라 바꿔야 한다 (PR #7 코멘트 참조)

### 왜 common이 답인가

| 항목 | 팀별 엔티티 소유 | common 통합 |
|---|---|---|
| FK 타입 계약 | 매번 협의 | 한 번에 결정 |
| 영속성 컨텍스트 | 어차피 단일 | 자연스러움 |
| 스키마 SSOT | 분산 | 단일 |
| 단일 DB 정합성 | 어색 | 부합 |

JPA 영속성 컨텍스트는 **DataSource 기준**으로 동작한다. 모듈 경계가 아니다. DB가 하나면 EntityManagerFactory도 하나고, 엔티티가 어느 모듈에 있든 같은 컨텍스트에서 관리된다. 즉 엔티티 분리는 **소유권 분리를 흉내내는 것**일 뿐 실질적인 격리 효과가 없다.

## What

`session-board/src/main/java/com/study/sessionboard/entity/` 하위 15개 파일을 `common/src/main/java/com/study/common/entity/` 로 이동.

- 엔티티: `EventPost`, `Comment`, `Like`, `PostImage`, `Session`, `SessionSpeaker`, `SessionNote`, `NoteLink`, `Resource`, `Retro`, `Notification`(이번 브랜치엔 없음), `SessionBoardTest`
- Enum/Converter: `PostStatus`, `SessionStatus`, `ResourceVisibility`, `ResourceVisibilityConverter`
- 패키지 선언: `com.study.sessionboard.entity` → `com.study.common.entity`

## How

- `git mv`로 파일 이동 (history 보존, rename으로 인식됨)
- `sed`로 패키지 선언 일괄 변경
- 다른 모듈에서 이 엔티티들을 import하는 코드 0건 확인 → 추가 수정 불필요
- `session-board` 모듈은 이미 `implementation project(':common')` 의존이라 build.gradle 변경 없음

## 검증

- ✅ `:common:compileJava` 통과
- ✅ `:session-board:compileJava` 통과
- ✅ `com.study.sessionboard.entity` 참조 grep 0건
- ⚠️ ArchUnit `ContractModuleTest` 1건 실패는 **이 PR과 무관한 사전 결함** (`session-board` 브랜치에서도 동일하게 실패함을 확인). `..profile..` 패턴이 `com.study.contract.profile`까지 매칭하는 false positive — 별도 이슈로 처리 필요.

## 후속 과제

- 다른 팀(blog, qna, profile)도 엔티티 작성 시 동일하게 `common.entity` 하위에 두는 컨벤션 확립 필요
- ArchUnit 패키지 패턴(`..profile..` → `..study.profile..`)으로 좁히는 별도 PR