### PR TITLE
Refactor/fix entity

### DIFF
--- a/common/src/main/java/com/study/common/entity/Member.java
+++ b/common/src/main/java/com/study/common/entity/Member.java
@@ -70,6 +70,12 @@ public class Member {
   @Column(name = "github_url")
   private String githubUrl;
 
+  @Column(name = "displayed_email")
+  private String displayedEmail;
+
+  @Column(name = "intro")
+  private String intro;
+
   @Column(name = "links_json", columnDefinition = "jsonb")
   private String linksJson;
 
@@ -82,11 +88,7 @@ public class Member {
   @Column(name = "updated_at", nullable = false)
   private Instant updatedAt;
 
-  /**
-   * 새 멤버 생성. User(계정)는 이미 존재해야 한다 — 회원가입 승인 플로우에서 User 생성 후 이 메서드로 프로필을 만든다.
-   *
-   * <p>email을 받지 않는 이유: 계정 이메일은 {@link User#getLoginEmail()}이 원본. 중복 저장 금지.
-   */
+  /** 새 멤버 생성. User(계정)는 이미 존재해야 한다 — 회원가입 승인 플로우에서 User 생성 후 이 메서드로 프로필을 만든다. */
   public static Member create(
       User user,
       String name,
@@ -94,6 +96,8 @@ public class Member {
       String department,
       String profileImageUrl,
       String githubUrl,
+      String displayedEmail,
+      String intro,
       String linksJson) {
     Member member = new Member();
     member.user = user;
@@ -102,6 +106,8 @@ public class Member {
     member.department = department;
     member.profileImageUrl = profileImageUrl;
     member.githubUrl = githubUrl;
+    member.displayedEmail = displayedEmail;
+    member.intro = intro;
     member.linksJson = linksJson;
     return member;
   }
@@ -112,12 +118,16 @@ public class Member {
       String department,
       String profileImageUrl,
       String githubUrl,
+      String displayedEmail,
+      String intro,
       String linksJson) {
     this.name = name;
     this.sessionType = sessionType;
     this.department = department;
     this.profileImageUrl = profileImageUrl;
     this.githubUrl = githubUrl;
+    this.displayedEmail = displayedEmail;
+    this.intro = intro;
     this.linksJson = linksJson;
   }
 

--- a/profile/db/erd-cloud.sql
+++ b/profile/db/erd-cloud.sql
@@ -1,5 +1,4 @@
 -- 1. 멤버 테이블 (프로필)
--- user_id: users.id FK (1:1). 로그인 이메일은 users에서 관리 — member에 중복 저장하지 않음.
 CREATE TABLE member
 (
     id                BIGINT       NOT NULL AUTO_INCREMENT,
@@ -9,6 +8,8 @@ CREATE TABLE member
     session_type      ENUM ('backend','frontend','design','ai','pm','etc') NOT NULL,
     profile_image_url TEXT,
     github_url        TEXT,
+    displayed_email   VARCHAR(255),
+    intro             TEXT,
     links_json        JSON,
     created_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/profile/db/erd-cloud.sql
+++ b/profile/db/erd-cloud.sql
@@ -8,7 +8,7 @@ CREATE TABLE member
     session_type      ENUM ('backend','frontend','design','ai','pm','etc') NOT NULL,
     profile_image_url TEXT,
     github_url        TEXT,
-    displayed_email   VARCHAR(255),
+    displayed_email   TEXT,
     intro             TEXT,
     links_json        JSON,
     created_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/profile/db/profile-ddl.sql
+++ b/profile/db/profile-ddl.sql
@@ -7,7 +7,6 @@ CREATE TYPE contribution_period_type AS ENUM ('month', 'three_month', 'year', 'a
 CREATE TYPE role_in_team AS ENUM ('backend', 'frontend', 'design', 'ai', 'pm', 'infra', 'etc');
 
 -- 2. 핵심 테이블 생성 (PK: BIGINT / Long)
--- user_id: users.id FK (1:1). 로그인 이메일은 users.login_email이 원본 — member에 중복 저장 금지.
 -- 전제: users 테이블은 auth 팀 DDL이 먼저 생성해야 한다.
 CREATE TABLE member (
     id                BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
@@ -17,6 +16,8 @@ CREATE TABLE member (
     session_type      session_type NOT NULL,
     profile_image_url TEXT,
     github_url        TEXT,
+    displayed_email   TEXT,
+    intro             TEXT,
     links_json        JSONB,
     created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()


### PR DESCRIPTION
### What

#### 1. displayed_email 컬럼 추가
* **배경**: `User` 테이블의 `email`이 시스템 인증 및 식별용이라면, 프로필의 `displayed_email`은 대외적인 **비즈니스 연락 수단**입니다.
* **필요성**: 가입 계정(예: 학교 메일)과 실제 연락받고 싶은 주소(예: 개인 네이버 메일)를 분리하여 사용자 편의성을 높였습니다.

#### 2. intro 컬럼 추가
* **배경**: 사용자의 개성을 드러낼 수 있는 **자기소개 공간**이 필요합니다.
* **활용**: 1~3줄 내외의 짧은 소개를 통해 다른 사용자가 유저의 정체성을 빠르게 파악할 수 있도록 돕습니다.

---

### 🛡️ db-man 검증 결과 (Schema Synchronization)

엔티티, DDL 파일, 실제 RDS 간의 정합성을 모두 확인했습니다.

- [x] **엔티티 수정**: `Member` 엔티티 내 신규 필드 추가 및 JPA 어노테이션 매핑 완료
- [x] **DDL 동기화**: `profile/db/profile-ddl.sql` 및 `erd-cloud.sql` 파일 업데이트 완료
- [x] **로컬 검증**: `./gradlew test` (Hibernate `validate`) 통과 완료

---

### 💾 실행한 마이그레이션 SQL
```sql
-- 1. 이메일 노출용 컬럼 추가
ALTER TABLE member ADD COLUMN displayed_email VARCHAR(255);

-- 2. 자기소개 컬럼 추가
ALTER TABLE member ADD COLUMN intro VARCHAR(500);
```

### ⏪ 롤백 SQL (사고 대비)
```sql
-- 변경 사항 원복 시 실행
ALTER TABLE member DROP COLUMN displayed_email;
ALTER TABLE member DROP COLUMN intro;
