### PR TITLE
feat: 헬스체크 API 추가 (liveness / readiness)

### DIFF
--- a/app/src/main/java/com/study/config/SecurityConfig.java
+++ b/app/src/main/java/com/study/config/SecurityConfig.java
@@ -55,7 +55,9 @@ public class SecurityConfig {
                         "/api/auth/signup",
                         "/api/auth/login",
                         "/api/auth/refresh",
-                        "/api/auth/logout")
+                        "/api/auth/logout",
+                        "/api/health",
+                        "/api/health/**")
                     .permitAll()
                     .anyRequest()
                     .authenticated())

--- a/app/src/main/java/com/study/health/HealthController.java
+++ b/app/src/main/java/com/study/health/HealthController.java
@@ -1,0 +1,51 @@
+package com.study.health;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import java.sql.Connection;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.Map;
+
+
+/**
+ * 헬스체크 엔드포인트.
+ *
+ * <p>liveness와 readiness를 분리한다. liveness에 DB 체크를 넣으면 DB 장애 시 컨테이너 재시작이 반복되며 장애가
+ * 증폭되기 때문에, liveness는 JVM 생존만 확인한다.
+ */
+@RestController
+@RequestMapping("/api/health")
+@RequiredArgsConstructor
+public class HealthController {
+
+    private final DataSource dataSource;
+
+
+
+    /** JVM이 살아있는지만 확인한다. DB 등 외부 의존성 체크하지 않는다. */
+    @GetMapping
+    public Map<String,String> liveness() {
+        return Map.of("status", "UP");
+    }
+
+
+
+    /**
+     * 트래픽을 받을 준비가 됐는지 확인한다. DB 커넥션이 유효하지 않으면 503을 반환해 로드밸런서/배포
+     * 파이프라인이 해당 인스턴스를 제외하도록 한다.
+     */
+    @GetMapping("/ready")
+    public ResponseEntity<Map<String,String>> readiness() {
+        try (Connection conn = dataSource.getConnection()) {
+            if (conn.isValid(1)) {
+                return ResponseEntity.ok(Map.of("status", "UP"));
+            }
+            return ResponseEntity.status(503).body(Map.of("status", "DOWN", "reason", "db invalid"));
+        } catch (Exception e) {
+            return ResponseEntity.status(503).body(Map.of("status", "DOWN", "reason", e.getMessage()));
+        }
+    }
+}


### PR DESCRIPTION
## 왜 하는가

CD 파이프라인에서 배포 검증용으로 쓸 헬스체크 엔드포인트가 필요합니다. 이슈 #21에서 결정된 대로 liveness와 readiness를 분리합니다.

## 추가된 엔드포인트

| 경로 | 용도 | DB 체크 |
|---|---|---|
| `GET /api/health` | liveness — JVM 생존만 확인 | ❌ |
| `GET /api/health/ready` | readiness — 트래픽 받을 준비 여부 | ✅ |

## 왜 liveness에는 DB 체크를 안 넣었나

liveness에 DB 체크를 넣으면 DB 장애가 발생했을 때 컨테이너 재시작이 반복되면서 **장애가 증폭**됩니다. liveness는 JVM이 살아있는지만 보고, DB 같은 외부 의존성은 readiness에서만 확인합니다.

## 변경 사항

- `HealthController` 신규 추가 (com.study.health 패키지)
- `SecurityConfig`에 `/api/health`, `/api/health/**` permitAll 경로 추가

## 참고

CI 워크플로 변경 이후 첫 PR입니다. Spotless는 이제 main push 시점에만 돌기 때문에, 이 PR의 포맷이 완벽하지 않아도 CI는 통과합니다. 머지 후 main 워크플로가 자동으로 정리합니다.