### PR TITLE
feat: QnA Answer·Tag 도메인 CRUD API 구현

### DIFF
--- a/src/main/java/com/study/qna/application/AnswerService.java
+++ b/src/main/java/com/study/qna/application/AnswerService.java
@@ -1,0 +1,112 @@
+package com.study.qna.application;
+
+import com.study.qna.application.dto.request.answer.AnswerCreateRequest;
+import com.study.qna.application.dto.request.answer.AnswerUpdateRequest;
+import com.study.qna.application.dto.response.answer.AnswerDetailResponse;
+import com.study.qna.application.dto.response.answer.AnswerListResponse;
+import com.study.qna.application.dto.response.common.MemberSummaryResponse;
+import com.study.qna.domain.Answer;
+import com.study.qna.domain.Question;
+import com.study.qna.domain.QuestionStatus;
+import com.study.qna.domain.exception.AnswerNotFoundException;
+import com.study.qna.domain.exception.ForbiddenQnaActionException;
+import com.study.qna.domain.exception.QuestionNotFoundException;
+import com.study.qna.infrastructure.AnswerRepository;
+import com.study.qna.infrastructure.QuestionRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AnswerService {
+
+  private static final String TEMP_NICKNAME = "임시닉네임";
+
+  private final AnswerRepository answerRepository;
+  private final QuestionRepository questionRepository;
+
+  public AnswerListResponse getAnswers(Long questionId) {
+    questionRepository
+        .findById(questionId)
+        .orElseThrow(() -> new QuestionNotFoundException(questionId));
+
+    List<AnswerDetailResponse> answers =
+        answerRepository.findByQuestionId(questionId).stream()
+            .map(a -> AnswerDetailResponse.from(a, tempAuthor(a.getUserId())))
+            .toList();
+
+    return AnswerListResponse.of(answers);
+  }
+
+  @Transactional
+  public AnswerDetailResponse createAnswer(
+      Long questionId, AnswerCreateRequest request, Long userId) {
+    Question question =
+        questionRepository
+            .findById(questionId)
+            .orElseThrow(() -> new QuestionNotFoundException(questionId));
+
+    if (question.getStatus() == QuestionStatus.CLOSED) {
+      throw new ForbiddenQnaActionException();
+    }
+
+    Answer answer = Answer.create(question, userId, request.content());
+    Answer saved = answerRepository.save(answer);
+    questionRepository.incrementAnswerCount(questionId);
+
+    return AnswerDetailResponse.from(saved, tempAuthor(userId));
+  }
+
+  @Transactional
+  public AnswerDetailResponse updateAnswer(Long answerId, AnswerUpdateRequest request, Long userId) {
+    Answer answer =
+        answerRepository
+            .findById(answerId)
+            .orElseThrow(() -> new AnswerNotFoundException(answerId));
+
+    if (!answer.isAuthor(userId)) {
+      throw new ForbiddenQnaActionException();
+    }
+
+    answer.update(request.content());
+    return AnswerDetailResponse.from(answer, tempAuthor(userId));
+  }
+
+  @Transactional
+  public AnswerDetailResponse acceptAnswer(Long answerId, Long userId) {
+    Answer answer =
+        answerRepository
+            .findById(answerId)
+            .orElseThrow(() -> new AnswerNotFoundException(answerId));
+
+    if (!answer.getQuestion().isAuthor(userId)) {
+      throw new ForbiddenQnaActionException();
+    }
+
+    answer.accept();
+    return AnswerDetailResponse.from(answer, tempAuthor(answer.getUserId()));
+  }
+
+  @Transactional
+  public void deleteAnswer(Long answerId, Long userId) {
+    Answer answer =
+        answerRepository
+            .findById(answerId)
+            .orElseThrow(() -> new AnswerNotFoundException(answerId));
+
+    if (!answer.isAuthor(userId)) {
+      throw new ForbiddenQnaActionException();
+    }
+
+    Long questionId = answer.getQuestion().getId();
+    answerRepository.delete(answer);
+    questionRepository.decrementAnswerCount(questionId);
+  }
+
+  private MemberSummaryResponse tempAuthor(Long userId) {
+    return MemberSummaryResponse.of(userId, TEMP_NICKNAME, 0);
+  }
+}

