### PR TITLE
feat: Comment 도메인 조회 및 등록 API 구현

### DIFF
--- a/src/main/java/com/study/qna/application/CommentService.java
+++ b/src/main/java/com/study/qna/application/CommentService.java
@@ -1,0 +1,43 @@
+package com.study.qna.application;
+
+import com.study.qna.application.dto.request.comment.CommentCreateRequest;
+import com.study.qna.application.dto.response.comment.CommentResponse;
+import com.study.qna.application.dto.response.common.MemberSummaryResponse;
+import com.study.qna.domain.Answer;
+import com.study.qna.domain.Comment;
+import com.study.qna.domain.exception.AnswerNotFoundException;
+import com.study.qna.infrastructure.AnswerRepository;
+import com.study.qna.infrastructure.CommentRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentService {
+
+  private static final String TEMP_NICKNAME = "임시닉네임";
+
+  private final CommentRepository commentRepository;
+  private final AnswerRepository answerRepository;
+
+  public List<CommentResponse> getComments(Long answerId) {
+    answerRepository.findById(answerId).orElseThrow(() -> new AnswerNotFoundException(answerId));
+    return commentRepository.findByAnswerIdOrderByCreatedAtAsc(answerId).stream()
+        .map(c -> CommentResponse.of(c, MemberSummaryResponse.of(c.getUserId(), TEMP_NICKNAME, 0)))
+        .toList();
+  }
+
+  @Transactional
+  public CommentResponse createComment(
+      Long answerId, CommentCreateRequest request, Long userId) {
+    Answer answer =
+        answerRepository.findById(answerId).orElseThrow(() -> new AnswerNotFoundException(answerId));
+    Comment comment = Comment.createForAnswer(userId, answer, request.content());
+    commentRepository.save(comment);
+    answerRepository.incrementCommentCount(answerId);
+    return CommentResponse.of(comment, MemberSummaryResponse.of(userId, TEMP_NICKNAME, 0));
+  }
+}

--- a/src/main/java/com/study/qna/application/CommentService.java
+++ b/src/main/java/com/study/qna/application/CommentService.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Service("qnaCommentService")
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CommentService {

--- a/src/main/java/com/study/qna/infrastructure/CommentRepository.java
+++ b/src/main/java/com/study/qna/infrastructure/CommentRepository.java
@@ -1,0 +1,10 @@
+package com.study.qna.infrastructure;
+
+import com.study.qna.domain.Comment;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+  List<Comment> findByAnswerIdOrderByCreatedAtAsc(Long answerId);
+}

--- a/src/main/java/com/study/qna/presentation/CommentController.java
+++ b/src/main/java/com/study/qna/presentation/CommentController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RestController
+@RestController("qnaCommentController")
 @RequestMapping("/api/v1/answers/{answerId}/comments")
 @RequiredArgsConstructor
 public class CommentController {

--- a/src/main/java/com/study/qna/presentation/CommentController.java
+++ b/src/main/java/com/study/qna/presentation/CommentController.java
@@ -1,0 +1,40 @@
+package com.study.qna.presentation;
+
+import com.study.auth.infrastructure.security.CurrentUser;
+import com.study.auth.infrastructure.security.CustomUserDetails;
+import com.study.qna.application.CommentService;
+import com.study.qna.application.dto.request.comment.CommentCreateRequest;
+import com.study.qna.application.dto.response.comment.CommentResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/answers/{answerId}/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+  private final CommentService commentService;
+
+  @GetMapping
+  public ResponseEntity<List<CommentResponse>> getComments(@PathVariable Long answerId) {
+    return ResponseEntity.ok(commentService.getComments(answerId));
+  }
+
+  @PostMapping
+  public ResponseEntity<CommentResponse> createComment(
+      @PathVariable Long answerId,
+      @CurrentUser CustomUserDetails user,
+      @Valid @RequestBody CommentCreateRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(commentService.createComment(answerId, request, user.userId()));
+  }
+}


### PR DESCRIPTION
## 개요
QnA 모듈 Comment 도메인의 infrastructure · application · presentation 계층을 구현합니다.

---

## 구현 내용

### CommentRepository
- 답변별 댓글 목록 조회 — `createdAt ASC` 정렬 (Spring Data JPA 메서드 네이밍)

### CommentService
- `getComments(answerId)` — 답변 존재 확인 후 댓글 목록 조회, `CommentResponse` 리스트 반환
- `createComment(answerId, request, userId)` — 답변 존재 확인 → `Comment.createForAnswer()` → 저장 → `answerRepository.incrementCommentCount()` 호출

### CommentController
- `GET /api/v1/answers/{answerId}/comments` — 댓글 목록 조회 (인증 불필요)
- `POST /api/v1/answers/{answerId}/comments` — 댓글 등록 (인증 필요, 201)

---

## 참고 사항
- 대댓글 미지원 — `Comment` 엔티티에 `parent` / `children` 필드 없음
- `AuthorResponse`의 `nickname`, `generation`은 Profile 모듈 연동 전까지 임시값 사용
- 답변이 존재하지 않을 경우 `AnswerNotFoundException` 발생
- `GlobalExceptionHandler` QnA 예외 연동은 배포 직전 별도 PR로 진행 예정