### PR TITLE
docs: 브랜치 전략 2단 계층 재편 (main ← dev ← feat/*)

### DIFF
--- a/docs/conventions/브랜치-커밋.md
+++ b/docs/conventions/브랜치-커밋.md
@@ -1,84 +1,115 @@
 # 브랜치 & 커밋 컨벤션
 
+## 왜 바뀌었나 (2026-04-24)
+
+이전 구조: `main ← dev ← 팀 베이스(blog/qna/profile/session-board) ← feat/*`
+
+실제 써보니 **"코드가 모이는 곳"과 "기능 단위 작업 브랜치" 사이에 팀 브랜치가 끼어** 병목과 혼란을 만들었다. 팀 베이스를 언제 dev로 올릴지, main 변경을 팀 베이스에 어떻게 반영할지 룰이 길고 복잡해지는 것도 문제.
+
+**새 구조는 2단 계층**으로 단순화한다:
+
+- **main** — 안정 상태. 관리자(@xhae123)만 관리.
+- **dev** — 코드가 실질적으로 모이는 통합 공간.
+- **feat/fix/refactor/...** — 개발자가 실제 작업하는 브랜치.
+
+---
+
 ## 브랜치 구조
 
 ```
-main ← dev ← blog ← blog/feat/post-crud
-                   ← blog/fix/title-validation
-             qna  ← qna/feat/question-create
-             profile ← profile/feat/member-search
-             session-board ← session-board/feat/event-list
+main (관리자만 건드림)
+  ↑ merge commit
+dev (통합 브랜치, CI 통과 필수)
+  ↑ rebase and merge
+{팀}/{타입}/{설명}  ← 여기가 개발자 작업 공간
 ```
 
-- **main**: 배포 브랜치
-- **dev**: 통합 브랜치. 팀별 작업이 여기로 모인다. main과 1:1
-- **blog / qna / profile / session-board**: 팀별 베이스 브랜치. 팀원들이 작업을 여기로 모은 뒤 dev로 PR
-- **blog/feat/... , qna/fix/...**: 팀원이 실제 작업하는 브랜치
+### 역할
 
-## 브랜치 이름
+| 브랜치 | 누가 건드리나 | 머지 방식 | 보호 |
+|---|---|---|---|
+| `main` | **관리자(@xhae123)만** | `dev → main` merge commit | PR 필수, CI 필수, force push 금지 |
+| `dev` | 팀원 PR로 | `feat/* → dev` rebase and merge | PR 필수, CI 통과 필수 |
+| `{팀}/...` | 작성자 본인 | 자유 | 보호 없음 |
+
+### 개발자는 main을 건드릴 일이 없다
+
+- 모든 PR의 base는 **`dev`**
+- `main`은 관리자가 주기적으로(예: 주 1회) `dev → main` PR을 열어 승격한다
+- 개발자는 `dev` 위에서 일하면 된다. main은 의식할 필요 없음
+
+---
+
+## 브랜치 이름 컨벤션
 
 ```
 {팀}/{타입}/{설명}
 ```
 
-| 타입 | 언제 | 예시 |
-|------|------|------|
-| `feat` | 새 기능 | `blog/feat/post-crud` |
-| `fix` | 버그 수정 | `qna/fix/answer-validation` |
-| `refactor` | 리팩토링 | `profile/refactor/member-query` |
-| `test` | 테스트 추가 | `session-board/test/event-integration` |
+- **팀**: `blog`, `qna`, `profile`, `session-board`
+- **타입**: `feat`, `fix`, `refactor`, `test`, `perf`, `chore`, `docs`
+- **설명**: 영어 소문자 + 하이픈(`-`)
 
-- 영어 소문자 + 하이픈(`-`)으로 구분
-- 이슈 번호가 있으면 붙여도 됨: `blog/feat/42-post-crud`
+### 예시
+
+```
+blog/feat/post-crud
+qna/fix/answer-validation
+profile/refactor/member-query
+session-board/test/event-integration
+```
+
+이슈 번호가 있으면 붙여도 된다: `blog/feat/42-post-crud`.
 
 ### 공통 작업 (팀 무관)
 
-인프라, 문서, 인증 등 특정 팀에 속하지 않는 작업은 팀 prefix 없이:
+인프라, 문서, 스킬, 인증 공통처럼 **특정 팀에 속하지 않는 작업**은 팀 prefix 없이:
 
 ```
-docs/team-conventions
+docs/branch-strategy-revamp
 infra/rds-postgres-setup
-feat/auth-jwt
+chore/spotless-config
+feat/auth-jwt       # auth는 공통 인프라로 취급
 ```
 
-## 흐름 요약
+---
 
-```
-1. 팀 베이스에서 작업 브랜치 생성   blog → blog/feat/post-crud
-2. 작업 완료 후 팀 베이스로 PR      blog/feat/post-crud → blog
-3. 팀 작업 모아서 dev로 PR          blog → dev
-4. dev에서 main으로 머지             dev → main
-```
+## 일상 작업 흐름
 
-## 베이스 브랜치 동기화
+### 1. 기능 작업 시작
 
-### 팀 베이스는 main의 downstream이다
-
-팀 베이스 브랜치(profile, blog 등)는 main 위에 팀 고유 커밋이 쌓인 구조다.
-main이 바뀐다고 팀 베이스를 항상 sync할 필요는 없다. main에 팀 작업에 영향을 주는 변경이 생겼을 때만 rebase한다.
-
-### feature는 반드시 팀 베이스에서 생성
-
-feature 브랜치를 main에서 직접 따면 안 된다.
-
-**왜?**
-팀 베이스에는 main에 없는 커밋이 있다. feature를 main에서 따면 그 커밋들이 feature의 base history에 없는 상태가 된다. 나중에 팀 베이스로 PR을 올릴 때 그 커밋들이 diff에 포함되거나, rebase 시 conflict가 예상치 못한 지점에서 터진다.
-
-### main 변경사항을 feature에 반영해야 할 때
-
-직접 main → feature rebase하지 않는다. 반드시 아래 순서를 따른다.
-
-```
-1. main → 팀 베이스 rebase
-   git checkout profile
-   git rebase main
-
-2. 팀 베이스 → feature rebase
-   git checkout profile/feat/member-search
-   git rebase profile
+```bash
+git checkout dev
+git pull origin dev                  # 최신 dev 받기
+git checkout -b blog/feat/post-crud  # dev에서 브랜치 따기
 ```
 
-팀 베이스를 거치지 않으면 팀 베이스의 커밋이 feature의 history에서 "새 커밋"으로 인식되어 히스토리가 꼬인다.
+### 2. 작업 중 dev에 새 커밋이 올라왔을 때 (반드시 rebase, merge 금지)
+
+```bash
+git fetch origin
+git rebase origin/dev
+```
+
+merge commit은 히스토리 지저분하게 만든다. 반드시 rebase.
+
+### 3. 작업 완료 후
+
+```bash
+git push origin blog/feat/post-crud
+# GitHub에서 PR 생성: blog/feat/post-crud → dev
+```
+
+- base가 **`dev`** 인지 확인 (기본값 main이면 바꿔야 함)
+- CI 통과 후 리뷰어 승인 받으면 머지
+- 머지 방식: **Rebase and merge** (히스토리 linear 유지)
+
+### 4. main 반영은 관리자가 한다
+
+- 관리자가 주기적으로 `dev → main` PR 열어 머지 (merge commit 방식)
+- 개발자가 직접 main을 건드리지 않는다
+
+---
 
 ## 커밋 메시지
 
@@ -115,4 +146,23 @@ feat: 여러 기능 추가
 
 - **하나의 커밋 = 하나의 논리적 변경**
 - "A도 하고 B도 하고"는 커밋 두 개로 나눈다
-- 단, spotless 포맷 같은 건 관련 커밋에 같이 넣어도 됨
+- spotless 포맷 같은 건 관련 커밋에 같이 넣어도 됨
+
+---
+
+## FAQ
+
+### Q. 왜 팀 베이스 브랜치가 없어졌나?
+팀 베이스는 "여러 기능을 한 번에 dev로 올리기 위한 묶음 공간"이었지만, 실제로는 dev에 바로 올리는 것과 별 차이 없었고 오히려 동기화 규칙이 길어져 혼란만 늘었다. 기능 단위 PR이 빈번히 올라오는 스터디 속도에는 **2단 계층**이 맞다.
+
+### Q. dev가 main과 크게 벌어지면?
+관리자가 주기적으로 `dev → main` 승격 PR을 여는 게 원칙. **통합 테스트 → 관리자 승인 → main 승격**이 하나의 리듬. 일주일 단위가 무난.
+
+### Q. dev가 깨지면?
+**dev의 CI는 항상 통과 상태여야 한다.** PR 머지 전 CI 통과가 필수이므로 일반적으로는 깨질 일이 없지만, 만약 깨지면 깨트린 PR 작성자가 즉시 fix PR을 올려 복구한다.
+
+### Q. main에 긴급 hotfix가 필요하면?
+관리자가 직접 판단. `hotfix/*` 브랜치를 `main`에서 따서 작업 후 `main`에 PR → 이후 `main → dev`로 역머지해 dev도 동기화한다. 예외적 상황이므로 규칙화보다 판단에 맡긴다.
+
+### Q. feat 작업 중 다른 팀이 dev를 자주 업데이트하면 rebase 지옥이 되지 않나?
+정상적인 트래픽에서는 rebase 충돌이 크지 않다. 만약 작업이 길어져 충돌이 많아진다면, **작업 단위가 너무 크다는 신호**. 기능을 더 잘게 쪼개 짧게 머지하는 리듬으로 가야 한다.


### PR DESCRIPTION
## 왜

팀 베이스 브랜치가 "코드가 모이는 곳(dev)"과 "기능 단위 작업(feat)" 사이에 끼어 **병목·혼란을 유발**했습니다. 팀 베이스 ↔ dev 동기화, main ↔ 팀 베이스 rebase 규칙이 길어져 실수 유발. 4팀 공동 레포 특성상 단순화가 낫다고 판단.

## 새 구조

```
main  (관리자만 건드림)
  ↑ merge commit — 관리자가 주기적으로 승격
dev   (통합 브랜치, CI 통과 필수)
  ↑ rebase and merge
{팀}/{타입}/{설명}  ← 개발자 작업 공간
```

## 핵심 원칙

- **개발자는 main을 건드릴 일이 없다.** 모든 PR의 base는 `dev`.
- **main은 관리자(@xhae123)가 주기적으로 dev에서 승격.** 주 1회 페이스 권장.
- **작업 브랜치에 dev 변경 반영 시 반드시 rebase** (merge commit 금지).

## 후속 작업 (이 PR 머지 후 진행)

- 기존 팀 브랜치(blog/profile/qna/session-board) 삭제
- Branch protection rule 재설정:
  - `main`: 관리자만 push, PR 필수, CI 필수
  - `dev`: PR 필수, CI 통과 필수
  - 팀 브랜치 rule 삭제
- 열린 PR 4개는 이미 base를 `dev`로 전환 완료

## 업계 레퍼런스

GitLab Flow / Environment Branch 패턴. Git Flow보다 가볍고 GitHub Flow보다 한 겹 더 보호된, 스터디 4팀 규모에 적합한 절충안.