### PR TITLE
feat: Question 도메인 CRUD API 구현

### DIFF
--- a/src/main/java/com/study/qna/application/QuestionService.java
+++ b/src/main/java/com/study/qna/application/QuestionService.java
@@ -1,0 +1,85 @@
+package com.study.qna.application;
+
+import com.study.qna.application.dto.request.question.QuestionCreateRequest;
+import com.study.qna.application.dto.response.common.MemberSummaryResponse;
+import com.study.qna.application.dto.response.question.QuestionDetailResponse;
+import com.study.qna.application.dto.response.question.QuestionSummaryResponse;
+import com.study.qna.application.dto.response.tag.TagResponse;
+import com.study.qna.domain.Question;
+import com.study.qna.domain.exception.ForbiddenQnaActionException;
+import com.study.qna.domain.exception.QuestionNotFoundException;
+import com.study.qna.infrastructure.QuestionRepository;
+import com.study.qna.infrastructure.TagRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuestionService {
+
+  private static final String TEMP_NICKNAME = "임시닉네임";
+
+  private final QuestionRepository questionRepository;
+  private final TagRepository tagRepository;
+
+  public List<QuestionSummaryResponse> getQuestions() {
+    return questionRepository.findAllWithTags().stream()
+        .map(this::toSummaryResponse)
+        .toList();
+  }
+
+  public QuestionDetailResponse getQuestion(Long questionId) {
+    Question question =
+        questionRepository
+            .findByIdWithTags(questionId)
+            .orElseThrow(() -> new QuestionNotFoundException(questionId));
+
+    questionRepository.incrementViewCount(questionId);
+    question.incrementViewCount();
+
+    return toDetailResponse(question);
+  }
+
+  @Transactional
+  public QuestionDetailResponse createQuestion(QuestionCreateRequest request, Long userId) {
+    Question question = Question.create(userId, request.title(), request.content(), 0);
+
+    if (request.tagIds() != null && !request.tagIds().isEmpty()) {
+      tagRepository.findAllByIdIn(request.tagIds()).forEach(question::addTag);
+    }
+
+    Question saved = questionRepository.save(question);
+    return toDetailResponse(saved);
+  }
+
+  @Transactional
+  public void deleteQuestion(Long questionId, Long userId) {
+    Question question =
+        questionRepository
+            .findByIdWithTags(questionId)
+            .orElseThrow(() -> new QuestionNotFoundException(questionId));
+
+    if (!question.isAuthor(userId)) {
+      throw new ForbiddenQnaActionException();
+    }
+
+    questionRepository.delete(question);
+  }
+
+  private QuestionSummaryResponse toSummaryResponse(Question question) {
+    return QuestionSummaryResponse.of(
+        question,
+        MemberSummaryResponse.of(question.getUserId(), TEMP_NICKNAME, 0),
+        question.getQuestionTags().stream().map(qt -> TagResponse.from(qt.getTag())).toList());
+  }
+
+  private QuestionDetailResponse toDetailResponse(Question question) {
+    return QuestionDetailResponse.of(
+        question,
+        MemberSummaryResponse.of(question.getUserId(), TEMP_NICKNAME, 0),
+        question.getQuestionTags().stream().map(qt -> TagResponse.from(qt.getTag())).toList());
+  }
+}

--- a/src/main/java/com/study/qna/infrastructure/QuestionRepository.java
+++ b/src/main/java/com/study/qna/infrastructure/QuestionRepository.java
@@ -1,0 +1,49 @@
+package com.study.qna.infrastructure;
+
+import com.study.qna.domain.Question;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+  @Query(
+      """
+      SELECT DISTINCT q
+      FROM QnaQuestion q
+      LEFT JOIN FETCH q.questionTags qt
+      LEFT JOIN FETCH qt.tag
+      ORDER BY q.createdAt DESC
+      """)
+  List<Question> findAllWithTags();
+
+  @Query(
+      """
+      SELECT q
+      FROM QnaQuestion q
+      LEFT JOIN FETCH q.questionTags qt
+      LEFT JOIN FETCH qt.tag
+      WHERE q.id = :id
+      """)
+  Optional<Question> findByIdWithTags(@Param("id") Long id);
+
+  @Modifying(clearAutomatically = true)
+  @Transactional
+  @Query("UPDATE QnaQuestion q SET q.viewCount = q.viewCount + 1 WHERE q.id = :id")
+  void incrementViewCount(@Param("id") Long id);
+
+  @Modifying(clearAutomatically = true)
+  @Transactional
+  @Query("UPDATE QnaQuestion q SET q.answerCount = q.answerCount + 1 WHERE q.id = :id")
+  void incrementAnswerCount(@Param("id") Long id);
+
+  @Modifying(clearAutomatically = true)
+  @Transactional
+  @Query(
+      "UPDATE QnaQuestion q SET q.answerCount = q.answerCount - 1 WHERE q.id = :id AND q.answerCount > 0")
+  void decrementAnswerCount(@Param("id") Long id);
+}

