### PR TITLE
fix: 프로필 엔티티/DDL 정합성 4건 보강

### DIFF
--- a/docs/db/profile/erd-cloud.sql
+++ b/docs/db/profile/erd-cloud.sql
@@ -102,6 +102,7 @@ CREATE TABLE team_member
     team_id    BIGINT   NOT NULL,
     member_id  BIGINT   NOT NULL,
     is_lead    BOOLEAN  NOT NULL DEFAULT FALSE,
+    status     ENUM ('pending','accepted','rejected','left','kicked') NOT NULL DEFAULT 'pending',
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (id),
     FOREIGN KEY (team_id) REFERENCES team_profile (id) ON DELETE CASCADE,

--- a/docs/db/profile/erd-cloud.sql
+++ b/docs/db/profile/erd-cloud.sql
@@ -49,6 +49,7 @@ CREATE TABLE tech_stack
     id         BIGINT       NOT NULL AUTO_INCREMENT,
     name       VARCHAR(255) NOT NULL UNIQUE,
     category   ENUM ('language','framework','ai','design','tool','infra','etc') NOT NULL,
+    logo_url   TEXT,
     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (id)
 );

--- a/docs/db/profile/erd-cloud.sql
+++ b/docs/db/profile/erd-cloud.sql
@@ -30,6 +30,9 @@ CREATE TABLE generation
     PRIMARY KEY (id)
 );
 
+-- generation.is_current는 PostgreSQL의 partial unique index로 1개만 TRUE 보장
+-- (profile-ddl.sql 참고). MySQL은 partial unique 미지원 → 시각화상 제약 표시 X.
+
 -- 3. 멤버-기수 연결 테이블
 CREATE TABLE member_generation
 (
@@ -39,6 +42,7 @@ CREATE TABLE member_generation
     role_in_gen   ENUM ('member','operating') NOT NULL DEFAULT 'member',
     joined_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (id),
+    UNIQUE KEY uq_member_generation (member_id, generation_id),
     FOREIGN KEY (member_id) REFERENCES member (id) ON DELETE CASCADE,
     FOREIGN KEY (generation_id) REFERENCES generation (id) ON DELETE CASCADE
 );
@@ -105,6 +109,7 @@ CREATE TABLE team_member
     status     ENUM ('pending','accepted','rejected','left','kicked') NOT NULL DEFAULT 'pending',
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (id),
+    UNIQUE KEY uq_team_member (team_id, member_id),
     FOREIGN KEY (team_id) REFERENCES team_profile (id) ON DELETE CASCADE,
     FOREIGN KEY (member_id) REFERENCES member (id) ON DELETE CASCADE
 );

