### PR TITLE
refactor(profile): Member-User 통합 — email 중복 제거, user_id FK 추가

### DIFF
--- a/common/src/main/java/com/study/common/entity/Member.java
+++ b/common/src/main/java/com/study/common/entity/Member.java
@@ -1,35 +1,42 @@
 package com.study.common.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
 
 /**
- * 멤버(사용자) 엔티티. @DynamicUpdate : 수정 시 변경된 컬럼만 UPDATE 쿼리에 포함시킨다 (불필요한 쿼리
- * 최소화). @NoArgsConstructor(PROTECTED) : 파라미터 없는 기본 생성자를 protected로 만든다. 외부에서 new Member()를 직접 못 하게
- * 막고, create() 팩토리 메서드를 쓰도록 강제한다.
+ * 멤버(프로필) 엔티티.
+ *
+ * <p>인증/계정 정보는 {@link User}에 있고, Member는 <b>프로필 도메인</b>만 담당한다. 로그인 이메일 · 비밀번호 · 승인 상태 같은 계정 속성은
+ * 여기에 두지 않는다 — 중복 저장으로 인한 정합성 붕괴를 피하기 위함.
+ *
+ * <p>User ↔ Member 는 1:1. User 없이는 Member가 존재할 수 없다(회원가입 승인 후 프로필 생성 흐름을 전제).
  */
 @Entity
 @DynamicUpdate
 @Table(
     name = "member",
-    indexes = {
-      // email 컬럼에 인덱스를 걸어 이메일로 빠르게 검색할 수 있게 한다.
-      @Index(name = "idx_member_email", columnList = "email", unique = true)
-    })
+    indexes = {@Index(name = "idx_member_user_id", columnList = "user_id", unique = true)})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
@@ -39,66 +46,58 @@ public class Member {
   @Column(name = "id")
   private Long id;
 
-  @Column(name = "name", nullable = false)
-  private String name; // 멤버 이름
+  /**
+   * 계정(User) 참조. LAZY로 두어 프로필 조회 시 불필요한 조인을 막는다. 로그인 이메일이 필요하면 {@code
+   * member.getUser().getLoginEmail()}으로 접근.
+   */
+  @OneToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "user_id", nullable = false, unique = true)
+  private User user;
 
-  @Column(name = "email", nullable = false, unique = true)
-  private String email; // 이메일 (중복 불가 — unique = true)
+  @Column(name = "name", nullable = false)
+  private String name;
 
   @Column(name = "department")
-  private String department; // 학과 (선택 입력, nullable)
+  private String department;
 
-  // @Enumerated(EnumType.STRING) : Enum 값을 DB에 숫자(0,1,2...)가 아닌 문자열("backend", "frontend"...)로
-  // 저장한다.
-  //                                 숫자로 저장하면 나중에 Enum 순서가 바뀌면 데이터가 오염되므로 STRING이 안전하다.
   @Enumerated(EnumType.STRING)
   @Column(name = "session_type", nullable = false)
-  private SessionType sessionType; // 소속 세션(트랙) — backend/frontend/design/ai/pm/etc
+  private SessionType sessionType;
 
   @Column(name = "profile_image_url")
-  private String profileImageUrl; // 프로필 이미지 URL (선택)
+  private String profileImageUrl;
 
   @Column(name = "github_url")
-  private String githubUrl; // GitHub 프로필 URL (선택)
+  private String githubUrl;
 
-  // columnDefinition = "jsonb" : 이 컬럼은 DB에서 JSON 형식으로 저장한다.
-  // 링크가 여러 개일 수 있어서(포트폴리오, 블로그, SNS 등) JSON 배열로 유연하게 관리한다.
   @Column(name = "links_json", columnDefinition = "jsonb")
-  private String linksJson; // 추가 링크 목록 (JSON 형식, 예: [{"type":"blog","url":"..."}])
+  private String linksJson;
 