--- a/src/main/java/com/study/qna/application/TagService.java
+++ b/src/main/java/com/study/qna/application/TagService.java
@@ -1,0 +1,39 @@
+package com.study.qna.application;
+
+import com.study.qna.application.dto.request.tag.TagCreateRequest;
+import com.study.qna.application.dto.response.tag.TagResponse;
+import com.study.qna.domain.Tag;
+import com.study.qna.domain.exception.TagAlreadyExistsException;
+import com.study.qna.domain.exception.TagNotFoundException;
+import com.study.qna.infrastructure.TagRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TagService {
+
+  private final TagRepository tagRepository;
+
+  public List<TagResponse> getTags() {
+    return tagRepository.findAllByOrderByNameAsc().stream().map(TagResponse::from).toList();
+  }
+
+  @Transactional
+  public void deleteTag(Long tagId) {
+    Tag tag = tagRepository.findById(tagId).orElseThrow(() -> new TagNotFoundException(tagId));
+    tagRepository.delete(tag);
+  }
+
+  @Transactional
+  public TagResponse createTag(TagCreateRequest request) {
+    if (tagRepository.existsByName(request.name())) {
+      throw new TagAlreadyExistsException(request.name());
+    }
+    Tag saved = tagRepository.save(Tag.create(request.name()));
+    return TagResponse.from(saved);
+  }
+}

--- a/src/main/java/com/study/qna/infrastructure/AnswerRepository.java
+++ b/src/main/java/com/study/qna/infrastructure/AnswerRepository.java
@@ -1,0 +1,31 @@
+package com.study.qna.infrastructure;
+
+import com.study.qna.domain.Answer;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
+  @Query(
+      """
+      SELECT a FROM QnaAnswer a
+      WHERE a.question.id = :questionId
+      ORDER BY a.accepted DESC, a.voteCount DESC, a.createdAt ASC
+      """)
+  List<Answer> findByQuestionId(@Param("questionId") Long questionId);
+
+  @Modifying(clearAutomatically = true)
+  @Transactional
+  @Query("UPDATE QnaAnswer a SET a.commentCount = a.commentCount + 1 WHERE a.id = :id")
+  void incrementCommentCount(@Param("id") Long id);
+
+  @Modifying(clearAutomatically = true)
+  @Transactional
+  @Query(
+      "UPDATE QnaAnswer a SET a.commentCount = a.commentCount - 1 WHERE a.id = :id AND a.commentCount > 0")
+  void decrementCommentCount(@Param("id") Long id);
+}

--- a/src/main/java/com/study/qna/infrastructure/TagRepository.java
+++ b/src/main/java/com/study/qna/infrastructure/TagRepository.java
@@ -6,5 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
+  boolean existsByName(String name);
+
+  List<Tag> findAllByOrderByNameAsc();
+
   List<Tag> findAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/study/qna/presentation/AnswerController.java
