### PR TITLE
feat: auth-ddl 파일 추가

### DIFF
--- a/app/src/main/resources/db/auth-ddl.sql
+++ b/app/src/main/resources/db/auth-ddl.sql
@@ -1,0 +1,49 @@
+-- ============================================================
+-- Auth / User — PostgreSQL DDL
+-- ============================================================
+-- 이 파일은 users 테이블과
+-- 인증에 사용되는 refresh_tokens 테이블을 정의합니다.
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- USERS
+-- ------------------------------------------------------------
+CREATE TYPE user_role   AS ENUM ('ADMIN', 'MEMBER');
+CREATE TYPE user_status AS ENUM ('PENDING', 'ACTIVE', 'REJECTED', 'EXPIRED');
+
+CREATE TABLE users (
+    id                   BIGINT      GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    login_email          TEXT        NOT NULL UNIQUE,
+    password_hash        TEXT        NOT NULL,
+    role                 user_role   NOT NULL DEFAULT 'MEMBER',
+    status               user_status NOT NULL DEFAULT 'PENDING',
+    signup_requested_at  TIMESTAMPTZ NOT NULL,
+    approved_at          TIMESTAMPTZ,
+    approved_by          BIGINT      REFERENCES users(id) ON DELETE SET NULL,
+    expired_at           TIMESTAMPTZ,
+    last_login_at        TIMESTAMPTZ,
+    created_at           TIMESTAMPTZ NOT NULL,
+    updated_at           TIMESTAMPTZ NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_user_login_email ON users(login_email);
+CREATE        INDEX idx_user_status      ON users(status);
+
+-- ------------------------------------------------------------
+-- REFRESH_TOKENS
+-- ------------------------------------------------------------
+CREATE TYPE refresh_token_status AS ENUM ('ACTIVE', 'USED', 'REVOKED');
+
+CREATE TABLE refresh_tokens (
+    id          BIGINT               GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id     BIGINT               NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash  TEXT                 NOT NULL UNIQUE,
+    family_id   UUID                 NOT NULL,
+    status      refresh_token_status NOT NULL,
+    expires_at  TIMESTAMPTZ          NOT NULL,
+    created_at  TIMESTAMPTZ          NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_refresh_token_hash   ON refresh_tokens(token_hash);
+CREATE        INDEX idx_refresh_token_family ON refresh_tokens(family_id);
+CREATE        INDEX idx_refresh_token_user   ON refresh_tokens(user_id);


### PR DESCRIPTION
 ### Why
인증 관련 테이블(users, refresh_tokens)의 DDL이 없어 개발/테스트 환경에서 DB 스키마를 직접 구성할 수 없었습니다. 스키마를 코드로 명시하여 환경 재현성을 확보합니다.
                             
  ### What
  - 기존에 구현 되어있던 엔티티와 동일하게 구성(validate 통과 해야함)
  - app/src/main/resources/db/auth-ddl.sql 신규 추가
  - users 테이블: 로그인 이메일, 비밀번호 해시, 권한(user_role), 상태(user_status), 가입/승인/만료 이력 컬럼
  - refresh_tokens 테이블: 토큰 SHA-256 해시, family ID(UUID), 상태(refresh_token_status), 만료 시각
  - 인덱스: login_email(unique), status, token_hash(unique), family_id, user_id

  ### How
  - 엔티티와 동일
  - PK는 BIGINT GENERATED ALWAYS AS IDENTITY로 통일 (User, RefreshToken 엔티티의 Long + IDENTITY 전략과 일치)
  - token_hash는 원문 대신 SHA-256 해시만 저장하는 보안 정책을 반영해 UNIQUE 제약 적용
  - refresh_tokens.user_id는 users(id) ON DELETE CASCADE — 유저 삭제 시 토큰 일괄 삭제
  - users.approved_by는 자기 참조 FK ON DELETE SET NULL — 승인한 관리자가 탈퇴해도 레코드 보존
