### PR TITLE
chore: dev → main 동기화 (새 브랜치 전략 첫 승격)

### DIFF
--- a/app/src/main/resources/db/auth-ddl.sql
+++ b/app/src/main/resources/db/auth-ddl.sql
@@ -1,0 +1,49 @@
+-- ============================================================
+-- Auth / User — PostgreSQL DDL
+-- ============================================================
+-- 이 파일은 users 테이블과
+-- 인증에 사용되는 refresh_tokens 테이블을 정의합니다.
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- USERS
+-- ------------------------------------------------------------
+CREATE TYPE user_role   AS ENUM ('ADMIN', 'MEMBER');
+CREATE TYPE user_status AS ENUM ('PENDING', 'ACTIVE', 'REJECTED', 'EXPIRED');
+
+CREATE TABLE users (
+    id                   BIGINT      GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    login_email          TEXT        NOT NULL UNIQUE,
+    password_hash        TEXT        NOT NULL,
+    role                 user_role   NOT NULL DEFAULT 'MEMBER',
+    status               user_status NOT NULL DEFAULT 'PENDING',
+    signup_requested_at  TIMESTAMPTZ NOT NULL,
+    approved_at          TIMESTAMPTZ,
+    approved_by          BIGINT      REFERENCES users(id) ON DELETE SET NULL,
+    expired_at           TIMESTAMPTZ,
+    last_login_at        TIMESTAMPTZ,
+    created_at           TIMESTAMPTZ NOT NULL,
+    updated_at           TIMESTAMPTZ NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_user_login_email ON users(login_email);
+CREATE        INDEX idx_user_status      ON users(status);
+
+-- ------------------------------------------------------------
+-- REFRESH_TOKENS
+-- ------------------------------------------------------------
+CREATE TYPE refresh_token_status AS ENUM ('ACTIVE', 'USED', 'REVOKED');
+
+CREATE TABLE refresh_tokens (
+    id          BIGINT               GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id     BIGINT               NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash  TEXT                 NOT NULL UNIQUE,
+    family_id   UUID                 NOT NULL,
+    status      refresh_token_status NOT NULL,
+    expires_at  TIMESTAMPTZ          NOT NULL,
+    created_at  TIMESTAMPTZ          NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_refresh_token_hash   ON refresh_tokens(token_hash);
+CREATE        INDEX idx_refresh_token_family ON refresh_tokens(family_id);
+CREATE        INDEX idx_refresh_token_user   ON refresh_tokens(user_id);

--- a/common/src/main/java/com/study/common/entity/Member.java
+++ b/common/src/main/java/com/study/common/entity/Member.java
@@ -70,6 +70,12 @@ public class Member {
   @Column(name = "github_url")
   private String githubUrl;
 
+  @Column(name = "displayed_email")
+  private String displayedEmail;
+
+  @Column(name = "intro")
+  private String intro;
+
   @Column(name = "links_json", columnDefinition = "jsonb")
   private String linksJson;
 
@@ -82,11 +88,7 @@ public class Member {
   @Column(name = "updated_at", nullable = false)
   private Instant updatedAt;
 
-  /**
-   * 새 멤버 생성. User(계정)는 이미 존재해야 한다 — 회원가입 승인 플로우에서 User 생성 후 이 메서드로 프로필을 만든다.
-   *
-   * <p>email을 받지 않는 이유: 계정 이메일은 {@link User#getLoginEmail()}이 원본. 중복 저장 금지.
-   */
+  /** 새 멤버 생성. User(계정)는 이미 존재해야 한다 — 회원가입 승인 플로우에서 User 생성 후 이 메서드로 프로필을 만든다. */
   public static Member create(
       User user,
       String name,
@@ -94,6 +96,8 @@ public class Member {
       String department,
       String profileImageUrl,
       String githubUrl,
+      String displayedEmail,
+      String intro,
       String linksJson) {
     Member member = new Member();
     member.user = user;
@@ -102,6 +106,8 @@ public class Member {
     member.department = department;
     member.profileImageUrl = profileImageUrl;
     member.githubUrl = githubUrl;
+    member.displayedEmail = displayedEmail;
+    member.intro = intro;
     member.linksJson = linksJson;
     return member;
   }
@@ -112,12 +118,16 @@ public class Member {
       String department,
       String profileImageUrl,
       String githubUrl,
+      String displayedEmail,
+      String intro,
       String linksJson) {
     this.name = name;
     this.sessionType = sessionType;
     this.department = department;
     this.profileImageUrl = profileImageUrl;
     this.githubUrl = githubUrl;
+    this.displayedEmail = displayedEmail;
+    this.intro = intro;
     this.linksJson = linksJson;
   }
 

--- a/profile/db/erd-cloud.sql
+++ b/profile/db/erd-cloud.sql
@@ -1,5 +1,4 @@
 -- 1. 멤버 테이블 (프로필)
--- user_id: users.id FK (1:1). 로그인 이메일은 users에서 관리 — member에 중복 저장하지 않음.
 CREATE TABLE member
 (
     id                BIGINT       NOT NULL AUTO_INCREMENT,
@@ -9,6 +8,8 @@ CREATE TABLE member
     session_type      ENUM ('backend','frontend','design','ai','pm','etc') NOT NULL,
     profile_image_url TEXT,
     github_url        TEXT,
+    displayed_email   VARCHAR(255),
+    intro             TEXT,
     links_json        JSON,
     created_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/profile/db/erd-cloud.sql
+++ b/profile/db/erd-cloud.sql
@@ -8,7 +8,7 @@ CREATE TABLE member
     session_type      ENUM ('backend','frontend','design','ai','pm','etc') NOT NULL,
     profile_image_url TEXT,
     github_url        TEXT,
-    displayed_email   VARCHAR(255),
+    displayed_email   TEXT,
     intro             TEXT,
     links_json        JSON,
     created_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/profile/db/profile-ddl.sql
+++ b/profile/db/profile-ddl.sql
@@ -7,7 +7,6 @@ CREATE TYPE contribution_period_type AS ENUM ('month', 'three_month', 'year', 'a
 CREATE TYPE role_in_team AS ENUM ('backend', 'frontend', 'design', 'ai', 'pm', 'infra', 'etc');
 
 -- 2. 핵심 테이블 생성 (PK: BIGINT / Long)
--- user_id: users.id FK (1:1). 로그인 이메일은 users.login_email이 원본 — member에 중복 저장 금지.
 -- 전제: users 테이블은 auth 팀 DDL이 먼저 생성해야 한다.
 CREATE TABLE member (
     id                BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
@@ -17,6 +16,8 @@ CREATE TABLE member (
     session_type      session_type NOT NULL,
     profile_image_url TEXT,
     github_url        TEXT,
+    displayed_email   TEXT,
+    intro             TEXT,
     links_json        JSONB,
     created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()


### PR DESCRIPTION
## 왜
새 브랜치 전략 도입 후 첫 번째 정기 승격.

- main: PR #30 (브랜치 전략 문서) 포함
- dev: PR #29 (refactor/fix-entity), PR #23 (feat/auth-ddl) 포함
- 양쪽을 합쳐 main = dev 상태로 정렬
- dev를 디펄트 브랜치로 변경

## 이후
머지 후 dev를 main으로 fast-forward 동기화 예정.