### PR TITLE
‎🤍feat: GET /api/profile/tech-stacks 구현 및 ENUM 버그 수정

### DIFF
--- a/docs/db/profile/erd-cloud.sql
+++ b/docs/db/profile/erd-cloud.sql
@@ -75,14 +75,16 @@ CREATE TABLE member_tech_stack
 -- 6. 팀 프로필 테이블
 CREATE TABLE team_profile
 (
-    id            BIGINT       NOT NULL AUTO_INCREMENT,
-    generation_id BIGINT,
-    name          VARCHAR(255) NOT NULL,
-    description   TEXT,
-    project_url   TEXT,
-    github_url    TEXT,
-    created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    id                     BIGINT       NOT NULL AUTO_INCREMENT,
+    generation_id          BIGINT,
+    name                   VARCHAR(255) NOT NULL,
+    description            TEXT,
+    project_url            TEXT,
+    github_url             TEXT,
+    invite_code            VARCHAR(255) NOT NULL UNIQUE,
+    invite_code_expires_at DATETIME     NOT NULL,
+    created_at             DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at             DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (id),
     FOREIGN KEY (generation_id) REFERENCES generation (id) ON DELETE SET NULL
 );

--- a/docs/db/profile/profile-ddl.sql
+++ b/docs/db/profile/profile-ddl.sql
@@ -65,14 +65,16 @@ CREATE TABLE member_tech_stack (
 );
 
 CREATE TABLE team_profile (
-    id            BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-    generation_id BIGINT REFERENCES generation(id) ON DELETE SET NULL,
-    name          TEXT NOT NULL,
-    description   TEXT,
-    project_url   TEXT,
-    github_url    TEXT,
-    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    id                     BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    generation_id          BIGINT REFERENCES generation(id) ON DELETE SET NULL,
+    name                   TEXT NOT NULL,
+    description            TEXT,
+    project_url            TEXT,
+    github_url             TEXT,
+    invite_code            TEXT NOT NULL UNIQUE,
+    invite_code_expires_at TIMESTAMPTZ NOT NULL,
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at             TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE team_tech_stack (

--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -1,0 +1,1002 @@
+# Profile API 정의서
+
+## 개요
+
+| 항목 | 내용 |
+|------|------|
+| Base URL | `/api` |
+| 인증 | `Authorization: Bearer {accessToken}` (모든 쓰기 요청 필수) |
+| Content-Type | `application/json` |
+| 날짜 형식 | ISO 8601 (`2025-05-18T10:00:00Z`) |
+
+---
+
+## 담당 분리
+
+| 섹션 | 담당 | 테이블 |
+|------|------|--------|
+| 1. 멤버 | domain.member | `member` |
+| 2. 기수 | domain.member | `generation`, `member_generation` |
+| 3. 기술 스택 | domain.team | `tech_stack` |
+| 4. 멤버 기술스택 | domain.team | `member_tech_stack` |
+| 5. 팀 | domain.team | `team_profile`, `team_member`, `team_member_role`, `team_tech_stack`, `team_image` |
+| 6. 활동 기록 | domain.activity | `activity` |
+
+---
+
+## 공통 타입
+
+### SessionType
+```
+"backend" | "frontend" | "design" | "ai" | "pm" | "etc"
+```
+
+### GenerationRole
+```
+"member" | "operating"
+```
+
+### RoleInTeam
+```
+"backend" | "frontend" | "design" | "ai" | "pm" | "infra" | "etc"
+```
+
+### TeamMemberStatus
+```
+"accepted" | "left" | "kicked"
+```
+> `pending`, `rejected`는 초대 코드 방식에서 사용하지 않음
+
+### TechStackCategory
+```
+"language" | "framework" | "ai" | "design" | "tool" | "infra" | "etc"
+```
+
+### ActivityType
+```
+"blog_post" | "blog_comment" | "qna_question" | "qna_answer" | "qna_accepted" | "other"
+```
+
+### ContributionPeriodType
+```
+"month" | "three_month" | "year" | "all"
+```
+
+### 공통 에러 응답
+```json
+{
+  "status": 404,
+  "message": "멤버를 찾을 수 없습니다."
+}
+```
+
+| HTTP 상태 | 의미 |
+|-----------|------|
+| `400` | 요청 값 오류 |
+| `401` | 인증 토큰 없음 또는 만료 |
+| `403` | 권한 없음 (본인 또는 팀장이 아님) |
+| `404` | 리소스 없음 |
+| `409` | 중복 (이미 해당 팀에 가입됨 등) |
+
+---
+
+## 1. 멤버 (Members)
+> **담당: domain.member**
+
+### 1-1. 내 프로필 조회
+
+```
+GET /profile/members/me
+```
+
+> 로그인한 유저 본인의 프로필을 조회한다.
+
+**Response `200 OK`**
+```json
+{
+  "id": 1,
+  "name": "홍길동",
+  "department": "컴퓨터공학과",
+  "sessionType": "backend",
+  "profileImageUrl": "https://...",
+  "githubUrl": "https://github.com/honggildong",
+  "displayedEmail": "gildong@example.com",
+  "intro": "백엔드 개발자를 꿈꿉니다.",
+  "linksJson": "{\"notion\": \"https://...\"}",
+  "techStacks": [
+    { "techStackId": 1, "name": "Java", "category": "language", "logoUrl": "https://...", "proficiency": 4 }
+  ],
+  "createdAt": "2025-03-01T09:00:00Z",
+  "updatedAt": "2025-05-01T12:00:00Z"
+}
+```
+
+---
+
+### 1-2. 내 프로필 수정
+
+```
+PATCH /profile/members/me
+```
+
+**Request Body**
+```json
+{
+  "name": "홍길동",
+  "department": "컴퓨터공학과",
+  "sessionType": "backend",
+  "profileImageUrl": "https://...",
+  "githubUrl": "https://github.com/honggildong",
+  "displayedEmail": "gildong@example.com",
+  "intro": "백엔드 개발자를 꿈꿉니다.",
+  "linksJson": "{\"notion\": \"https://...\"}"
+}
+```
+
+| 필드 | 타입 | 필수 | 제약 |
+|------|------|------|------|
+| `name` | `string` | 예 | — |
+| `department` | `string` | 아니오 | — |
+| `sessionType` | `SessionType` | 예 | — |
+| `profileImageUrl` | `string` | 아니오 | — |
+| `githubUrl` | `string` | 아니오 | — |
+| `displayedEmail` | `string` | 아니오 | — |
+| `intro` | `string` | 아니오 | — |
+| `linksJson` | `string` | 아니오 | JSON 문자열 |
+
+**Response `200 OK`**
+```json
+{
+  "id": 1,
+  "name": "홍길동",
+  "updatedAt": "2025-05-07T10:00:00Z"
+}
+```
+
+---
+
+### 1-3. 멤버 목록 조회
+
+```
+GET /profile/members
+```
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|----------|------|------|--------|------|
+| `generationId` | `number` | 아니오 | — | 특정 기수 필터 |
+| `sessionType` | `SessionType` | 아니오 | — | 세션 트랙 필터 |
+
+**Response `200 OK`**
+```json
+[
+  {
+    "id": 1,
+    "name": "홍길동",
+    "department": "컴퓨터공학과",
+    "sessionType": "backend",
+    "profileImageUrl": "https://...",
+    "intro": "백엔드 개발자를 꿈꿉니다."
+  }
+]
+```
+
+---
+
+### 1-4. 멤버 상세 조회
+
+```
+GET /profile/members/{memberId}
+```
+
+**Response `200 OK`**
+```json
+{
+  "id": 1,
+  "name": "홍길동",
+  "department": "컴퓨터공학과",
+  "sessionType": "backend",
+  "profileImageUrl": "https://...",
+  "githubUrl": "https://github.com/honggildong",
+  "displayedEmail": "gildong@example.com",
+  "intro": "백엔드 개발자를 꿉니다.",
+  "linksJson": "{\"notion\": \"https://...\"}",
+  "techStacks": [
+    { "techStackId": 1, "name": "Java", "category": "language", "logoUrl": "https://...", "proficiency": 4 }
+  ],
+  "generations": [
+    { "generationId": 1, "label": "13기", "number": 13, "roleInGen": "member" }
+  ],
+  "createdAt": "2025-03-01T09:00:00Z"
+}
+```
+
+---
+
+### 1-5. 내가 속한 팀 목록 조회
+
+```
+GET /profile/members/me/teams
+```
+
+> 로그인한 유저가 `status = accepted`로 가입된 팀 목록을 반환한다.
+
+**Response `200 OK`**
+```json
+[
+  {
+    "id": 1,
+    "name": "헬스케어팀",
+    "description": "건강 관리 앱을 만드는 팀입니다.",
+    "generation": { "id": 1, "label": "13기", "number": 13 },
+    "techStacks": [
+      { "id": 1, "name": "Java", "category": "language", "logoUrl": "https://..." }
+    ],
+    "isLead": true,
+    "roles": ["backend"],
+    "thumbUrl": "https://..."
+  }
+]
+```
+
+| 필드 | 설명 |
+|------|------|
+| `isLead` | 해당 팀에서 내가 팀장인지 여부 |
+| `roles` | 해당 팀에서 내가 맡은 역할 목록 |
+
+---
+
+## 2. 기수 (Generations)
+> **담당: domain.member**
+
+### 2-1. 기수 목록 조회
+
+```
+GET /profile/generations
+```
+
+**Response `200 OK`**
+```json
+[
+  {
+    "id": 1,
+    "label": "13기",
+    "number": 13,
+    "startDate": "2025-03-01",
+    "endDate": null,
+    "isCurrent": true
+  }
+]
+```
+
+---
+
+### 2-2. 기수 생성 (관리자)
+
+```
+POST /profile/generations
+```
+
+**Request Body**
+```json
+{
+  "label": "13기",
+  "number": 13,
+  "startDate": "2025-03-01",
+  "endDate": null,
+  "isCurrent": true
+}
+```
+
+| 필드 | 타입 | 필수 | 제약 |
+|------|------|------|------|
+| `label` | `string` | 예 | — |
+| `number` | `number` | 예 | 중복 불가 |
+| `startDate` | `string` | 예 | `yyyy-MM-dd` |
+| `endDate` | `string` | 아니오 | `yyyy-MM-dd`, 진행 중이면 null |
+| `isCurrent` | `boolean` | 아니오 | `true`는 동시에 1개만 가능 |
+
+**Response `201 Created`**
+```json
+{ "id": 1 }
+```
+
+---
+
+### 2-3. 기수 상세 조회
+
+```
+GET /profile/generations/{generationId}
+```
+
+**Response `200 OK`**
+```json
+{
+  "id": 1,
+  "label": "13기",
+  "number": 13,
+  "startDate": "2025-03-01",
+  "endDate": null,
+  "isCurrent": true,
+  "createdAt": "2025-01-01T00:00:00Z"
+}
+```
+
+---
+
+### 2-4. 기수 수정 (관리자)
+
+```
+PATCH /profile/generations/{generationId}
+```
+
+**Request Body** — 2-2와 동일 구조
+
+**Response `200 OK`**
+```json
+{ "id": 1 }
+```
+
+---
+
+### 2-5. 기수 멤버 목록 조회
+
+```
+GET /profile/generations/{generationId}/members
+```
+
+**Response `200 OK`**
+```json
+[
+  {
+    "memberId": 1,
+    "name": "홍길동",
+    "sessionType": "backend",
+    "profileImageUrl": "https://...",
+    "roleInGen": "member",
+    "joinedAt": "2025-03-01T09:00:00Z"
+  }
+]
+```
+
+---
+
+### 2-6. 기수에 멤버 등록 (관리자)
+
+```
+POST /profile/generations/{generationId}/members
+```
+
+**Request Body**
+```json
+{
+  "memberId": 1,
+  "roleInGen": "member"
+}
+```
+
+| 필드 | 타입 | 필수 | 제약 |
+|------|------|------|------|
+| `memberId` | `number` | 예 | — |
+| `roleInGen` | `GenerationRole` | 예 | — |
+
+**Response `201 Created`**
+```json
+{ "id": 5 }
+```
+
+---
+
+## 3. 기술 스택 (Tech Stacks)
+> **담당: domain.team**
+>
+> 기술 스택은 시드 데이터로 제공된다 (`tech_stack_seed.json`). 일반 사용자는 읽기만 가능하고, 관리자만 추가/수정/삭제할 수 있다.
+
+### 3-1. 기술 스택 목록 조회
+
+```
+GET /profile/tech-stacks
+```
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|----------|------|------|------|
+| `category` | `TechStackCategory` | 아니오 | 카테고리 필터 |
+
+**Response `200 OK`**
+```json
+[
+  {
+    "id": 1,
+    "name": "Java",
+    "category": "language",
+    "logoUrl": "https://..."
+  }
+]
+```
+
+---
+
+### 3-2. 기술 스택 등록 (관리자)
+
+```
+POST /profile/tech-stacks
+```
+
+**Request Body**
+```json
+{
+  "name": "Bun",
+  "category": "framework",
+  "logoUrl": "https://..."
+}
+```
+
+| 필드 | 타입 | 필수 | 제약 |
+|------|------|------|------|
+| `name` | `string` | 예 | 중복 불가 |
+| `category` | `TechStackCategory` | 예 | — |
+| `logoUrl` | `string` | 아니오 | — |
+
+**Response `201 Created`**
+```json
+{ "id": 120 }
+```
+
+---
+
+### 3-3. 기술 스택 수정 (관리자)
+
+```
+PATCH /profile/tech-stacks/{techStackId}
+```
+
+**Request Body** — 3-2와 동일 구조
+
+**Response `200 OK`**
+```json
+{ "id": 1 }
+```
+
+---
+
+### 3-4. 기술 스택 삭제 (관리자)
+
+```
+DELETE /profile/tech-stacks/{techStackId}
+```
+
+**Response `204 No Content`**
+
+---
+
+## 4. 멤버 기술 스택 (Member Tech Stacks)
+> **담당: domain.team**
+
+### 4-1. 멤버 기술 스택 조회
+
+```
+GET /profile/members/{memberId}/tech-stacks
+```
+
+**Response `200 OK`**
+```json
+[
+  {
+    "techStackId": 1,
+    "name": "Java",
+    "category": "language",
+    "logoUrl": "https://...",
+    "proficiency": 4
+  }
+]
+```
+
+---
+
+### 4-2. 내 기술 스택 수정
+
+```
+PUT /profile/members/me/tech-stacks
+```
+
+> 기존 목록을 전체 교체한다. 빈 배열 `[]`을 보내면 전체 삭제.
+
+**Request Body**
+```json
+[
+  { "techStackId": 1, "proficiency": 4 },
+  { "techStackId": 2, "proficiency": 3 }
+]
+```
+
+| 필드 | 타입 | 필수 | 제약 |
+|------|------|------|------|
+| `techStackId` | `number` | 예 | 존재하는 tech_stack id |
+| `proficiency` | `number` | 아니오 | `1` ~ `5`, 미입력 시 null |
+
+**Response `200 OK`**
+```json
+[
+  {
+    "techStackId": 1,
+    "name": "Java",
+    "category": "language",
+    "logoUrl": "https://...",
+    "proficiency": 4
+  }
+]
+```
+
+---
+
+## 5. 팀 (Teams)
+> **담당: domain.team**
+>
+### 5-1. 팀 목록 조회
+
+```
+GET /profile/teams
+```
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|----------|------|------|------|
+| `generationId` | `number` | 아니오 | 기수 필터 |
+
+**Response `200 OK`**
+```json
+[
+  {
+    "id": 1,
+    "name": "헬스케어팀",
+    "description": "건강 관리 앱을 만드는 팀입니다.",
+    "generation": { "id": 1, "label": "13기", "number": 13 },
+    "techStacks": [
+      { "id": 1, "name": "Java", "category": "language", "logoUrl": "https://..." }
+    ],
+    "memberCount": 4,
+    "thumbUrl": "https://..."
+  }
+]
+```
+
+| 필드 | 설명 |
+|------|------|
+| `thumbUrl` | 팀 이미지가 1개 이상이면 첫 번째 이미지 URL, 없으면 `null` |
+
+---
+
+### 5-2. 팀 생성
+
+```
+POST /profile/teams
+```
+
+> 팀을 생성한 사람이 자동으로 팀장(`isLead = true`, `status = accepted`)이 된다.
+
+**Request Body**
+```json
+{
+  "name": "헬스케어팀",
+  "description": "건강 관리 앱을 만드는 팀입니다.",
+  "projectUrl": "https://...",
+  "githubUrl": "https://github.com/...",
+  "generationId": 1,
+  "imageUrls": ["https://...", "https://..."],
+  "techStackIds": [1, 2, 3]
+}
+```
+
+| 필드 | 타입 | 필수 | 제약 |
+|------|------|------|------|
+| `name` | `string` | 예 | — |
+| `description` | `string` | 아니오 | — |
+| `projectUrl` | `string` | 아니오 | — |
+| `githubUrl` | `string` | 아니오 | — |
+| `generationId` | `number` | 아니오 | 존재하는 generation id |
+| `imageUrls` | `string[]` | 아니오 | — |
+| `techStackIds` | `number[]` | 아니오 | 존재하는 tech_stack id 목록 |
+
+**Response `201 Created`**
+```json
+{
+  "id": 1,
+  "inviteCode": "A1B2C3",
+  "inviteCodeExpiresAt": "2025-05-10T10:00:00Z"
+}
+```
+
+---
+
+### 5-3. 팀 상세 조회
+
+```
+GET /profile/teams/{teamId}
+```
+
+**Response `200 OK`**
+```json
+{
+  "id": 1,
+  "name": "헬스케어팀",
+  "description": "건강 관리 앱을 만드는 팀입니다.",
+  "projectUrl": "https://...",
+  "githubUrl": "https://github.com/...",
+  "generation": { "id": 1, "label": "13기", "number": 13 },
+  "imageUrls": ["https://...", "https://..."],
+  "techStacks": [
+    { "id": 1, "name": "Java", "category": "language", "logoUrl": "https://..." }
+  ],
+  "members": [
+    {
+      "memberId": 1,
+      "name": "홍길동",
+      "sessionType": "backend",
+      "profileImageUrl": "https://...",
+      "isLead": true,
+      "roles": ["backend", "infra"],
+      "status": "accepted"
+    }
+  ],
+  "createdAt": "2025-05-01T10:00:00Z",
+  "updatedAt": "2025-05-07T10:00:00Z"
+}
+```
+
+---
+
+### 5-4. 팀 정보 수정 (팀장만)
+
+```
+PATCH /profile/teams/{teamId}
+```
+
+> 팀장만 호출 가능. 타인 요청 시 `403`.
+
+**Request Body**
+```json
+{
+  "name": "헬스케어팀 v2",
+  "description": "...",
+  "projectUrl": "https://...",
+  "githubUrl": "https://github.com/...",
+  "generationId": 1,
+  "imageUrls": ["https://..."],
+  "techStackIds": [1, 3]
+}
+```
+
+> `imageUrls` / `techStackIds` — `null`이면 기존 유지, 빈 배열 `[]`이면 전체 삭제
+
+**Response `200 OK`**
+```json
+{ "id": 1, "updatedAt": "2025-05-07T10:00:00Z" }
+```
+
+---
+
+### 5-5. 팀 삭제 (팀장만)
+
+```
+DELETE /profile/teams/{teamId}
+```
+
+> 팀장만 호출 가능. 삭제 시 `team_member`, `team_member_role`, `team_tech_stack`, `team_image` 모두 CASCADE 삭제.
+
+**Response `204 No Content`**
+
+---
+
+### 5-6. 초대 코드 조회 (팀장만)
+
+```
+GET /profile/teams/{teamId}/invite-code
+```
+
+> 팀장만 조회 가능. 팀원 초대 시 이 코드를 공유한다.
+
+**Response `200 OK`**
+```json
+{
+  "inviteCode": "A1B2C3",
+  "inviteCodeExpiresAt": "2025-05-10T10:00:00Z"
+}
+```
+
+---
+
+### 5-7. 초대 코드 재생성 (팀장만)
+
+```
+POST /profile/teams/{teamId}/invite-code/regenerate
+```
+
+> 기존 코드를 무효화하고 새 코드를 발급한다. 팀장만 호출 가능.
+> 재생성 시 만료 시각은 현재 시각 + 3일로 갱신된다.
+
+**Response `200 OK`**
+```json
+{
+  "inviteCode": "X9Y8Z7",
+  "inviteCodeExpiresAt": "2025-05-10T10:00:00Z"
+}
+```
+
+---
+
+### 5-8. 초대 코드로 팀 가입
+
+```
+POST /profile/teams/join
+```
+
+> 로그인한 유저가 초대 코드를 입력해 팀에 가입한다. 가입 즉시 `status = accepted`.
+
+**Request Body**
+```json
+{ "inviteCode": "A1B2C3" }
+```
+
+| 필드 | 타입 | 필수 | 제약 |
+|------|------|------|------|
+| `inviteCode` | `string` | 예 | — |
+
+**Response `200 OK`**
+```json
+{
+  "teamId": 1,
+  "teamName": "헬스케어팀"
+}
+```
+
+| 에러 | HTTP | 메시지 |
+|------|------|--------|
+| 존재하지 않는 코드 | `404` | 유효하지 않은 초대 코드입니다 |
+| 만료된 코드 | `400` | 만료된 초대 코드입니다 |
+| 이미 가입된 팀 | `409` | 이미 가입된 팀입니다 |
+
+---
+
+### 5-9. 팀장 양도 (팀장만)
+
+```
+PATCH /profile/teams/{teamId}/lead
+```
+
+> 팀장만 호출 가능. 기존 팀장의 `isLead`는 `false`, 새 팀장의 `isLead`는 `true`로 변경된다.
+> 대상 멤버는 `status = accepted` 상태여야 한다 — `400`.
+
+**Request Body**
+```json
+{ "memberId": 3 }
+```
+
+| 필드 | 타입 | 필수 | 제약 |
+|------|------|------|------|
+| `memberId` | `number` | 예 | 해당 팀의 accepted 팀원 |
+
+**Response `200 OK`**
+```json
+{
+  "teamId": 1,
+  "newLeadMemberId": 3
+}
+```
+
+---
+
+### 5-10. 팀원 역할 수정 (팀장만)
+
+```
+PUT /profile/teams/{teamId}/members/{memberId}/roles
+```
+
+> 팀장만 호출 가능. 기존 역할 목록을 전체 교체한다.
+
+**Request Body**
+```json
+{ "roles": ["backend", "infra"] }
+```
+
+| 필드 | 타입 | 필수 | 제약 |
+|------|------|------|------|
+| `roles` | `RoleInTeam[]` | 예 | 1개 이상 |
+
+**Response `200 OK`**
+```json
+{ "memberId": 2, "roles": ["backend", "infra"] }
+```
+
+---
+
+### 5-10. 팀원 강퇴 (팀장만)
+
+```
+DELETE /profile/teams/{teamId}/members/{memberId}
+```
+
+> 팀장만 호출 가능. 강퇴된 팀원의 `status`는 `kicked`로 변경된다.
+> 팀장 본인은 강퇴할 수 없다 — `400`.
+
+**Response `204 No Content`**
+
+---
+
+### 5-11. 팀 탈퇴
+
+```
+DELETE /profile/teams/{teamId}/members/me
+```
+
+> 팀장은 탈퇴 불가 — `400`. 팀을 해산하려면 팀 삭제(5-5)를 사용.
+> 탈퇴 시 `status`는 `left`로 변경된다.
+
+**Response `204 No Content`**
+
+---
+
+## 6. 활동 기록 (Activities)
+> **담당: domain.activity**
+>
+> 활동 기록은 blog / qna 도메인에서 이벤트 방식으로 자동 적재된다. 이 섹션은 **읽기 전용** API만 제공한다.
+
+### 점수 기준
+
+| ActivityType | 점수 |
+|---|---|
+| `blog_post` | +10 |
+| `blog_comment` | +5 |
+| `qna_question` | +5 |
+| `qna_answer` | +5 |
+| `qna_accepted` | +10 |
+| `other` | 별도 지정 |
+
+---
+
+### 6-1. 멤버 활동 목록 조회
+
+```
+GET /profile/members/{memberId}/activities
+```
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|----------|------|------|--------|------|
+| `type` | `ActivityType` | 아니오 | — | 활동 종류 필터 |
+| `page` | `number` | 아니오 | `0` | 페이지 번호 (0-based) |
+| `size` | `number` | 아니오 | `20` | 페이지 크기 |
+
+**Response `200 OK`**
+```json
+{
+  "content": [
+    {
+      "id": 1,
+      "type": "blog_post",
+      "referenceId": 42,
+      "referenceType": "blog_post",
+      "score": 10,
+      "createdAt": "2025-05-01T10:00:00Z"
+    }
+  ],
+  "page": 0,
+  "size": 20,
+  "totalElements": 35,
+  "totalPages": 2,
+  "hasNext": true
+}
+```
+
+---
+
+### 6-2. 멤버 기여도 요약
+
+```
+GET /profile/members/{memberId}/contributions
+```
+
+> `activity` 테이블에서 기간별 점수를 집계해 반환한다.
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|----------|------|------|--------|------|
+| `period` | `ContributionPeriodType` | 아니오 | `all` | 집계 기간 |
+
+**Response `200 OK`**
+```json
+{
+  "memberId": 1,
+  "name": "홍길동",
+  "period": "month",
+  "totalScore": 55,
+  "breakdown": {
+    "blog_post": 30,
+    "blog_comment": 5,
+    "qna_question": 5,
+    "qna_answer": 5,
+    "qna_accepted": 10,
+    "other": 0
+  }
+}
+```
+
+---
+
+### 6-3. 기여도 랭킹
+
+```
+GET /profile/contributions/ranking
+```
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|----------|------|------|--------|------|
+| `period` | `ContributionPeriodType` | 아니오 | `all` | 집계 기간 |
+| `generationId` | `number` | 아니오 | — | 특정 기수 필터 |
+| `limit` | `number` | 아니오 | `10` | 반환할 순위 수 |
+
+**Response `200 OK`**
+```json
+[
+  {
+    "rank": 1,
+    "memberId": 1,
+    "name": "홍길동",
+    "profileImageUrl": "https://...",
+    "totalScore": 120
+  },
+  {
+    "rank": 2,
+    "memberId": 3,
+    "name": "김지수",
+    "profileImageUrl": "https://...",
+    "totalScore": 95
+  }
+]
+```
+
+---
+
+## 엔드포인트 요약
+
+| 메서드 | 경로 | 설명 | 담당 |
+|--------|------|------|------|
+| `GET` | `/profile/members/me` | 내 프로필 조회 | member |
+| `PATCH` | `/profile/members/me` | 내 프로필 수정 | member |
+| `GET` | `/profile/members/me/teams` | 내가 속한 팀 목록 | team |
+| `GET` | `/profile/members` | 멤버 목록 | member |
+| `GET` | `/profile/members/{memberId}` | 멤버 상세 | member |
+| `GET` | `/profile/generations` | 기수 목록 | member |
+| `POST` | `/profile/generations` | 기수 생성 (관리자) | member |
+| `GET` | `/profile/generations/{generationId}` | 기수 상세 | member |
+| `PATCH` | `/profile/generations/{generationId}` | 기수 수정 (관리자) | member |
+| `GET` | `/profile/generations/{generationId}/members` | 기수 멤버 목록 | member |
+| `POST` | `/profile/generations/{generationId}/members` | 기수에 멤버 등록 (관리자) | member |
+| `GET` | `/profile/tech-stacks` | 기술 스택 목록 | team |
+| `POST` | `/profile/tech-stacks` | 기술 스택 등록 (관리자) | team |
+| `PATCH` | `/profile/tech-stacks/{techStackId}` | 기술 스택 수정 (관리자) | team |
+| `DELETE` | `/profile/tech-stacks/{techStackId}` | 기술 스택 삭제 (관리자) | team |
+| `GET` | `/profile/members/{memberId}/tech-stacks` | 멤버 기술 스택 조회 | team |
+| `PUT` | `/profile/members/me/tech-stacks` | 내 기술 스택 수정 | team |
+| `GET` | `/profile/teams` | 팀 목록 | team |
+| `POST` | `/profile/teams` | 팀 생성 | team |
+| `GET` | `/profile/teams/{teamId}` | 팀 상세 | team |
+| `PATCH` | `/profile/teams/{teamId}` | 팀 정보 수정 (팀장) | team |
+| `DELETE` | `/profile/teams/{teamId}` | 팀 삭제 (팀장) | team |
+| `GET` | `/profile/teams/{teamId}/invite-code` | 초대 코드 조회 (팀장) | team |
+| `POST` | `/profile/teams/{teamId}/invite-code/regenerate` | 초대 코드 재생성 (팀장) | team |
+| `POST` | `/profile/teams/join` | 초대 코드로 팀 가입 | team |
+| `PATCH` | `/profile/teams/{teamId}/lead` | 팀장 양도 (팀장) | team |
+| `PUT` | `/profile/teams/{teamId}/members/{memberId}/roles` | 팀원 역할 수정 (팀장) | team |
+| `DELETE` | `/profile/teams/{teamId}/members/{memberId}` | 팀원 강퇴 (팀장) | team |
+| `DELETE` | `/profile/teams/{teamId}/members/me` | 팀 탈퇴 | team |
+| `GET` | `/profile/members/{memberId}/activities` | 멤버 활동 목록 | activity |
+| `GET` | `/profile/members/{memberId}/contributions` | 멤버 기여도 요약 | activity |
+| `GET` | `/profile/contributions/ranking` | 기여도 랭킹 | activity |

--- a/src/main/java/com/study/profile/application/ActivityDto.java
+++ b/src/main/java/com/study/profile/application/ActivityDto.java
@@ -1,3 +1,0 @@
-package com.study.profile.application;
-
-public class ActivityDto {}

--- a/src/main/java/com/study/profile/application/MemberDto.java
+++ b/src/main/java/com/study/profile/application/MemberDto.java
@@ -1,3 +1,0 @@
-package com.study.profile.application;
-
-public class MemberDto {}

--- a/src/main/java/com/study/profile/application/TeamDto.java
+++ b/src/main/java/com/study/profile/application/TeamDto.java
@@ -1,3 +1,0 @@
-package com.study.profile.application;
-
-public class TeamDto {}

--- a/src/main/java/com/study/profile/application/TechStackService.java
+++ b/src/main/java/com/study/profile/application/TechStackService.java
@@ -28,21 +28,24 @@ public class TechStackService {
 
     // 11. category 파라미터가 없으면(null 또는 빈 문자열) 전체 조회
     //     있으면 해당 카테고리로 필터링해서 조회
+    // 11. 전체 목록을 한 번에 조회한 뒤 Java에서 필터링
+    //     PostgreSQL 커스텀 ENUM 타입(tech_stack_category)을 WHERE 절에 직접 쓰면
+    //     타입 불일치 오류가 발생하므로 애플리케이션 레벨에서 필터링한다.
+    //     tech_stack 테이블은 마스터 데이터라 수백 건 이하이므로 성능 문제 없음.
     if (category == null || category.isBlank()) {
       list = techStackRepository.findAllByOrderByNameAsc().stream()
-          .map(TechStackResponse::from)  // 엔티티 → DTO 변환 (6번에서 만든 from() 사용)
+          .map(TechStackResponse::from)
           .toList();
     } else {
-      // 12. 클라이언트가 "Language" 또는 "LANGUAGE" 같은 대소문자 섞인 값을 보내도 처리되도록
-      //     toLowerCase()로 소문자로 바꾼 뒤 Enum으로 변환한다.
-      //     Enum에 없는 값이면 IllegalArgumentException → 400 Bad Request로 응답된다.
+      // 12. 잘못된 category 값이면 IllegalArgumentException → 400 Bad Request
       TechStackCategory cat;
       try {
         cat = TechStackCategory.valueOf(category.toLowerCase());
       } catch (IllegalArgumentException e) {
         throw new IllegalArgumentException("유효하지 않은 category 값입니다: " + category);
       }
-      list = techStackRepository.findAllByCategoryOrderByNameAsc(cat).stream()
+      list = techStackRepository.findAllByOrderByNameAsc().stream()
+          .filter(ts -> ts.getCategory() == cat)
           .map(TechStackResponse::from)
           .toList();
     }

--- a/src/main/java/com/study/profile/application/TechStackService.java
+++ b/src/main/java/com/study/profile/application/TechStackService.java
@@ -1,0 +1,52 @@
+package com.study.profile.application;
+
+import com.study.profile.application.dto.TechStackDto.TechStackListResponse;
+import com.study.profile.application.dto.TechStackDto.TechStackResponse;
+import com.study.profile.domain.techstack.TechStackCategory;
+import com.study.profile.infrastructure.TechStackRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 8. Service — 비즈니스 로직을 담당하는 계층
+//    Controller는 "어떤 요청이 왔는지"만 알고,
+//    실제로 "무엇을 어떻게 처리할지"는 Service가 결정한다.
+@Service
+// 9. @RequiredArgsConstructor — final 필드를 파라미터로 받는 생성자를 자동 생성한다.
+//    덕분에 아래 techStackRepository 필드에 Spring이 자동으로 의존성을 주입한다.
+@RequiredArgsConstructor
+public class TechStackService {
+
+  private final TechStackRepository techStackRepository;
+
+  // 10. @Transactional(readOnly = true) — 이 메서드는 DB를 읽기만 하고 변경하지 않는다는 표시.
+  //     JPA가 변경 감지(dirty checking)를 생략해서 성능이 약간 좋아진다.
+  @Transactional(readOnly = true)
+  public TechStackListResponse getTechStacks(String category) {
+    List<TechStackResponse> list;
+
+    // 11. category 파라미터가 없으면(null 또는 빈 문자열) 전체 조회
+    //     있으면 해당 카테고리로 필터링해서 조회
+    if (category == null || category.isBlank()) {
+      list = techStackRepository.findAllByOrderByNameAsc().stream()
+          .map(TechStackResponse::from)  // 엔티티 → DTO 변환 (6번에서 만든 from() 사용)
+          .toList();
+    } else {
+      // 12. 클라이언트가 "Language" 또는 "LANGUAGE" 같은 대소문자 섞인 값을 보내도 처리되도록
+      //     toLowerCase()로 소문자로 바꾼 뒤 Enum으로 변환한다.
+      //     Enum에 없는 값이면 IllegalArgumentException → 400 Bad Request로 응답된다.
+      TechStackCategory cat;
+      try {
+        cat = TechStackCategory.valueOf(category.toLowerCase());
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("유효하지 않은 category 값입니다: " + category);
+      }
+      list = techStackRepository.findAllByCategoryOrderByNameAsc(cat).stream()
+          .map(TechStackResponse::from)
+          .toList();
+    }
+
+    return new TechStackListResponse(list);
+  }
+}

--- a/src/main/java/com/study/profile/application/dto/ActivityDto.java
+++ b/src/main/java/com/study/profile/application/dto/ActivityDto.java
@@ -1,0 +1,3 @@
+package com.study.profile.application.dto;
+
+public class ActivityDto {}

--- a/src/main/java/com/study/profile/application/dto/MemberDto.java
+++ b/src/main/java/com/study/profile/application/dto/MemberDto.java
@@ -1,0 +1,3 @@
+package com.study.profile.application.dto;
+
+public class MemberDto {}

--- a/src/main/java/com/study/profile/application/dto/TeamDto.java
+++ b/src/main/java/com/study/profile/application/dto/TeamDto.java
@@ -1,0 +1,3 @@
+package com.study.profile.application.dto;
+
+public class TeamDto {}

--- a/src/main/java/com/study/profile/application/dto/TechStackDto.java
+++ b/src/main/java/com/study/profile/application/dto/TechStackDto.java
@@ -1,0 +1,33 @@
+package com.study.profile.application.dto;
+
+import com.study.profile.domain.techstack.TechStack;
+import com.study.profile.domain.techstack.TechStackCategory;
+import java.util.List;
+
+// 4. DTO (Data Transfer Object) — 계층 간 데이터를 주고받는 그릇
+//    엔티티(TechStack)를 그대로 외부에 노출하지 않고,
+//    필요한 필드만 골라서 응답 형태로 만든다.
+public class TechStackDto {
+
+  // 5. record — Java 16+ 문법. 불변 데이터 클래스를 한 줄로 선언한다.
+  //    생성자, getter, equals, hashCode, toString 이 자동 생성된다.
+  //    여기서는 클라이언트에게 돌려줄 기술 스택 1개의 모양을 정의한다.
+  public record TechStackResponse(
+      Long id, String name, TechStackCategory category, String logoUrl) {
+
+    // 6. 정적 팩토리 메서드 from() — 엔티티 → DTO 변환을 한 곳에서 처리한다.
+    //    Service에서 techStack.getId() 같은 변환 코드를 직접 짜지 않아도 된다.
+    //    사용 예: TechStackResponse.from(techStack)
+    public static TechStackResponse from(TechStack techStack) {
+      return new TechStackResponse(
+          techStack.getId(),
+          techStack.getName(),
+          techStack.getCategory(),
+          techStack.getLogoUrl());
+    }
+  }
+
+  // 7. 목록 응답 전용 DTO — List<TechStackResponse> 를 감싸서
+  //    JSON 응답이 { "techStacks": [...] } 형태로 나오게 한다.
+  public record TechStackListResponse(List<TechStackResponse> techStacks) {}
+}

--- a/src/main/java/com/study/profile/domain/team/TeamProfile.java
+++ b/src/main/java/com/study/profile/domain/team/TeamProfile.java
@@ -61,6 +61,12 @@ public class TeamProfile {
   @Column(name = "github_url")
   private String githubUrl; // 프로젝트 GitHub (선택 입력)
 
+  @Column(name = "invite_code", nullable = false, unique = true)
+  private String inviteCode; // 팀 초대 코드 (서버가 랜덤 생성, 재생성 가능)
+
+  @Column(name = "invite_code_expires_at", nullable = false)
+  private Instant inviteCodeExpiresAt; // 초대 코드 만료 시각 (생성/재생성 시 현재 시각 + 3일)
+
   @Column(name = "created_at", nullable = false, updatable = false)
   private Instant createdAt; // 팀 생성 시각
 
@@ -111,14 +117,28 @@ public class TeamProfile {
   }
 
   public static TeamProfile create(
-      Generation generation, String name, String description, String projectUrl, String githubUrl) {
+      Generation generation,
+      String name,
+      String description,
+      String projectUrl,
+      String githubUrl,
+      String inviteCode,
+      Instant inviteCodeExpiresAt) {
     TeamProfile teamProfile = new TeamProfile();
     teamProfile.generation = generation;
     teamProfile.name = name;
     teamProfile.description = description;
     teamProfile.projectUrl = projectUrl;
     teamProfile.githubUrl = githubUrl;
+    teamProfile.inviteCode = inviteCode;
+    teamProfile.inviteCodeExpiresAt = inviteCodeExpiresAt;
     return teamProfile;
+  }
+
+  /** 초대 코드를 재생성한다. 기존 코드는 즉시 무효화되고 만료 시각은 현재 시각 + 3일로 갱신된다. */
+  public void regenerateInviteCode(String newCode) {
+    this.inviteCode = newCode;
+    this.inviteCodeExpiresAt = Instant.now().plus(3, java.time.temporal.ChronoUnit.DAYS);
   }
 
   public void update(

--- a/src/main/java/com/study/profile/domain/techstack/TechStack.java
+++ b/src/main/java/com/study/profile/domain/techstack/TechStack.java
@@ -46,7 +46,7 @@ public class TechStack {
   private String name; // 기술 스택 이름 (예: "Java", "React") — 중복 불가
 
   @Enumerated(EnumType.STRING)
-  @Column(name = "category", nullable = false)
+  @Column(name = "category", nullable = false, columnDefinition = "tech_stack_category")
   private TechStackCategory category; // 분류 (language/framework/ai/design/tool/infra/etc)
 
   @Column(name = "logo_url")

--- a/src/main/java/com/study/profile/infrastructure/TechStackRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/TechStackRepository.java
@@ -1,7 +1,6 @@
 package com.study.profile.infrastructure;
 
 import com.study.profile.domain.techstack.TechStack;
-import com.study.profile.domain.techstack.TechStackCategory;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -13,8 +12,4 @@ public interface TechStackRepository extends JpaRepository<TechStack, Long> {
   //    → 결과: 전체 스택을 이름 오름차순으로 조회
   List<TechStack> findAllByOrderByNameAsc();
 
-  // 3. findAllBy + Category(조건) + OrderByNameAsc(정렬)
-  //    → SELECT * FROM tech_stack WHERE category = ? ORDER BY name ASC
-  //    category 파라미터 값이 WHERE 절에 자동으로 들어간다.
-  List<TechStack> findAllByCategoryOrderByNameAsc(TechStackCategory category);
 }

--- a/src/main/java/com/study/profile/infrastructure/TechStackRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/TechStackRepository.java
@@ -1,0 +1,20 @@
+package com.study.profile.infrastructure;
+
+import com.study.profile.domain.techstack.TechStack;
+import com.study.profile.domain.techstack.TechStackCategory;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TechStackRepository extends JpaRepository<TechStack, Long> {
+
+  // 2. 메서드 이름 규칙만 지키면 Spring Data JPA가 SQL을 자동으로 만들어준다.
+  //    findAllBy          → SELECT * FROM tech_stack
+  //    OrderByNameAsc     → ORDER BY name ASC
+  //    → 결과: 전체 스택을 이름 오름차순으로 조회
+  List<TechStack> findAllByOrderByNameAsc();
+
+  // 3. findAllBy + Category(조건) + OrderByNameAsc(정렬)
+  //    → SELECT * FROM tech_stack WHERE category = ? ORDER BY name ASC
+  //    category 파라미터 값이 WHERE 절에 자동으로 들어간다.
+  List<TechStack> findAllByCategoryOrderByNameAsc(TechStackCategory category);
+}

--- a/src/main/java/com/study/profile/presentation/TechStackController.java
+++ b/src/main/java/com/study/profile/presentation/TechStackController.java
@@ -1,0 +1,33 @@
+package com.study.profile.presentation;
+
+import com.study.profile.application.dto.TechStackDto.TechStackListResponse;
+import com.study.profile.application.TechStackService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+// 13. Controller — HTTP 요청의 진입점
+//     클라이언트(프론트엔드)가 보낸 요청을 받아서 Service에 넘기고,
+//     Service가 돌려준 결과를 HTTP 응답으로 내보내는 역할만 한다.
+@RestController  // @Controller + @ResponseBody. 반환값을 JSON으로 자동 변환한다.
+@RequestMapping("/api/profile/tech-stacks")  // 이 컨트롤러가 처리할 URL prefix
+@RequiredArgsConstructor
+public class TechStackController {
+
+  private final TechStackService techStackService;
+
+  // 14. @GetMapping — GET /api/profile/tech-stacks 요청을 이 메서드가 처리한다.
+  //     @RequestParam(required = false) — URL 뒤에 ?category=language 처럼 붙는 쿼리 파라미터.
+  //     required = false 이므로 생략 가능 → 생략하면 category가 null로 들어온다.
+  @GetMapping
+  public ResponseEntity<TechStackListResponse> getTechStacks(
+      @RequestParam(required = false) String category) {
+
+    // 15. ResponseEntity.ok() — HTTP 200 OK 상태코드와 함께 body를 응답한다.
+    //     Service에서 받은 TechStackListResponse가 JSON으로 변환되어 클라이언트에 전달된다.
+    return ResponseEntity.ok(techStackService.getTechStacks(category));
+  }
+}

--- a/src/main/java/com/study/shared/config/SecurityConfig.java
+++ b/src/main/java/com/study/shared/config/SecurityConfig.java
@@ -62,7 +62,8 @@ public class SecurityConfig {
                     .requestMatchers(
                         org.springframework.http.HttpMethod.GET,
                         "/api/blog/posts",
-                        "/api/blog/posts/**")
+                        "/api/blog/posts/**",
+                        "/api/profile/tech-stacks")
                     .permitAll()
                     .anyRequest()
                     .authenticated())

--- a/src/main/java/com/study/shared/config/SecurityConfig.java
+++ b/src/main/java/com/study/shared/config/SecurityConfig.java
@@ -63,7 +63,8 @@ public class SecurityConfig {
                         org.springframework.http.HttpMethod.GET,
                         "/api/blog/posts",
                         "/api/blog/posts/**",
-                        "/api/profile/tech-stacks")
+                        "/api/profile/tech-stacks",
+                        "/api/profile/tech-stacks/**")
                     .permitAll()
                     .anyRequest()
                     .authenticated())


### PR DESCRIPTION
## Summary   
  - profile API 명세서에 담당자(세인/시현/근엽) 및 구현 체크리스트 추가                                                                                                                                                                                                                                                        
  - GET /api/profile/tech-stacks 구현 (category 필터 지원)
  - PostgreSQL 커스텀 ENUM 타입 불일치 버그 수정 -> 애플리케이션 레벨에서 필터링
                                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                                   
  - [x] GET /api/profile/tech-stacks → 전체 목록 200 응답 확인                                                                                                                                   
  - [x] GET /api/profile/tech-stacks?category=language → 필터링 200 응답 확인                                                                                                                    
  - [x] GET /api/profile/tech-stacks?category=invalid → 400 응답 확인                            