--- a/docs/db/profile/profile-ddl.sql
+++ b/docs/db/profile/profile-ddl.sql
@@ -5,6 +5,7 @@ CREATE TYPE tech_stack_category AS ENUM ('language', 'framework', 'ai', 'design'
 CREATE TYPE activity_type AS ENUM ('blog_post', 'blog_comment', 'qna_answer', 'qna_question', 'qna_accepted', 'other');
 CREATE TYPE contribution_period_type AS ENUM ('month', 'three_month', 'year', 'all');
 CREATE TYPE role_in_team AS ENUM ('backend', 'frontend', 'design', 'ai', 'pm', 'infra', 'etc');
+CREATE TYPE team_member_status AS ENUM ('pending', 'accepted', 'rejected', 'left', 'kicked');
 
 -- 2. 핵심 테이블 생성 (PK: BIGINT / Long)
 -- 전제: users 테이블은 auth 팀 DDL이 먼저 생성해야 한다.
@@ -82,6 +83,7 @@ CREATE TABLE team_member (
     team_id    BIGINT NOT NULL REFERENCES team_profile(id) ON DELETE CASCADE,
     member_id  BIGINT NOT NULL REFERENCES member(id) ON DELETE CASCADE,
     is_lead    BOOLEAN NOT NULL DEFAULT FALSE,
+    status     team_member_status NOT NULL DEFAULT 'pending',
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 

--- a/docs/db/profile/profile-ddl.sql
+++ b/docs/db/profile/profile-ddl.sql
@@ -34,13 +34,17 @@ CREATE TABLE generation (
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+-- 한 시점에 활동 중인 기수는 1개 (is_current=TRUE인 row 1개로 제한)
+CREATE UNIQUE INDEX uq_generation_is_current ON generation (is_current) WHERE is_current = TRUE;
+
 -- 3. 관계 및 활동 테이블
 CREATE TABLE member_generation (
     id            BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     member_id     BIGINT NOT NULL REFERENCES member(id) ON DELETE CASCADE,
     generation_id BIGINT NOT NULL REFERENCES generation(id) ON DELETE CASCADE,
     role_in_gen   generation_role NOT NULL DEFAULT 'member',
-    joined_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    joined_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_member_generation UNIQUE (member_id, generation_id)
 );
 
 CREATE TABLE tech_stack (
@@ -84,7 +88,8 @@ CREATE TABLE team_member (
     member_id  BIGINT NOT NULL REFERENCES member(id) ON DELETE CASCADE,
     is_lead    BOOLEAN NOT NULL DEFAULT FALSE,
     status     team_member_status NOT NULL DEFAULT 'pending',
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_team_member UNIQUE (team_id, member_id)
 );
 
 CREATE TABLE team_member_role (

--- a/docs/db/profile/profile-ddl.sql
+++ b/docs/db/profile/profile-ddl.sql
@@ -46,6 +46,7 @@ CREATE TABLE tech_stack (
     id         BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     name       TEXT NOT NULL UNIQUE,
     category   tech_stack_category NOT NULL,
+    logo_url   TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 

--- a/src/main/java/com/study/profile/domain/activity/ActivityType.java
+++ b/src/main/java/com/study/profile/domain/activity/ActivityType.java
@@ -3,8 +3,8 @@ package com.study.profile.domain.activity;
 /**
  * 활동마다 점수(score)가 다르게 부여된다.
  *
- * <p>blog_post : 블로그 글 작성 +10 blog_comment : 블로그 글 댓글 작성 +5 qna_question : Q&A 질문 등록 +5 qna_answer :
- * Q&A 질문에 답변 작성 +5 qna_accepted : 작성한 답변이 채택됨 (추가 점수 부여) +10 other : 기타 활동
+ * <p>blog_post : 블로그 글 작성 +10 blog_comment : 블로그 글 댓글 작성 +5 qna_question : Q&A 질문 등록 +5 qna_answer
+ * : Q&A 질문에 답변 작성 +5 qna_accepted : 작성한 답변이 채택됨 (추가 점수 부여) +10 other : 기타 활동
  */
 public enum ActivityType {
   blog_post,

--- a/src/main/java/com/study/profile/domain/activity/ActivityType.java
+++ b/src/main/java/com/study/profile/domain/activity/ActivityType.java
@@ -3,13 +3,13 @@ package com.study.profile.domain.activity;
 /**
  * 활동마다 점수(score)가 다르게 부여된다.
  *
- * <p>blog_post : 블로그 글 작성 +10 blog_comment : 블로그 글 댓글 작성 +5 qna_post : Q&A 질문 등록 +5 qna_answer :
+ * <p>blog_post : 블로그 글 작성 +10 blog_comment : 블로그 글 댓글 작성 +5 qna_question : Q&A 질문 등록 +5 qna_answer :
  * Q&A 질문에 답변 작성 +5 qna_accepted : 작성한 답변이 채택됨 (추가 점수 부여) +10 other : 기타 활동
  */
 public enum ActivityType {
   blog_post,
   blog_comment,
-  qna_post,
+  qna_question,
   qna_answer,
   qna_accepted,
   other

--- a/src/main/java/com/study/profile/domain/generation/MemberGeneration.java
+++ b/src/main/java/com/study/profile/domain/generation/MemberGeneration.java
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -30,7 +31,12 @@ import lombok.NoArgsConstructor;
  * <p>[DB 테이블: member_generation]
  */
 @Entity
-@Table(name = "member_generation")
+@Table(
+    name = "member_generation",
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uq_member_generation",
+            columnNames = {"member_id", "generation_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberGeneration {

--- a/src/main/java/com/study/profile/domain/team/TeamMember.java
+++ b/src/main/java/com/study/profile/domain/team/TeamMember.java
@@ -15,6 +15,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +31,12 @@ import lombok.NoArgsConstructor;
  * <p>[DB 테이블: team_member]
  */
 @Entity
-@Table(name = "team_member")
+@Table(
+    name = "team_member",
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uq_team_member",
+            columnNames = {"team_id", "member_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TeamMember {

--- a/src/main/java/com/study/profile/domain/team/TeamMember.java
+++ b/src/main/java/com/study/profile/domain/team/TeamMember.java
@@ -4,6 +4,8 @@ import com.study.profile.domain.member.Member;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -57,6 +59,10 @@ public class TeamMember {
   @Column(name = "is_lead", nullable = false)
   private Boolean isLead = false; // 팀장 여부 (true면 팀장, false면 일반 팀원)
 
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false)
+  private TeamMemberStatus status; // 팀원 가입 상태 (pending/accepted/rejected/left/kicked)
+
   @Column(name = "created_at", nullable = false, updatable = false)
   private Instant createdAt; // 팀에 합류한 시각
 
@@ -71,6 +77,7 @@ public class TeamMember {
     teamMember.team = team;
     teamMember.member = member;
     teamMember.isLead = isLead;
+    teamMember.status = isLead ? TeamMemberStatus.accepted : TeamMemberStatus.pending;
     if (roles != null) {
       for (RoleInTeam role : roles) {
         teamMember.addRole(role);

--- a/src/main/java/com/study/profile/domain/team/TeamMember.java
+++ b/src/main/java/com/study/profile/domain/team/TeamMember.java
@@ -63,7 +63,7 @@ public class TeamMember {
   private List<TeamMemberRole> roles = new ArrayList<>();
 
   @Column(name = "is_lead", nullable = false)
-  private Boolean isLead = false; // 팀장 여부 (true면 팀장, false면 일반 팀원)
+  private boolean isLead = false; // 팀장 여부 (true면 팀장, false면 일반 팀원)
 
   @Enumerated(EnumType.STRING)
   @Column(name = "status", nullable = false)

--- a/src/main/java/com/study/profile/domain/team/TeamMemberStatus.java
+++ b/src/main/java/com/study/profile/domain/team/TeamMemberStatus.java
@@ -1,0 +1,18 @@
+package com.study.profile.domain.team;
+
+/**
+ * 팀원의 가입 상태.
+ *
+ * <p>pending : 조장이 초대했고 수락 대기 중
+ * <p>accepted : 수락 완료, 활동 중인 정식 팀원 (조장은 팀 생성과 동시에 이 상태)
+ * <p>rejected : 초대를 거절함
+ * <p>left : 자기 의지로 팀에서 빠짐
+ * <p>kicked : 조장이 강퇴함
+ */
+public enum TeamMemberStatus {
+  pending,
+  accepted,
+  rejected,
+  left,
+  kicked
+}

--- a/src/main/java/com/study/profile/domain/team/TeamMemberStatus.java
+++ b/src/main/java/com/study/profile/domain/team/TeamMemberStatus.java
@@ -4,9 +4,13 @@ package com.study.profile.domain.team;
  * 팀원의 가입 상태.
  *
  * <p>pending : 조장이 초대했고 수락 대기 중
+ *
  * <p>accepted : 수락 완료, 활동 중인 정식 팀원 (조장은 팀 생성과 동시에 이 상태)
+ *
  * <p>rejected : 초대를 거절함
+ *
  * <p>left : 자기 의지로 팀에서 빠짐
+ *
  * <p>kicked : 조장이 강퇴함
  */
 public enum TeamMemberStatus {

--- a/src/main/java/com/study/profile/domain/techstack/TechStack.java
+++ b/src/main/java/com/study/profile/domain/techstack/TechStack.java
@@ -56,8 +56,8 @@ public class TechStack {
   private Instant createdAt; // 등록 시각
 
   /**
-   * 새 기술 스택을 목록에 추가할 때 사용하는 정적 팩토리 메서드.
-   * (예: TechStack.create("Kotlin", TechStackCategory.language,  "https://.../kotlin.svg"))
+   * 새 기술 스택을 목록에 추가할 때 사용하는 정적 팩토리 메서드. (예: TechStack.create("Kotlin", TechStackCategory.language,
+   * "https://.../kotlin.svg"))
    */
   public static TechStack create(String name, TechStackCategory category, String logoUrl) {
     TechStack techStack = new TechStack();

--- a/src/main/java/com/study/profile/domain/techstack/TechStack.java
+++ b/src/main/java/com/study/profile/domain/techstack/TechStack.java
@@ -49,22 +49,28 @@ public class TechStack {
   @Column(name = "category", nullable = false)
   private TechStackCategory category; // 분류 (language/framework/ai/design/tool/infra/etc)
 
+  @Column(name = "logo_url")
+  private String logoUrl; // 기술 스택 로고 이미지 URL (nullable)
+
   @Column(name = "created_at", nullable = false, updatable = false)
   private Instant createdAt; // 등록 시각
 
   /**
-   * 새 기술 스택을 목록에 추가할 때 사용하는 정적 팩토리 메서드. (예: TechStack.create("Kotlin", TechStackCategory.language))
+   * 새 기술 스택을 목록에 추가할 때 사용하는 정적 팩토리 메서드.
+   * (예: TechStack.create("Kotlin", TechStackCategory.language,  "https://.../kotlin.svg"))
    */
-  public static TechStack create(String name, TechStackCategory category) {
+  public static TechStack create(String name, TechStackCategory category, String logoUrl) {
     TechStack techStack = new TechStack();
     techStack.name = name;
     techStack.category = category;
+    techStack.logoUrl = logoUrl;
     return techStack;
   }
 
-  public void update(String name, TechStackCategory category) {
+  public void update(String name, TechStackCategory category, String logoUrl) {
     this.name = name;
     this.category = category;
+    this.logoUrl = logoUrl;
   }
 
   /** DB 저장 직전에 JPA가 자동으로 현재 시각을 createdAt에 넣어준다. */


### PR DESCRIPTION
## Why

작업 시작할 기초 정리하는 차원에서, 명세서 작성 중 발견한 엔티티/DDL 정합성 4건 보강합니다.


## What

### 1. ActivityType `qna_post` → `qna_question` 통일하기

DDL은 `qna_question`인데 Java enum만 `qna_post`로 달랐습니다. 
Java를 DDL 기준으로 통일했습니다.

### 2. tech_stack에 `logo_url` 컬럼 추가 하기

tech_stack_seed에서 이미지를 logo_url로 가져오기 때문에 
Entity랑 DDL에 logo_url 컬럼을 추가했습니다.

### 3. TeamMember에 `status` 컬럼 + 'enum' 추가하기

팀원 초대 메커니즘이 
조장이 팀 생성 → 멤버 초대 → 수락 이니깐, 수락 상태를 관리하는 status를 엔티티/DDL에 추가했습니다

조장은 팀 생성 시 자동 accepted, 일반 멤버는 default pending

<status enum>
pending : 수락 대기
accepted : 팀원 확정
rejected : 거절
left : 탈퇴
kicked : 강퇴

### 4. 복합 UNIQUE 제약 3건 보강하기

- `member_generation (member_id, generation_id)` — 같은 사람 같은 기수 중복 방지
- `team_member (team_id, member_id)` — 한 팀에 같은 사람 중복 row 방지
- `generation.is_current=TRUE`는 1개만 (PostgreSQL partial unique index)
- 엔티티에도 `@UniqueConstraint` 어노테이션 추가

### 영향 범위
- 다른 팀 모듈에서 참조하는 컬럼/메서드 **없음** — 외부 영향 X

 ## Test
 - `./gradlew compileJava` 빌드 성공
 - `./gradlew spotlessApply` 적용 (포맷 통과)
 - `TechStack.create()/update()` 시그니처에 `logoUrl` 추가 (외부 호출자 0개 — grep 확인)

 ## RDS 반영
ddl-auto=validate라 머지 전 RDS DDL 적용이 필요합니다. @xhae123 님께 적용 요청드립니다. 적용 후 CI 재실행하면 통과될 예정입니다.

## Check
- [x] 빌드 + spotless 통과
- [x] @xhae123 RDS 적용 (CI 통과 위해 필수)
- [x] CI 통과