+++ b/src/main/java/com/study/qna/presentation/AnswerController.java
@@ -1,0 +1,64 @@
+package com.study.qna.presentation;
+
+import com.study.auth.infrastructure.security.CurrentUser;
+import com.study.auth.infrastructure.security.CustomUserDetails;
+import com.study.qna.application.AnswerService;
+import com.study.qna.application.dto.request.answer.AnswerCreateRequest;
+import com.study.qna.application.dto.request.answer.AnswerUpdateRequest;
+import com.study.qna.application.dto.response.answer.AnswerDetailResponse;
+import com.study.qna.application.dto.response.answer.AnswerListResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class AnswerController {
+
+  private final AnswerService answerService;
+
+  @GetMapping("/questions/{questionId}/answers")
+  public ResponseEntity<AnswerListResponse> getAnswers(@PathVariable Long questionId) {
+    return ResponseEntity.ok(answerService.getAnswers(questionId));
+  }
+
+  @PostMapping("/questions/{questionId}/answers")
+  public ResponseEntity<AnswerDetailResponse> createAnswer(
+      @PathVariable Long questionId,
+      @CurrentUser CustomUserDetails user,
+      @Valid @RequestBody AnswerCreateRequest request) {
+    AnswerDetailResponse result = answerService.createAnswer(questionId, request, user.userId());
+    return ResponseEntity.status(HttpStatus.CREATED).body(result);
+  }
+
+  @PatchMapping("/answers/{answerId}")
+  public ResponseEntity<AnswerDetailResponse> updateAnswer(
+      @PathVariable Long answerId,
+      @CurrentUser CustomUserDetails user,
+      @Valid @RequestBody AnswerUpdateRequest request) {
+    return ResponseEntity.ok(answerService.updateAnswer(answerId, request, user.userId()));
+  }
+
+  @PostMapping("/answers/{answerId}/accept")
+  public ResponseEntity<AnswerDetailResponse> acceptAnswer(
+      @PathVariable Long answerId, @CurrentUser CustomUserDetails user) {
+    return ResponseEntity.ok(answerService.acceptAnswer(answerId, user.userId()));
+  }
+
+  @DeleteMapping("/answers/{answerId}")
+  public ResponseEntity<Void> deleteAnswer(
+      @PathVariable Long answerId, @CurrentUser CustomUserDetails user) {
+    answerService.deleteAnswer(answerId, user.userId());
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/study/qna/presentation/TagController.java
+++ b/src/main/java/com/study/qna/presentation/TagController.java
@@ -1,0 +1,41 @@
+package com.study.qna.presentation;
+
+import com.study.qna.application.TagService;
+import com.study.qna.application.dto.request.tag.TagCreateRequest;
+import com.study.qna.application.dto.response.tag.TagResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/tags")
+public class TagController {
+
+  private final TagService tagService;
+
+  @GetMapping
+  public ResponseEntity<List<TagResponse>> getTags() {
+    return ResponseEntity.ok(tagService.getTags());
+  }
+
+  @PostMapping
+  public ResponseEntity<TagResponse> createTag(@Valid @RequestBody TagCreateRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED).body(tagService.createTag(request));
+  }
+
+  @DeleteMapping("/{tagId}")
+  public ResponseEntity<Void> deleteTag(@PathVariable Long tagId) {
+    tagService.deleteTag(tagId);
+    return ResponseEntity.noContent().build();
+  }
+}


### PR DESCRIPTION
## 개요
QnA 모듈 Answer·Tag 도메인의 infrastructure · application · presentation 계층을 구현합니다.

---

## 구현 내용

**AnswerRepository**
- 질문별 답변 목록 조회 — `accepted DESC, voteCount DESC, createdAt ASC` 정렬
- 단건 답변 조회
- commentCount 원자적 증가/감소 — `@Modifying` UPDATE (CommentService에서 호출)

**TagRepository**
- `existsByName()` — 이름 중복 확인
- `findAllByOrderByNameAsc()` — 전체 태그 이름 오름차순
- `findAllByIdIn()` — ID 목록으로 태그 일괄 조회 (QuestionService에서도 사용)

**AnswerService**
- `getAnswers()` — 답변 목록 조회, 채택 답변 분리 반환
- `createAnswer()` — 질문 존재 확인 + 답변 등록 + answerCount 증가
- `updateAnswer()` — 작성자 검증 후 수정
- `deleteAnswer()` — 작성자 검증 후 soft delete + answerCount 감소
- `acceptAnswer()` — 질문 작성자 검증 + 기존 채택 해제 + 신규 채택 + 상태 전이

**TagService**
- `getTags()` — 전체 태그 목록 조회
- `createTag()` — 이름 중복 확인 후 태그 생성
- `deleteTag()` — 태그 삭제

**AnswerController**
- `GET /api/v1/questions/{questionId}/answers` — 답변 목록 조회 (인증 불필요)
- `POST /api/v1/questions/{questionId}/answers` — 답변 등록 (인증 필요, 201)
- `PATCH /api/v1/answers/{answerId}` — 답변 수정 (인증 필요, 작성자 본인만)
- `DELETE /api/v1/answers/{answerId}` — 답변 삭제 (인증 필요, 204)
- `POST /api/v1/answers/{answerId}/accept` — 답변 채택 (인증 필요, 질문 작성자만)

**TagController**
- `GET /api/v1/tags` — 태그 목록 조회 (인증 불필요)
- `POST /api/v1/tags` — 태그 생성 (인증 필요, 201)
- `DELETE /api/v1/tags/{tagId}` — 태그 삭제 (인증 필요, 204)

---

## 참고 사항
- `author.nickname`, `author.generation`은 Profile 모듈 연동 전까지 임시값 반환 (`AnswerService.tempAuthor()`)
- voteCount 갱신은 `@Modifying` 원자적 UPDATE 방식으로 처리 예정 (VoteService 구현 시)