### PR TITLE
docs: 브랜치 rebase 전략 및 CI 컨벤션 추가

### DIFF
--- a/app/src/main/java/com/study/auth/controller/AuthController.java
+++ b/app/src/main/java/com/study/auth/controller/AuthController.java
@@ -42,8 +42,8 @@ public class AuthController {
   /**
    * refresh token 쿠키 경로.
    *
-   * <p>/api/auth로 설정 — 브라우저가 /api/auth/refresh와 /api/auth/logout에만 쿠키를 전송한다. 일반 API
-   * 호출(/api/blogs 등)에는 쿠키가 포함되지 않아 불필요한 노출을 방지.
+   * <p>/api/auth로 설정 — 브라우저가 /api/auth/refresh와 /api/auth/logout에만 쿠키를 전송한다. 일반 API 호출(/api/blogs
+   * 등)에는 쿠키가 포함되지 않아 불필요한 노출을 방지.
    */
   private static final String COOKIE_PATH = "/api/auth";
 
@@ -59,7 +59,8 @@ public class AuthController {
   public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
     AuthService.LoginResult result = authService.login(request.email(), request.password());
 
-    ResponseCookie cookie = buildRefreshTokenCookie(result.rawRefreshToken(), result.refreshMaxAgeMs());
+    ResponseCookie cookie =
+        buildRefreshTokenCookie(result.rawRefreshToken(), result.refreshMaxAgeMs());
 
     return ResponseEntity.ok()
         .header(HttpHeaders.SET_COOKIE, cookie.toString())
@@ -72,7 +73,8 @@ public class AuthController {
 
     AuthService.RefreshResult result = authService.refresh(refreshToken);
 
-    ResponseCookie cookie = buildRefreshTokenCookie(result.rawRefreshToken(), result.refreshMaxAgeMs());
+    ResponseCookie cookie =
+        buildRefreshTokenCookie(result.rawRefreshToken(), result.refreshMaxAgeMs());
 
     return ResponseEntity.ok()
         .header(HttpHeaders.SET_COOKIE, cookie.toString())

--- a/app/src/main/java/com/study/auth/service/AuthService.java
+++ b/app/src/main/java/com/study/auth/service/AuthService.java
@@ -146,7 +146,8 @@ public class AuthService {
 
     saveRefreshToken(userId, newRawRefreshToken, familyId);
 
-    return new RefreshResult(newAccessToken, newRawRefreshToken, jwtProvider.getRefreshTokenExpiration());
+    return new RefreshResult(
+        newAccessToken, newRawRefreshToken, jwtProvider.getRefreshTokenExpiration());
   }
 
   /** 로그아웃 — 해당 토큰의 family 전체 revoke. */
@@ -191,6 +192,5 @@ public class AuthService {
   public record LoginResult(LoginResponse response, String rawRefreshToken, long refreshMaxAgeMs) {}
 
   /** 토큰 갱신 결과. */
-  public record RefreshResult(
-      String accessToken, String rawRefreshToken, long refreshMaxAgeMs) {}
+  public record RefreshResult(String accessToken, String rawRefreshToken, long refreshMaxAgeMs) {}
 }

--- a/app/src/main/java/com/study/config/CorsConfig.java
+++ b/app/src/main/java/com/study/config/CorsConfig.java
@@ -10,8 +10,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 /**
  * CORS 설정.
  *
- * <p>allowCredentials=true가 핵심 — refresh token이 HttpOnly 쿠키로 전달되므로 credentials를 허용해야 쿠키가 전송된다.
- * 이 옵션을 쓰면 allowedOrigins에 "*"를 쓸 수 없어서 명시적 origin 지정이 필수.
+ * <p>allowCredentials=true가 핵심 — refresh token이 HttpOnly 쿠키로 전달되므로 credentials를 허용해야 쿠키가 전송된다. 이
+ * 옵션을 쓰면 allowedOrigins에 "*"를 쓸 수 없어서 명시적 origin 지정이 필수.
  */
 @Configuration
 public class CorsConfig {

--- a/app/src/main/java/com/study/config/GlobalExceptionHandler.java
+++ b/app/src/main/java/com/study/config/GlobalExceptionHandler.java
@@ -15,8 +15,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 /**
  * 전역 예외 → HTTP 응답 매핑.
  *
- * <p>인증/인가 예외를 일관된 JSON 형식으로 반환한다. Spring Security의 AuthenticationEntryPoint /
- * AccessDeniedHandler는 필터 체인 레벨에서 401/403을 처리하고, 여기서는 서비스 레이어에서 발생하는 비즈니스 예외를 처리한다.
+ * <p>인증/인가 예외를 일관된 JSON 형식으로 반환한다. Spring Security의 AuthenticationEntryPoint / AccessDeniedHandler는
+ * 필터 체인 레벨에서 401/403을 처리하고, 여기서는 서비스 레이어에서 발생하는 비즈니스 예외를 처리한다.
  */
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -54,15 +54,12 @@ public class GlobalExceptionHandler {
     String message =
         e.getBindingResult().getFieldErrors().stream()
             .findFirst()
-            .map(
-                fieldError ->
-                    fieldError.getField() + ": " + fieldError.getDefaultMessage())
+            .map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
             .orElse("요청 값이 올바르지 않습니다");
     return errorResponse(HttpStatus.BAD_REQUEST, message);
   }
 
   private ResponseEntity<Map<String, Object>> errorResponse(HttpStatus status, String message) {
-    return ResponseEntity.status(status)
-        .body(Map.of("status", status.value(), "message", message));
+    return ResponseEntity.status(status).body(Map.of("status", status.value(), "message", message));
   }
 }

--- a/app/src/main/java/com/study/config/JwtAuthenticationFilter.java
+++ b/app/src/main/java/com/study/config/JwtAuthenticationFilter.java
@@ -19,12 +19,12 @@ import org.springframework.web.filter.OncePerRequestFilter;
 /**
  * 매 요청마다 Authorization 헤더의 Bearer 토큰을 검증하는 필터.
  *
- * <p>UsernamePasswordAuthenticationFilter 앞에 등록한다 — 폼 로그인 인증 전에 JWT 인증을 먼저 시도하기 위함. 토큰이
- * 유효하면 SecurityContext에 인증 정보를 설정하고, 유효하지 않으면 (만료, 변조 등) 아무것도 설정하지 않아
- * AuthenticationEntryPoint가 401을 반환하게 된다.
+ * <p>UsernamePasswordAuthenticationFilter 앞에 등록한다 — 폼 로그인 인증 전에 JWT 인증을 먼저 시도하기 위함. 토큰이 유효하면
+ * SecurityContext에 인증 정보를 설정하고, 유효하지 않으면 (만료, 변조 등) 아무것도 설정하지 않아 AuthenticationEntryPoint가 401을
+ * 반환하게 된다.
  *
- * <p>jjwt 라이브러리 타입은 이 클래스에 노출되지 않는다 — JwtProvider.parseAccessToken()이 Optional로 감싸서 반환하므로
- * app 모듈은 jjwt에 의존하지 않는다 (의존성 역전).
+ * <p>jjwt 라이브러리 타입은 이 클래스에 노출되지 않는다 — JwtProvider.parseAccessToken()이 Optional로 감싸서 반환하므로 app 모듈은
+ * jjwt에 의존하지 않는다 (의존성 역전).
  */
 @Component
 @RequiredArgsConstructor

--- a/app/src/main/java/com/study/config/SecurityConfig.java
+++ b/app/src/main/java/com/study/config/SecurityConfig.java
@@ -106,8 +106,6 @@ public class SecurityConfig {
     response.setStatus(status);
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);
     response.setCharacterEncoding("UTF-8");
-    objectMapper.writeValue(
-        response.getWriter(),
-        Map.of("status", status, "message", message));
+    objectMapper.writeValue(response.getWriter(), Map.of("status", status, "message", message));
   }
 }

--- a/app/src/test/java/com/study/auth/AuthIntegrationTest.java
+++ b/app/src/test/java/com/study/auth/AuthIntegrationTest.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.study.auth.dto.LoginRequest;
 import com.study.auth.dto.SignupRequest;
 import com.study.common.entity.User;
-import com.study.common.entity.UserRole;
 import com.study.common.repository.RefreshTokenRepository;
 import com.study.common.repository.UserRepository;
 import jakarta.servlet.http.Cookie;
@@ -30,8 +29,8 @@ import org.springframework.test.web.servlet.MvcResult;
 /**
  * 인증/인가 통합 테스트.
  *
- * <p>실제 DB(PostgreSQL)와 Spring Security 필터 체인을 포함한 전체 스택 테스트. 모든 테스트는 @Transactional로 롤백되어
- * 독립적으로 실행된다.
+ * <p>실제 DB(PostgreSQL)와 Spring Security 필터 체인을 포함한 전체 스택 테스트. 모든 테스트는 @Transactional로 롤백되어 독립적으로
+ * 실행된다.
  */
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -246,8 +245,7 @@ class AuthIntegrationTest {
     void access_withTamperedToken() throws Exception {
       mockMvc
           .perform(
-              get("/api/blog/hello")
-                  .header(HttpHeaders.AUTHORIZATION, "Bearer invalid.token.here"))
+              get("/api/blog/hello").header(HttpHeaders.AUTHORIZATION, "Bearer invalid.token.here"))
           .andExpect(status().isUnauthorized());
     }
   }
