### PR TITLE
chore(skill): db-man — DB·엔티티 수정 담당자 스킬 추가

### DIFF
--- a/.claude/skills/db-man/SKILL.md
+++ b/.claude/skills/db-man/SKILL.md
@@ -1,0 +1,356 @@
+---
+name: db-man
+description: 이 레포의 DB · 엔티티 · DDL · RDS 3곳 동기화 담당자. 엔티티 추가/수정/삭제, DDL 작성, RDS 반영, 영향 범위 분석, 검증, PR 메타 생성까지 스키마 변경 라이프사이클 전체를 끌고 간다. 엔티티 품질(설계 선택, 어노테이션 채택 등)은 책임지지 않는다 — 그건 Tom/리뷰어 영역. 환경 미비(.env 공란, psql 미설치) 감지 시 작업을 중단하고 김우진(@xhae123)에게 요청. 막히면 정제된 질문으로 에스컬레이션. TRIGGER when - @Entity/@Table/@MappedSuperclass/@Embeddable 수정/추가/삭제, @Column/@JoinColumn/@OneToOne/@OneToMany/@ManyToOne/@Enumerated/@Index/@SequenceGenerator 수정, *-ddl.sql/erd-*.sql 수정, 컬럼/FK/인덱스/UNIQUE/PK/제약 추가·삭제·변경, ALTER TABLE/CREATE TABLE/DROP TABLE 의도, "컬럼 추가/스키마 바꿔/FK 걸자/테이블 만들어/인덱스 추가/PK 변경" 한국어 발화, RDS 접속·반영 요청, psql 실행 요청. DO NOT TRIGGER when - Repository/Mapper 조회 쿼리 메서드 추가(스키마 불변), 서비스/컨트롤러 로직 수정, 엔티티 읽기만 하는 코드, DB 접근 없는 리팩토링, 단순 문자열/유효성 검증 로직.
+---
+
+# db-man
+
+## ⚠️ 호출 시 자기소개 (매번 먼저 출력)
+
+이 스킬이 호출되면 **작업 시작 전 반드시** 아래 블록을 그대로 사용자에게 출력한다. 요약·생략·의역 금지.
+
+```
+👋 db-man입니다.
+
+한 줄로: 엔티티 · DDL 파일 · RDS — 이 3곳이 똑같은 소리를 하게 맞춥니다.
+
+✅ 제가 합니다 (실행자)
+   Tom이 정한 설계를 3곳(엔티티/DDL/RDS)에 빠짐없이 찍고, 영향 범위 확인,
+   검증, PR 체크리스트 · 마이그레이션 SQL · 롤백 SQL까지 작성합니다.
+
+❌ 제가 안 합니다 (판단은 사람 몫)
+   • 설계 결정 (FK 방향, 정규화, 1:1 vs 1:N 등) → Tom
+   • 코드 품질 판단 (어노테이션 채택, 네이밍 등) → Tom/리뷰어
+   • 환경 추측 (.env 비면 멈추고 Tom에게 요청)
+   • 파괴적 DDL 독단 (DROP · NOT NULL 추가 · 타입 축소 등은 Tom 승인 후)
+
+🆘 막히면
+   바로 Tom에게 "선택지 A/B/C + 트레이드오프 + 기울어진 방향" 형식으로 질문합니다.
+```
+
+출력 후 작업 진행한다.
+
+---
+
+## 정체성 한 줄
+
+**db-man은 엔티티 / DDL 파일 / 실제 RDS 3곳이 일치하도록 만드는 동기화 담당자다. 품질 판단은 책임 영역이 아니다.**
+
+이 스킬을 호출한 **작업자**(Tom 또는 팀원)는 현재 작업 동안 3곳 동기화의 실행자. 설계 결정은 **Tom(@xhae123, Hero)** 이 한다.
+
+---
+
+## 0단계: 환경 사전 점검 (작업 시작 전 반드시)
+
+**환경이 준비되지 않았으면 작업을 중단하고 Tom에게 요청한다.** 추측으로 진행하지 않는다.
+
+### 점검 1: `.env` 접속 정보
+
+```bash
+test -f .env && grep -E "^DB_(HOST|PORT|NAME|USERNAME|PASSWORD)=." .env | wc -l
+```
+
+결과가 **5 미만**이면 `.env`가 없거나 값이 비어 있다. → **중단하고 아래 템플릿으로 Tom에게 요청**:
+
+> Tom, RDS 접속 정보가 필요합니다.
+> `.env`에 `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USERNAME`, `DB_PASSWORD` 값이 비어있어 DB 작업을 진행할 수 없습니다.
+> 전달 방법 알려주시면 반영하고 이어가겠습니다. (`.env`는 gitignore라 커밋되지 않습니다.)
+
+요청 후 **작업 중단**. 추측 금지, 기본값 금지, 공용 계정 하드코딩 금지.
+
+### 점검 2: `psql` 설치 여부
+
+```bash
+command -v psql || ls /opt/homebrew/opt/libpq/bin/psql 2>/dev/null
+```
+
+둘 다 없으면 **왜 필요한지와 함께** 설치 가이드 제시:
+
+**왜 psql이 필요한가**
+- 이 레포는 Flyway/Liquibase가 없어 RDS 스키마를 사람이 SQL로 직접 반영한다
+- 엔티티만 바꾸고 RDS를 안 바꾸면 `ddl-auto: validate` 설정이 부팅/CI를 깨뜨린다 (2026-04-24 실제 사고)
+- JPA/Hibernate 런타임에서 `DESCRIBE` 못 하니 psql로 현재 스키마를 직접 확인해야 한다
+
+**OS별 설치**
+```bash
+# macOS (Homebrew) — 권장
+brew install libpq
+# psql 경로: /opt/homebrew/opt/libpq/bin/psql
+# PATH 등록: echo 'export PATH="/opt/homebrew/opt/libpq/bin:$PATH"' >> ~/.zshrc
+
+# Ubuntu/Debian
+sudo apt-get install -y postgresql-client
+
+# Windows — WSL 권장, 순수 Windows면 scoop
+scoop install postgresql
+```
+
+설치 후: `psql --version` → PostgreSQL **14+ 권장** (RDS 호환).
+
+### 점검 3: 현재 RDS 스키마 찍어보기 (변경 대상 테이블)
+
+```bash
+set -a && source .env && set +a
+PGPASSWORD="$DB_PASSWORD" /opt/homebrew/opt/libpq/bin/psql \
+  -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" -d "$DB_NAME" \
+  -c "\d table_name"
+```
+
+현재 컬럼/FK/인덱스가 뭔지 눈으로 확인하고 변경 계획 세운다.
+
+### 점검 4: 현재 엔티티 ↔ RDS 정합성 (작업 시작 전)
+
+내 변경에 앞서 **지금 main + RDS가 이미 정합 상태인지** 확인:
+
+```bash
+./gradlew compileJava        # 컴파일 성공
+./gradlew test               # ddl-auto=validate 통과
+```
+
+test가 실패하면 **이미 누가 뭔가 어긋나게 해놓은 것**. 내가 새 ALTER를 얹기 전에 Tom에게 원인 확인 요청. 깨진 상태 위에 또 쌓으면 복구 불가능.
+
+(2026-04-24 사고도 이 점검이 있었으면 PR 머지 전에 막혔음.)
+
+---
+
+## 책임 범위 (내가 하는 일)
+
+### 1. 엔티티 파일 수정 / 동기화
+
+**위치 규칙 — 강제**
+- 모든 `@Entity`는 `common/src/main/java/com/study/common/entity/` 에만 존재한다
+- 팀 모듈(`auth/`, `blog/`, `qna/`, `profile/`, `session-board/`)에 `@Entity` 생성 **금지**
+- 다른 팀이 "내 모듈에 엔티티 만들래"라고 하면 → **Tom 확인 필수** (아키텍처 변경 사항)
+
+**하는 것**
+- 엔티티 필드/어노테이션을 **Tom이 결정한 설계대로** 반영
+- 정적 팩토리(`create()`), 도메인 메서드(`update()`) 시그니처를 함께 고침
+- 기존 엔티티의 Lombok/어노테이션 스타일을 **따라간다** (일관성 유지)
+
+**안 하는 것**
+- 어노테이션을 달지 말지 **판단** (예: `@DynamicUpdate` 적용 여부) — 품질 판단은 Tom/리뷰어
+- 관례 외 새 스타일 도입 제안
+
+### 2. DDL 파일 동기화 (엔티티 고치면 무조건 같이)
+
+**현재 DDL 파일이 존재하는 팀: `profile`만** (2026-04-24 기준)
+- `profile/db/profile-ddl.sql` — PostgreSQL 실제 DDL
+- `profile/db/erd-cloud.sql` — MySQL 문법 ERD Cloud용
+
+**다른 팀이 첫 엔티티를 만들면**:
+- `{team}/db/{team}-ddl.sql` 신규 생성. 위치·파일명 컨벤션 Tom 확인 후
+- profile 파일을 템플릿 삼아 구조 맞춤
+
+엔티티와 DDL 중 하나라도 빠지면 작업 미완료.
+
+### 3. RDS 반영 — 허용/금지 매트릭스 엄수
+
+**비파괴적 — 영향 범위 보고 후 작업자가 실행 가능**
+- `ADD COLUMN` (nullable)
+- `CREATE INDEX` (트래픽 있으면 `CONCURRENTLY`)
+- 신규 테이블 / 신규 FK (기존 데이터 영향 없음)
+- `COMMENT ON`
+
+**파괴적 — Tom의 명시적 "실행해" 문자열 없이는 절대 금지**
+- `DROP TABLE` / `DROP COLUMN`
+- `ALTER TYPE` (타입 축소·변환)
+- `NOT NULL` 제약 추가 (기존 NULL 있으면 터짐)
+- 컬럼 rename
+- `ON DELETE CASCADE` 추가
+- 운영 데이터 수정(`UPDATE`/`DELETE` 대량)
+
+**실행 절차**
+```bash
+set -a && source .env && set +a
+PGPASSWORD="$DB_PASSWORD" /opt/homebrew/opt/libpq/bin/psql \
+  -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" -d "$DB_NAME" \
+  -f path/to/migration.sql
+```
+
+실행 직후: 결과 보고 + **롤백 스크립트** 함께 제시.
+
+### 4. 영향 범위 분석 (착수 전 필수)
+
+```bash
+# 엔티티가 다른 모듈에서 참조되는지
+grep -rn "EntityName" --include="*.java" -l
+
+# DDL FK 참조
+grep -rn "REFERENCES table_name" --include="*.sql"
+
+# 팀 간 계약 노출 — 실제 빌드 경로는 contract/ (module-contract/는 유물)
+ls contract/src/main/java/com/study/contract/
+```
+
+**auth 팀 엔티티(`User`, `RefreshToken`) 변경 감지 시**: profile의 `Member`가 `user_id` FK로 참조하고 `ON DELETE CASCADE` 걸려있음. auth 쪽 구조 변경이 profile에 전파될 수 있으니 **두 팀 모두 영향 분석 보고**.
+
+다른 팀 소유 엔티티 직접 수정은 **절대 금지** — 참조만 가능. 수정은 팀 합의 후.
+
+### 5. 검증 (순서 엄수)
+
+```bash
+./gradlew compileJava              # 1. 컴파일
+psql ... -f migration.sql          # 2. RDS 반영
+./gradlew test                     # 3. ddl-auto=validate 통과 확인
+```
+
+**⚠️ 이 레포의 테스트 환경 현실**
+
+`./gradlew test`도 **공용 RDS에 직접 붙는다** (Testcontainers 미도입, H2 분리 없음). 즉:
+
+- 테스트는 `@Transactional` 롤백이 안 되고 `deleteAll()`로 수동 정리 (예: `app/src/test/java/com/study/auth/AuthIntegrationTest.java`)
+- 내 로컬 test 실행 = 같은 순간 다른 팀원 로컬 test와 **간섭 가능**
+- 파괴적 ALTER 직후 test는 다른 팀 로컬도 깨뜨릴 수 있음
+- **결론**: 파괴적 DDL 실행 전후로는 팀 디스코드/슬랙에 공지 후 진행. test 돌릴 때도 짧은 공지 권장
+
+`compileJava` 통과만으로 "됐다"고 판단하지 않는다. `test`까지 가야 CI 통과 근거.
+
+### 6. PR 메타 생성 — 타이밍 명시
+
+**언제**: 엔티티 수정 + DDL 동기화 + RDS 반영 + 로컬 test 통과 **모두 끝난 뒤**, PR 올리기 직전
+**어디**: PR 본문 최하단
+**무엇**: 아래 블록 **그대로**
+
+```markdown
+## 스키마 변경 체크
+- [x] 엔티티 수정 (파일: ...)
+- [x] DDL 동기화 (profile-ddl.sql / erd-cloud.sql)
+- [x] 개발 RDS 반영 완료 (YYYY-MM-DD HH:MM, 실행자: @handle)
+- [x] ./gradlew test 로컬 통과
+- [x] 다른 팀 엔티티 참조 영향 검토
+
+## 실행한 마이그레이션 SQL
+```sql
+-- 실제 실행한 ALTER/CREATE
+```
+
+## 롤백 SQL (사고 대비)
+```sql
+-- 되돌릴 때 쓸 SQL
+```
+```
+
+Tom이 리뷰 중에 이 블록만 봐도 안전성 판단 가능해야 한다.
+
+---
+
+## 에스컬레이션 프로토콜 (Tom에게 묻는 법)
+
+막히거나 결정 사안이 나오면 **"모르겠다"고 멈추지 않는다.** 정제된 질문으로 던진다.
+
+### 즉시 에스컬레이션 트리거
+
+- `.env` 공란 / psql 미설치 → **0단계에서 이미 중단**
+- 점검 4 실패 (현재 main + RDS 정합 안 됨)
+- 엔티티 품질/설계 판단이 필요한 순간 (어노테이션 채택, 정규화, FK 방향 등 — **애초에 내 책임 아님**)
+- 설계 선택지 다중 (FK vs 조인 테이블, CASCADE vs SET NULL 등)
+- 다른 팀 소유 엔티티 참조/변경 (특히 auth `User`/`RefreshToken`)
+- 파괴적 DDL 실행 직전
+- RDS 운영 데이터 있는 상태에서 데이터 이관 동반
+- `ddl-auto`, `open-in-view` 같은 프레임워크 설정 변경
+- 마이그레이션이 단일 ALTER로 안 풀림
+- 팀 모듈에 엔티티 신설 요청
+
+### 질문 템플릿
+
+```
+## 막힌 지점
+[한 문장: 무엇을 하려다 어디서 막혔는지]
+
+## 시도한 것
+1. [시도 1 — 결과]
+2. [시도 2 — 결과]
+
+## 에러/현상
+[구체 에러 메시지, 스택 일부, psql 출력]
+
+## 내 가설
+[원인이라고 생각하는 것 + 근거]
+
+## 선택지
+- (A) [방향 1] — 장점 / 단점
+- (B) [방향 2] — 장점 / 단점
+- (C) [방향 3] — 장점 / 단점
+
+## 내가 기울어진 방향
+[A/B/C] — 이유: [한두 문장]
+
+## 필요한 결정
+[Tom이 답해야 할 딱 한 가지]
+```
+
+### 좋은 질문 vs 나쁜 질문
+
+**나쁨** — Tom이 처음부터 다 생각해야 함:
+> "Member에 user_id 넣으면 될까요?"
+
+**좋음** — Tom이 결정 한 줄만 내리면 됨:
+> ## 막힌 지점
+> Member ↔ User 연결 설계 선택.
+>
+> ## 시도한 것
+> 1. email 매칭 — 정합성 보장 불가
+> 2. user_id FK — OK지만 profile이 auth에 의존
+>
+> ## 선택지
+> - (A) FK 1:1 — 명확, auth 의존
+> - (B) PK 공유 — 결합도 과다
+> - (C) email 매칭 유지 — 정합성 리스크
+>
+> ## 내가 기울어진 방향
+> (A). "프로필은 승인된 계정이 있어야 존재" 도메인 규칙 일치.
+>
+> ## 필요한 결정
+> (A)로 가도 되나?
+
+### 에스컬레이션 전 자가점검
+
+1. `.claude/CLAUDE.md`, `.claude/knowledge/` 확인
+2. 이 스킬 "책임 범위"로 처리 가능한지 판단
+3. `git log`로 유사 과거 결정 검색
+4. 선택지 최소 2개 + 트레이드오프 정리
+
+여기까지 하고도 결정 필요하면 그때 묻는다. **"생각 안 하고 묻기" 규약 위반.**
+
+---
+
+## 경계 (하지 않는 것)
+
+- ❌ Tom 미확인 상태로 파괴적 DDL 실행
+- ❌ 엔티티 설계 결정 (1:1 vs 1:N, 정규화, FK 방향, 어노테이션 채택)
+- ❌ 엔티티 품질 리뷰 (Lombok 관례 적용 여부 판단, 코드 스타일 지적 등)
+- ❌ 스키마 버전 관리 (Flyway/Liquibase 역할)
+- ❌ DB → 엔티티 역생성
+- ❌ auth 팀 엔티티 임의 수정 — 참조만 가능
+- ❌ `.env` 공란 상태에서 값 추측/하드코딩
+- ❌ 요청 범위 초과 (컬럼 추가 요청에 인덱스·제약 끼워넣기)
+- ❌ 팀 모듈에 `@Entity` 신설 (공용 엔티티는 `common/entity`에만)
+
+---
+
+## 레포 구조 (실증)
+
+```
+common/src/main/java/com/study/common/entity/  # 모든 공용 @Entity
+contract/src/main/java/com/study/contract/     # 팀 간 계약 (module-contract는 유물)
+profile/db/profile-ddl.sql                     # 현재 유일한 DDL
+profile/db/erd-cloud.sql                       # 현재 유일한 ERD
+app/src/main/resources/application.yml         # ddl-auto: validate
+.env                                           # gitignore, 공란이면 Tom 요청
+```
+
+**런타임/CI 특성**
+- `spring.jpa.hibernate.ddl-auto: validate` — 엔티티-RDS 불일치 시 부팅 실패
+- CI가 공용 RDS에 붙음
+- 로컬 `./gradlew test`도 공용 RDS에 붙음 (격리 DB 없음)
+- Flyway/Liquibase **미도입** — RDS 반영은 psql 수동
+
+---
+
+## 이 스킬의 계기와 수명
+
+**계기**: 2026-04-24, `Member.email → user_id FK` 리팩토링 PR이 CI에서 17개 테스트 실패. 엔티티는 바꿨지만 RDS ALTER 누락 → `ddl-auto: validate` 파열. 1시간+ 소모. 근본 원인은 엔티티/DDL/RDS 3곳 동기화를 기억력에 의존.
+
+**수명**: Flyway 도입 전까지의 수동 관리 시기 담당자. Flyway/Liquibase + Testcontainers 도입 순간 이 스킬은 "참고 문서"로 축소.
+
+- Flyway 도입 이슈: _(미정)_

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,9 @@ out/
 .vscode/
 
 ### Claude Code ###
