### PR TITLE
docs: CodeRabbit 수동 트리거로 변경

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,15 +6,7 @@ reviews:
   poem: false
   collapse_walkthrough: true
   auto_review:
-    enabled: true
-    drafts: false
-    base_branches:
-      - main
-      - dev
-      - session-board
-      - profile
-      - blog
-      - qna
+    enabled: false
   path_filters:
     - "!**/*.md"
     - "!**/migration/**"


### PR DESCRIPTION
## Why

자동 리뷰는 PR을 열 때마다 CodeRabbit이 무조건 돌아서, 원하지 않을 때도 리뷰가 달린다.
수동 트리거로 바꾸면 필요할 때만 요청할 수 있어 노이즈를 줄일 수 있다.

## What

`.coderabbit.yaml`에서 `auto_review.enabled: true` → `false`로 변경.

## How — CodeRabbit 사용법

### 리뷰 요청하는 법

PR 코멘트에 아래 한 줄 입력:

```
@coderabbitai review
```

CodeRabbit이 전체 diff를 분석해 인라인 코멘트와 요약을 남겨준다.

### 어떤 일이 일어나나

- 변경된 파일 기준으로 코드 품질, 잠재 버그, 개선 제안을 코멘트로 달아준다
- `*.md`, `**/migration/**`은 리뷰 제외 (설정에 명시됨)
- 리뷰 성격은 `chill` — blocking 리뷰 없이 참고용으로만 달린다

### 왜 쓰면 좋나

- PR 리뷰어가 놓칠 수 있는 부분을 사전에 짚어준다
- 팀원 리뷰 전에 혼자 한 번 돌려보면 기본적인 이슈는 미리 잡힌다
- 한국어로 코멘트가 달린다

---

참조 @ahyeon24 @cjang3285 @ebinee @hyroh5 @lbeul372 @papuagigi @parksein0223 @qoxkal @sunwoo1256 @Suuunz @xihxxn @Yejin111