--- a/src/main/java/com/study/qna/infrastructure/TagRepository.java
+++ b/src/main/java/com/study/qna/infrastructure/TagRepository.java
@@ -1,0 +1,10 @@
+package com.study.qna.infrastructure;
+
+import com.study.qna.domain.Tag;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+  List<Tag> findAllByIdIn(List<Long> ids);
+}

--- a/src/main/java/com/study/qna/presentation/QuestionController.java
+++ b/src/main/java/com/study/qna/presentation/QuestionController.java
@@ -1,0 +1,52 @@
+package com.study.qna.presentation;
+
+import com.study.auth.infrastructure.security.CurrentUser;
+import com.study.auth.infrastructure.security.CustomUserDetails;
+import com.study.qna.application.QuestionService;
+import com.study.qna.application.dto.request.question.QuestionCreateRequest;
+import com.study.qna.application.dto.response.question.QuestionDetailResponse;
+import com.study.qna.application.dto.response.question.QuestionSummaryResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/questions")
+@RequiredArgsConstructor
+public class QuestionController {
+
+  private final QuestionService questionService;
+
+  @GetMapping
+  public ResponseEntity<List<QuestionSummaryResponse>> getQuestions() {
+    return ResponseEntity.ok(questionService.getQuestions());
+  }
+
+  @GetMapping("/{questionId}")
+  public ResponseEntity<QuestionDetailResponse> getQuestion(@PathVariable Long questionId) {
+    return ResponseEntity.ok(questionService.getQuestion(questionId));
+  }
+
+  @PostMapping
+  public ResponseEntity<QuestionDetailResponse> createQuestion(
+      @CurrentUser CustomUserDetails user, @Valid @RequestBody QuestionCreateRequest request) {
+    QuestionDetailResponse result = questionService.createQuestion(request, user.userId());
+    return ResponseEntity.status(HttpStatus.CREATED).body(result);
+  }
+
+  @DeleteMapping("/{questionId}")
+  public ResponseEntity<Void> deleteQuestion(
+      @PathVariable Long questionId, @CurrentUser CustomUserDetails user) {
+    questionService.deleteQuestion(questionId, user.userId());
+    return ResponseEntity.noContent().build();
+  }
+}


### PR DESCRIPTION
## 개요
QnA 모듈 Question 도메인의 infrastructure · application · presentation 계층을 구현합니다.

---

## 구현 내용

### QuestionRepository
- 전체 질문 목록 조회 — questionTags, tag fetch join (N+1 방지), createdAt DESC 정렬
- 단건 질문 조회 — questionTags, tag fetch join
- 조회수 원자적 증가 — @Modifying UPDATE
- answerCount 원자적 증가/감소 — @Modifying UPDATE (AnswerService에서 호출)

### QuestionService
- `getQuestions()` — 전체 목록 최신순 조회
- `getQuestion()` — 단건 조회 + 조회수 증가
- `createQuestion()` — 질문 등록 + 태그 연결
- `deleteQuestion()` — 작성자 검증 후 soft delete

### QuestionController
- `GET /api/v1/questions` — 전체 질문 목록 조회 (인증 불필요)
- `GET /api/v1/questions/{questionId}` — 질문 단건 조회 (인증 불필요)
- `POST /api/v1/questions` — 질문 등록 (인증 필요, 201)
- `DELETE /api/v1/questions/{questionId}` — 질문 삭제 (인증 필요, 204)

---

## 참고 사항
- AuthorResponse의 nickname, generation은 Profile 모듈 연동 전까지 임시값 사용
- voteCount 갱신은 @Modifying 원자적 UPDATE 방식으로 처리 예정 (VoteService 구현 시)