@@ -287,7 +285,8 @@ class AuthIntegrationTest {
       mockMvc
           .perform(post(REFRESH_URL).cookie(refreshCookie))
           .andExpect(status().isUnauthorized())
-          .andExpect(jsonPath("$.message").value("토큰이 재사용되었습니다. 보안을 위해 모든 세션이 만료되었습니다. 다시 로그인해주세요."));
+          .andExpect(
+              jsonPath("$.message").value("토큰이 재사용되었습니다. 보안을 위해 모든 세션이 만료되었습니다. 다시 로그인해주세요."));
     }
 
     @Test

--- a/common/src/main/java/com/study/common/entity/RefreshToken.java
+++ b/common/src/main/java/com/study/common/entity/RefreshToken.java
@@ -21,8 +21,8 @@ import lombok.NoArgsConstructor;
  *
  * <p>토큰 원문은 저장하지 않는다 — SHA-256 해시만 보관. DB가 유출되어도 토큰을 복원할 수 없다.
  *
- * <p>familyId는 최초 로그인 시 생성되고, rotation마다 동일한 familyId로 새 토큰이 발급된다. 사용된(USED) 토큰이 다시
- * 들어오면 해당 familyId의 모든 토큰을 REVOKED 처리한다.
+ * <p>familyId는 최초 로그인 시 생성되고, rotation마다 동일한 familyId로 새 토큰이 발급된다. 사용된(USED) 토큰이 다시 들어오면 해당
+ * familyId의 모든 토큰을 REVOKED 처리한다.
  */
 @Entity
 @Table(
@@ -64,7 +64,8 @@ public class RefreshToken {
   // ── 팩토리 메서드 ──
 
   /** 새 refresh token 레코드 생성. tokenHash는 반드시 SHA-256 해시여야 한다. */
-  public static RefreshToken create(Long userId, String tokenHash, UUID familyId, Instant expiresAt) {
+  public static RefreshToken create(
+      Long userId, String tokenHash, UUID familyId, Instant expiresAt) {
     RefreshToken token = new RefreshToken();
     token.userId = userId;
     token.tokenHash = tokenHash;

--- a/common/src/main/java/com/study/common/entity/User.java
+++ b/common/src/main/java/com/study/common/entity/User.java
@@ -2,7 +2,6 @@ package com.study.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import org.hibernate.annotations.DynamicUpdate;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -16,12 +15,13 @@ import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 /**
  * 사용자 엔티티.
  *
- * <p>가입 시 PENDING 상태로 생성되며, 관리자 승인 후 ACTIVE가 되어야 로그인 가능. passwordHash는 BCrypt로 인코딩된 값만
- * 저장한다 — 평문은 절대 이 객체에 들어오지 않는다.
+ * <p>가입 시 PENDING 상태로 생성되며, 관리자 승인 후 ACTIVE가 되어야 로그인 가능. passwordHash는 BCrypt로 인코딩된 값만 저장한다 — 평문은
+ * 절대 이 객체에 들어오지 않는다.
  */
 @Entity
 @DynamicUpdate

--- a/common/src/main/java/com/study/common/exception/InvalidCredentialsException.java
+++ b/common/src/main/java/com/study/common/exception/InvalidCredentialsException.java
@@ -3,8 +3,7 @@ package com.study.common.exception;
 /**
  * 로그인 실패 — 이메일 미존재 또는 비밀번호 불일치.
  *
- * <p>어떤 이유인지 구분하지 않는다 — "이메일이 없습니다" vs "비밀번호가 틀렸습니다"를 나누면 공격자에게 가입된 이메일 목록을
- * 노출하는 셈이다.
+ * <p>어떤 이유인지 구분하지 않는다 — "이메일이 없습니다" vs "비밀번호가 틀렸습니다"를 나누면 공격자에게 가입된 이메일 목록을 노출하는 셈이다.
  */
 public class InvalidCredentialsException extends AuthException {
 

--- a/common/src/main/java/com/study/common/repository/RefreshTokenRepository.java
+++ b/common/src/main/java/com/study/common/repository/RefreshTokenRepository.java
@@ -15,8 +15,8 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
   /**
    * 토큰을 USED로 전환 (atomic).
    *
-   * <p>WHERE status='ACTIVE' 조건 덕분에 동시에 같은 토큰으로 refresh 요청이 오면 하나만 성공한다. 반환값이 0이면 이미
-   * 사용된 토큰 → 재사용 공격으로 판단.
+   * <p>WHERE status='ACTIVE' 조건 덕분에 동시에 같은 토큰으로 refresh 요청이 오면 하나만 성공한다. 반환값이 0이면 이미 사용된 토큰 → 재사용
+   * 공격으로 판단.
    */
   @Modifying(flushAutomatically = true, clearAutomatically = true)
   @Query(

--- a/common/src/main/java/com/study/common/security/CurrentUser.java
+++ b/common/src/main/java/com/study/common/security/CurrentUser.java
@@ -11,8 +11,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
  *
  * <p>사용법: {@code public ResponseEntity<?> foo(@CurrentUser CustomUserDetails user)}
  *
- * <p>내부적으로 {@link AuthenticationPrincipal}을 위임한다. 팀 모듈에서 Spring Security 어노테이션을 직접 쓰지 않아도
- * 되도록 감싸는 역할.
+ * <p>내부적으로 {@link AuthenticationPrincipal}을 위임한다. 팀 모듈에서 Spring Security 어노테이션을 직접 쓰지 않아도 되도록 감싸는
+ * 역할.
  */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)

--- a/common/src/main/java/com/study/common/security/CustomUserDetails.java
+++ b/common/src/main/java/com/study/common/security/CustomUserDetails.java
@@ -5,8 +5,8 @@ import com.study.common.entity.UserRole;
 /**
  * SecurityContext에 저장되는 인증 주체(principal).
  *
- * <p>JWT 필터가 토큰을 검증한 뒤 이 객체를 생성하여 SecurityContextHolder에 넣는다. 이후 컨트롤러에서
- * {@code @CurrentUser} 또는 {@code @AuthenticationPrincipal}로 꺼내 쓴다.
+ * <p>JWT 필터가 토큰을 검증한 뒤 이 객체를 생성하여 SecurityContextHolder에 넣는다. 이후 컨트롤러에서 {@code @CurrentUser} 또는
+ * {@code @AuthenticationPrincipal}로 꺼내 쓴다.
  *
  * <p>Spring Security의 UserDetails를 구현하지 않는 이유 — JWT 기반 인증에서는 username/password/authorities가
  * principal 내부에 있을 필요 없다. authorities는 Authentication 객체에 별도로 세팅한다.

--- a/common/src/main/java/com/study/common/security/JwtProvider.java
+++ b/common/src/main/java/com/study/common/security/JwtProvider.java
@@ -18,8 +18,8 @@ import org.springframework.stereotype.Component;
  *
  * <p>HS256 대칭키 — 토큰 발급과 검증이 같은 서버에서 이루어지므로 비대칭키(RS256)는 불필요.
  *
- * <p>access token: sub=userId(Long), role 클레임 포함 (매 요청마다 DB 조회 없이 인가 판단) refresh token:
- * sub=userId, familyId 클레임 포함 (rotation 추적용)
+ * <p>access token: sub=userId(Long), role 클레임 포함 (매 요청마다 DB 조회 없이 인가 판단) refresh token: sub=userId,
+ * familyId 클레임 포함 (rotation 추적용)
  */
 @Component
 public class JwtProvider {
@@ -54,8 +54,8 @@ public class JwtProvider {
   /**
    * refresh token 생성. familyId로 같은 세션의 토큰 체인을 추적한다.
    *
-   * <p>jti(JWT ID)를 랜덤 UUID로 설정하여 동일 시각에 생성되어도 토큰이 유니크하도록 보장한다. 이것이 없으면 같은
-   * 밀리초에 rotation이 일어날 때 동일한 토큰이 생성되어 DB unique 제약 위반이 발생한다.
+   * <p>jti(JWT ID)를 랜덤 UUID로 설정하여 동일 시각에 생성되어도 토큰이 유니크하도록 보장한다. 이것이 없으면 같은 밀리초에 rotation이 일어날 때 동일한
+   * 토큰이 생성되어 DB unique 제약 위반이 발생한다.
    */
   public String generateRefreshToken(Long userId, UUID familyId) {
     Date now = new Date();
@@ -98,8 +98,8 @@ public class JwtProvider {
   /**
    * access token을 파싱하여 인증 정보를 반환한다.
    *
-   * <p>jjwt 타입(Claims, JwtException)을 외부 모듈에 노출하지 않기 위해 Optional로 감싼다. 토큰이 유효하지 않거나
-   * access 타입이 아니면 empty를 반환.
+   * <p>jjwt 타입(Claims, JwtException)을 외부 모듈에 노출하지 않기 위해 Optional로 감싼다. 토큰이 유효하지 않거나 access 타입이 아니면
+   * empty를 반환.
    */
   public Optional<AccessTokenInfo> parseAccessToken(String token) {
     try {

--- a/common/src/main/java/com/study/common/security/SecurityUtils.java
+++ b/common/src/main/java/com/study/common/security/SecurityUtils.java
@@ -7,11 +7,11 @@ import org.springframework.security.core.context.SecurityContextHolder;
 /**
  * 현재 인증된 사용자 정보를 꺼내는 static 유틸리티.
  *
- * <p>컨트롤러에서는 {@code @CurrentUser CustomUserDetails user}로 주입받을 수 있지만, 서비스/리포지토리 등 컨트롤러
- * 바깥에서 현재 유저가 필요할 때 이 클래스를 쓴다.
+ * <p>컨트롤러에서는 {@code @CurrentUser CustomUserDetails user}로 주입받을 수 있지만, 서비스/리포지토리 등 컨트롤러 바깥에서 현재 유저가
+ * 필요할 때 이 클래스를 쓴다.
  *
- * <p>내부적으로 SecurityContextHolder의 ThreadLocal에서 Authentication을 꺼낸다 — 같은 요청 스레드 내에서만 유효하고,
- * 요청이 끝나면 자동 정리된다.
+ * <p>내부적으로 SecurityContextHolder의 ThreadLocal에서 Authentication을 꺼낸다 — 같은 요청 스레드 내에서만 유효하고, 요청이 끝나면
+ * 자동 정리된다.
  *
  * <p>사용법:
  *

--- a/common/src/main/java/com/study/common/security/TokenHasher.java
+++ b/common/src/main/java/com/study/common/security/TokenHasher.java
@@ -9,9 +9,9 @@ import org.springframework.stereotype.Component;
 /**
  * Refresh token SHA-256 해싱.
  *
- * <p>DB에는 해시만 저장한다. DB가 유출되어도 토큰 원문을 복원할 수 없다. BCrypt와 달리 salt 없는 단방향 해시를 쓰는 이유 —
- * refresh token은 충분히 긴 랜덤 문자열(JWT)이라 rainbow table 공격이 비현실적이고, 매 요청마다 빠르게 조회해야 하므로
- * BCrypt의 의도적 느림(cost factor)이 부적절하다.
+ * <p>DB에는 해시만 저장한다. DB가 유출되어도 토큰 원문을 복원할 수 없다. BCrypt와 달리 salt 없는 단방향 해시를 쓰는 이유 — refresh token은
+ * 충분히 긴 랜덤 문자열(JWT)이라 rainbow table 공격이 비현실적이고, 매 요청마다 빠르게 조회해야 하므로 BCrypt의 의도적 느림(cost factor)이
+ * 부적절하다.
  */
 @Component
 public class TokenHasher {
@@ -19,8 +19,7 @@ public class TokenHasher {
   public String hash(String rawToken) {
     try {
       byte[] digest =
-          MessageDigest.getInstance("SHA-256")
-              .digest(rawToken.getBytes(StandardCharsets.UTF_8));
+          MessageDigest.getInstance("SHA-256").digest(rawToken.getBytes(StandardCharsets.UTF_8));
       return HexFormat.of().formatHex(digest);
     } catch (NoSuchAlgorithmException e) {
       // SHA-256은 모든 JVM에서 지원 — 도달 불가능한 코드

--- a/docs/conventions/CI.md
+++ b/docs/conventions/CI.md
@@ -1,0 +1,65 @@
+# CI 컨벤션
+
+## 개요
+
+모든 PR에 대해 자동으로 CI가 실행된다. CI를 통과하지 못하면 머지할 수 없다.
+
+## 트리거
+
+`pull_request` 이벤트. push-to-main에는 실행되지 않는다.
+대상 베이스 브랜치: main, dev, profile, blog, qna, session-board
+
+## CI 파이프라인 단계
+
+### 1. Spotless 자동 수정
+
+CI가 `spotlessApply`를 실행해 포맷을 자동으로 수정하고, 변경사항이 있으면 커밋을 푸시한다.
+
+```
+style: Spotless 자동 수정
+```
+
+**팀원이 직접 할 필요 없다.** 단, Spotless 봇 커밋 이후 로컬을 그대로 push하면 conflict가 난다.
+작업 브랜치에서 `git pull --rebase origin {브랜치명}`으로 봇 커밋을 먼저 당겨온 뒤 push해야 한다.
+
+### 2. 빌드 + 테스트
+
+```
+./gradlew compileJava test
+```
+
+컴파일 에러 또는 테스트 실패 시 CI가 실패한다.
+
+### 3. PR 코멘트
+
+CI 결과가 PR 코멘트로 자동으로 남는다.
+
+- 성공: `CI 통과 — 빌드 및 테스트 성공`
+- 실패: 전체 로그 링크 + 실패 원인 일부 발췌
+
+## 머지 정책
+
+CI가 통과되지 않으면 PR을 머지할 수 없다 (branch protection).
+머지 방식은 **Squash and merge** 사용 — feature 브랜치의 커밋을 하나로 압축해 팀 베이스에 반영한다.
+
+## AI 코드 리뷰 (CodeRabbit)
+
+PR이 열리면 CodeRabbit이 자동으로 코드 리뷰를 남긴다.
+
+- 언어: 한국어
+- 프로필: chill (blocking 리뷰 없음, 참고용)
+- 제외: `*.md`, `**/migration/**`
+
+CodeRabbit 리뷰는 머지 필수 조건이 아니다. 참고해서 반영 여부는 팀원이 판단한다.
+
+## 로컬에서 미리 확인하는 법
+
+PR 올리기 전에 아래를 로컬에서 돌려보면 CI 실패를 방지할 수 있다.
+
+```bash
+# 포맷 확인 (수정까지)
+./gradlew spotlessApply
+
+# 빌드 + 테스트
+./gradlew compileJava test
+```

--- a/docs/conventions/브랜치-커밋.md
+++ b/docs/conventions/브랜치-커밋.md
@@ -50,6 +50,36 @@ feat/auth-jwt
 4. dev에서 main으로 머지             dev → main
 ```
 
+## 베이스 브랜치 동기화
+
+### 팀 베이스는 main의 downstream이다
+
+팀 베이스 브랜치(profile, blog 등)는 main 위에 팀 고유 커밋이 쌓인 구조다.
+main이 바뀐다고 팀 베이스를 항상 sync할 필요는 없다. main에 팀 작업에 영향을 주는 변경이 생겼을 때만 rebase한다.
+
+### feature는 반드시 팀 베이스에서 생성
+
+feature 브랜치를 main에서 직접 따면 안 된다.
+
+**왜?**
+팀 베이스에는 main에 없는 커밋이 있다. feature를 main에서 따면 그 커밋들이 feature의 base history에 없는 상태가 된다. 나중에 팀 베이스로 PR을 올릴 때 그 커밋들이 diff에 포함되거나, rebase 시 conflict가 예상치 못한 지점에서 터진다.
+
+### main 변경사항을 feature에 반영해야 할 때
+
+직접 main → feature rebase하지 않는다. 반드시 아래 순서를 따른다.
+
+```
+1. main → 팀 베이스 rebase
+   git checkout profile
+   git rebase main
+
+2. 팀 베이스 → feature rebase
+   git checkout profile/feat/member-search
+   git rebase profile
+```
+
+팀 베이스를 거치지 않으면 팀 베이스의 커밋이 feature의 history에서 "새 커밋"으로 인식되어 히스토리가 꼬인다.
+
 ## 커밋 메시지
 
 ```


### PR DESCRIPTION
## Why

팀원들이 브랜치를 잘못 생성하거나 rebase 순서를 틀려서 커밋 히스토리가 꼬이는 일이 실제로 발생했다.
CI 정책도 코드에만 있고 문서화되지 않아, 팀원들이 왜 CI가 돌고 무엇을 해야 하는지 파악하기 어려운 상황이었다.

## What

- `브랜치-커밋.md` — 베이스 브랜치 동기화 섹션 추가
  - 팀 베이스는 main의 downstream이라는 구조 설명
  - feature는 반드시 팀 베이스에서 생성해야 하는 이유
  - main 변경사항 반영 시 올바른 rebase 순서 (main → 팀 베이스 → feature)
- `CI.md` 신규 생성
  - CI 트리거 조건 및 파이프라인 단계 (Spotless 자동 수정 → 빌드/테스트 → PR 코멘트)
  - 머지 정책 (CI 통과 필수, Squash and merge)
  - CodeRabbit AI 코드 리뷰 정책
  - 로컬 사전 확인 커맨드

## How

기존 컨벤션 문서 구조를 유지하면서 섹션 추가 및 신규 파일 생성.
코드 변경 없음, 문서만 수정.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CI/CD pipeline conventions documentation defining build, test, and merge processes.
  * Added branch and commit strategy guidelines for team coordination.

* **Style**
  * Improved code formatting and JavaDoc readability across authentication and security modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->