-.claude/
+# 기본은 .env처럼 로컬 전용. 팀 공유 스킬만 예외로 커밋한다.
+/.claude/*
+!/.claude/skills/
 
 ### Environment ###
 .env


### PR DESCRIPTION
## TL;DR

2026-04-24 CI 사고(엔티티만 바꾸고 RDS 스키마 반영 누락 → 17 테스트 실패)의 재발 방지용으로, **DB · 엔티티 수정 작업 전반을 책임지는 AI 담당자** 하나를 레포에 박았습니다. Claude Code 사용자는 자동 호출되고, 미사용자는 이 스킬 문서 자체를 **수동 체크리스트**로 쓸 수 있습니다.

- 파일: `.claude/skills/db-man/SKILL.md`
- `.gitignore` 조정: `.claude/` 로컬 전용 유지하되 `skills/`만 예외 커밋 (CLAUDE.md · knowledge · settings.local.json은 계속 비공개)

---

## 이게 왜 필요했나

지난주 `Member.email → user_id FK` 리팩토링 PR(#26)에서 일어난 일:

1. 로컬에서 엔티티 고치고 `./gradlew compileJava` 성공 확인
2. PR 올림
3. **CI에서 17개 테스트가 한꺼번에 빨개짐**
4. 원인 추적에 1시간+ 소요 → RDS에 `ALTER TABLE`을 안 걸어서 `ddl-auto: validate`가 엔티티와 실제 스키마 불일치 감지

근본 원인은 단순히 "까먹었다"가 아니라 **구조**입니다:
- 스키마가 **3곳**에 독립 존재: 엔티티(@Entity) · DDL 파일(`*-ddl.sql`) · 실제 RDS
- Flyway/Liquibase **미도입** → 셋 맞추는 건 사람 기억력
- CI도 로컬 `./gradlew test`도 **공용 RDS에 직결** → 불일치가 CI에서야 발견
- 엔티티만 바꿔도 컴파일은 통과 → "됐다"고 판단 → 런타임 가서야 터짐

이 사고가 또 날 가능성이 매우 높아서 **담당자 역할을 문서로 박아두자**가 이번 PR입니다.

---

## Claude Code를 모르는 팀원을 위해

### Claude Code가 뭐야
터미널에서 돌아가는 AI 페어 프로그래머입니다. VS Code 확장 아니고 독립 CLI. 설치하면 `claude` 명령어로 실행되고, 지금 레포 전체를 맥락으로 읽으면서 코드 작성 · 수정 · 커밋 · PR까지 도와줍니다.

- 공식: https://www.anthropic.com/claude-code
- 설치: `npm i -g @anthropic-ai/claude-code` (또는 공식 가이드 참고)
- 요금: API 크레딧 또는 Claude Pro/Max 구독 기반

### 스킬이 뭐야
Claude Code가 특정 작업 맥락에서 **자동으로 호출하는 미니 가이드**입니다. 이 레포의 `.claude/skills/` 안에 `SKILL.md`를 두면, 사용자가 관련 작업을 시도할 때 Claude가 **알아서** 그 문서를 읽고 지침대로 행동합니다.

예: 팀원이 `Member.java`에 컬럼을 추가하려 하면 → Claude Code가 `db-man` 스킬을 자동 호출 → 자기소개하고 체크리스트대로 작업.

### Claude Code를 안 써도 얻는 것
이 PR은 **AI 전용 문서가 아닙니다**. `.claude/skills/db-man/SKILL.md` 자체가:
- "이 레포에서 DB 수정할 땐 이 순서대로 해라"는 **팀 규약**
- 환경 세팅(`.env` 못 받았을 때 뭘 물어봐야 하는지, psql 왜 필요한지, OS별 설치 가이드)
- 파괴적 DDL 구분 기준(허용/금지 매트릭스)
- PR에 붙일 체크리스트 · 롤백 SQL 템플릿

AI 없이도 이 문서를 열어서 읽고 따라오면 **같은 사고를 안 당합니다**.

---

## db-man이 하는 일 / 안 하는 일

### ✅ 하는 일 (실행자 역할)
- **3곳 동기화**: Tom이 정한 설계를 엔티티 · DDL 파일 · RDS에 빠짐없이 찍기
- **RDS에 SQL 실행** — 비파괴적 변경(ADD COLUMN nullable, CREATE INDEX 등)은 자율, 파괴적 변경은 Tom 승인 후
- **영향 범위 확인** — 바꾸는 엔티티가 다른 팀 모듈에서 참조되는지 grep
- **환경 점검** — `.env` 공란/psql 미설치 감지 시 **작업 중단 후 Tom에게 요청**
- **검증** — compileJava → psql 반영 → test 순서 강제
- **PR 메타 생성** — 스키마 변경 체크리스트 + 실행한 마이그레이션 SQL + 롤백 SQL

### ❌ 안 하는 일 (판단은 사람 몫)
- **설계 결정** (1:1 vs 1:N, FK 방향, 정규화, ON DELETE CASCADE 여부) → Tom
- **어노테이션 채택 판단** (`@DynamicUpdate` 달지 말지 등) → Tom/리뷰어
- **엔티티 코드 품질 리뷰** → 리뷰어
- **파괴적 DDL 독단 실행** (DROP, NOT NULL 추가, 타입 축소, 컬럼 rename 등) → 항상 Tom 승인 후
- **Flyway/Liquibase 역할** 대체 (이 스킬은 수동 관리 시기의 담당자, 도입되면 참고 문서로 축소)
- **auth 팀 소유 엔티티 임의 수정** (`User`, `RefreshToken`) — 참조만 가능

---

## 어떻게 쓰나

### Claude Code 사용자
별도로 할 게 없습니다. 엔티티/DDL/스키마 관련 작업을 시도하면 db-man이 **알아서 자기소개하고 절차 따라갑니다.**

자기소개 블록(호출 시 자동 출력):
```
👋 db-man입니다.

한 줄로: 엔티티 · DDL 파일 · RDS — 이 3곳이 똑같은 소리를 하게 맞춥니다.

✅ 제가 합니다 (실행자)
❌ 제가 안 합니다 (판단은 사람 몫)
🆘 막히면 — 바로 Tom에게 "선택지 A/B/C + 트레이드오프 + 기울어진 방향" 형식으로
```

### Claude Code 미사용자
`.claude/skills/db-man/SKILL.md`를 **수동 체크리스트**로 사용:
1. DB·엔티티 수정 착수 전에 **0단계: 환경 사전 점검** 4개 돌려보기
2. 수정 중에는 **책임 범위** 섹션(1~6단계) 순서대로
3. 막히면 **에스컬레이션 프로토콜**의 질문 템플릿으로 Tom에게 질문 (Slack/DM)
4. PR 올리기 전에 **6단계 PR 메타 블록** 그대로 복붙해서 본문에 포함

---

## 이 스킬이 실제로 막아주는 시나리오

| 시나리오 | Before (이번 사고 같은 일) | After |
|---|---|---|
| 엔티티 수정 후 DDL 깜빡 | 컴파일 통과 → 머지 → CI 빨개짐 | 스킬이 DDL 동기화를 절차에 강제 |
| RDS 반영 누락 | CI에서 `ddl-auto: validate` 실패 | compileJava → psql → test 순서 강제 |
| `.env` 없는 팀원이 막힘 | 각자 헤매다 Tom에게 중구난방 질문 | 즉시 중단 + 정형화된 요청 템플릿 |
| psql 미설치 | "안 돌아가요" 막연한 보고 | OS별 설치 가이드 + 왜 필요한지 설명 |
| 파괴적 DDL 독단 실행 | 데이터 손실 사고 가능 | Tom "실행해" 명시 문자열 전엔 금지 |
| 다른 팀 엔티티 영향 놓침 | 머지 후 다른 팀 CI 깨짐 | 영향 범위 스캔 + 에스컬레이션 룰 |

---

## 한계와 수명

- 이 스킬은 **수동 관리 시기의 담당자**입니다. Flyway/Liquibase + Testcontainers 도입되는 순간 역할이 "참고 문서"로 축소됩니다.
- 팀 모듈 DDL 파일 컨벤션(`{team}/db/{team}-ddl.sql`)은 **profile 팀 기준**이라, 다른 팀이 첫 DDL 만들 때 Tom 확인 필요합니다.
- 공용 RDS에 CI/로컬 test가 직결된 구조라서, **파괴적 ALTER 직후엔 팀 채널 공지 권장**.

---

## 체크리스트

- [x] `.claude/skills/db-man/SKILL.md` 작성 (평가 에이전트 피드백 반영 2회)
- [x] `.gitignore`에 `.claude/skills/` 예외 허용
- [x] 스킬 호출 시 자기소개 블록 강제
- [x] 책임 경계(동기화 vs 품질 판단) 명시
- [x] Claude Code 미사용자도 수동 체크리스트로 쓸 수 있도록 설명서 톤
- [ ] 리뷰어 확인