-  /**
-   * 멤버가 보유한 기술 스택 목록. mappedBy = "member" : MemberTechStack 엔티티에 있는 'member' 필드와 매핑된다는 뜻. cascade =
-   * ALL : 멤버가 저장/삭제될 때 연결된 기술 스택 정보도 함께 처리한다. orphanRemoval = true : 리스트에서 제거하면 DB에서도 해당 행을 삭제한다.
-   */
-  @jakarta.persistence.OneToMany(
-      mappedBy = "member",
-      cascade = jakarta.persistence.CascadeType.ALL,
-      orphanRemoval = true)
-  private java.util.List<MemberTechStack> techStacks = new java.util.ArrayList<>();
+  @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<MemberTechStack> techStacks = new ArrayList<>();
 
   @Column(name = "created_at", nullable = false, updatable = false)
-  private Instant createdAt; // 최초 생성 시각
+  private Instant createdAt;
 
   @Column(name = "updated_at", nullable = false)
-  private Instant updatedAt; // 마지막 수정 시각
+  private Instant updatedAt;
 
   /**
-   * 새 멤버를 만들 때 사용하는 정적 팩토리 메서드.
+   * 새 멤버 생성. User(계정)는 이미 존재해야 한다 — 회원가입 승인 플로우에서 User 생성 후 이 메서드로 프로필을 만든다.
    *
-   * <p>new Member()를 직접 쓰는 대신 이 메서드를 통해야 한다. 필수값(name, email, sessionType)만 받고, 나머지는 나중에
-   * updateProfile()로 채운다.
+   * <p>email을 받지 않는 이유: 계정 이메일은 {@link User#getLoginEmail()}이 원본. 중복 저장 금지.
    */
   public static Member create(
+      User user,
       String name,
-      String email,
       SessionType sessionType,
       String department,
       String profileImageUrl,
       String githubUrl,
       String linksJson) {
     Member member = new Member();
+    member.user = user;
     member.name = name;
-    member.email = email;
     member.sessionType = sessionType;
     member.department = department;
     member.profileImageUrl = profileImageUrl;
@@ -109,14 +108,12 @@ public class Member {
 
   public void update(
       String name,
-      String email,
       SessionType sessionType,
       String department,
       String profileImageUrl,
       String githubUrl,
       String linksJson) {
     this.name = name;
-    this.email = email;
     this.sessionType = sessionType;
     this.department = department;
     this.profileImageUrl = profileImageUrl;
@@ -124,10 +121,6 @@ public class Member {
     this.linksJson = linksJson;
   }
 
-  /**
-   * JPA가 DB에 INSERT(저장)하기 직전에 자동으로 호출하는 콜백 메서드. createdAt과 updatedAt을 현재 시각으로 초기화한다. 개발자가 직접 호출할 필요
-   * 없이 JPA가 알아서 실행한다.
-   */
   @PrePersist
   void prePersist() {
     Instant now = Instant.now();
@@ -135,7 +128,6 @@ public class Member {
     this.updatedAt = now;
   }
 
-  /** JPA가 DB에 UPDATE(수정)하기 직전에 자동으로 호출하는 콜백 메서드. updatedAt을 현재 시각으로 갱신한다. */
   @PreUpdate
   void preUpdate() {
     this.updatedAt = Instant.now();

--- a/profile/db/erd-cloud.sql
+++ b/profile/db/erd-cloud.sql
@@ -1,9 +1,10 @@
--- 1. 멤버 테이블
+-- 1. 멤버 테이블 (프로필)
+-- user_id: users.id FK (1:1). 로그인 이메일은 users에서 관리 — member에 중복 저장하지 않음.
 CREATE TABLE member
 (
     id                BIGINT       NOT NULL AUTO_INCREMENT,
+    user_id           BIGINT       NOT NULL UNIQUE,
     name              VARCHAR(255) NOT NULL,
-    email             VARCHAR(255) NOT NULL UNIQUE,
     department        VARCHAR(255),
     session_type      ENUM ('backend','frontend','design','ai','pm','etc') NOT NULL,
     profile_image_url TEXT,
@@ -11,7 +12,8 @@ CREATE TABLE member
     links_json        JSON,
     created_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    PRIMARY KEY (id)
+    PRIMARY KEY (id),
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
 );
 
 -- 2. 기수 테이블

--- a/profile/db/profile-ddl.sql
+++ b/profile/db/profile-ddl.sql
@@ -7,10 +7,12 @@ CREATE TYPE contribution_period_type AS ENUM ('month', 'three_month', 'year', 'a
 CREATE TYPE role_in_team AS ENUM ('backend', 'frontend', 'design', 'ai', 'pm', 'infra', 'etc');
 
 -- 2. 핵심 테이블 생성 (PK: BIGINT / Long)
+-- user_id: users.id FK (1:1). 로그인 이메일은 users.login_email이 원본 — member에 중복 저장 금지.
+-- 전제: users 테이블은 auth 팀 DDL이 먼저 생성해야 한다.
 CREATE TABLE member (
     id                BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    user_id           BIGINT NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
     name              TEXT NOT NULL,
-    email             TEXT NOT NULL UNIQUE,
     department        TEXT,
     session_type      session_type NOT NULL,
     profile_image_url TEXT,


### PR DESCRIPTION
## 왜

`common/entity/User`(auth)와 `common/entity/Member`(profile)가 독립적으로 만들어져 **연결고리가 없고 email 컬럼이 중복**되어 있다.

- 같은 사람이 `users`와 `member`에 따로 존재할 수 있는 구조
- 이메일 변경 시 두 테이블 동기화 필요 → 정합성 깨지기 쉬움

계정(인증)과 프로필(도메인)은 분리 유지하되, 두 엔티티의 **관계와 원본을 명확히** 잡는다.

## 설계 결정

| 선택지 | 내용 | 판단 |
|---|---|---|
| **(A) user_id FK 1:1** | Member에 `user_id` FK. email은 User가 원본 | ✅ 선택 |
| (B) PK 공유 | `Member.id == User.id` | 생성 시점 결합 과다 |
| (C) email 매칭 | 현재 상태 유지 | 정합성 보장 불가 |

**(A) 근거**
- 도메인 규칙 "프로필은 승인된 계정이 있어야 존재"와 일치
- profile이 auth에 의존하지만, 역방향(auth → profile)은 없어 의존성 역전 없음
- 이메일은 User 한 곳에서만 관리 → 중복 제거

## 변경 내용

**`common/entity/Member.java`**
- `email` 필드 제거
- `@OneToOne(fetch = LAZY) User user` 추가 (`user_id` FK, `nullable=false`, `unique=true`)
- 인덱스 `idx_member_email` → `idx_member_user_id`
- `create()` 팩토리 시그니처: `email` 파라미터 → `User user` 파라미터

**DDL (`profile/db/profile-ddl.sql`)**
- `member.email` 제거
- `member.user_id BIGINT NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE` 추가
- 전제: `users` 테이블은 auth 팀 DDL이 먼저 생성

**ERD (`profile/db/erd-cloud.sql`)**
- 동일하게 `user_id` FK 반영

## 사용 예시

```java
// Before
Member.create("우진", "woojin@example.com", SessionType.backend, ...);

// After — User(계정) 먼저 만든 뒤 프로필 생성
User user = User.create("woojin@example.com", bcryptHash);
userRepository.save(user);
Member member = Member.create(user, "우진", SessionType.backend, ...);
// 이메일 조회: member.getUser().getLoginEmail()
```

## 영향받는 팀

- **auth 팀**: 영향 없음 (User는 그대로)
- **profile 팀**: `Member.create()` 시그니처 변경 — 아직 실제 호출부 없어 영향 미미
- **다른 도메인 팀**: 프로필 조회 시 `member.getUser().getLoginEmail()` 사용

## 체크리스트

- [x] `./gradlew compileJava` 성공
- [x] DDL/ERD 동기화
- [x] auth 팀 리뷰 (User 엔티티 의존 추가에 대한 합의)
- [ ] profile 팀 리뷰

## 후속

- Flyway 마이그레이션 전환 시 `member.email` → `member.user_id` 변환 스크립트 필요 (현재는 스키마 초기화 단계라 불필요)
- `ProfilePort` 인터페이스 확장 시 `getLoginEmail(memberId)` 고려