### PR TITLE
✨ feat: implement team creation API 

### DIFF
--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -1004,7 +1004,7 @@ GET /profile/contributions/ranking
 | [ ] | `GET` | `/profile/members/{memberId}/tech-stacks` | 멤버 기술 스택 조회 | 시현 |
 | [ ] | `PUT` | `/profile/members/me/tech-stacks` | 내 기술 스택 수정 | 시현 |
 | [ ] | `GET` | `/profile/teams` | 팀 목록 | 시현 |
-| [ ] | `POST` | `/profile/teams` | 팀 생성 | 시현 |
+| ✅ | `POST` | `/profile/teams` | 팀 생성 | 시현 |
 | [ ] | `GET` | `/profile/teams/{teamId}` | 팀 상세 | 시현 |
 | [ ] | `PATCH` | `/profile/teams/{teamId}` | 팀 정보 수정 (팀장) | 시현 |
 | [ ] | `DELETE` | `/profile/teams/{teamId}` | 팀 삭제 (팀장) | 시현 |

--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -15,12 +15,12 @@
 
 | 섹션 | 담당 | 테이블 |
 |------|------|--------|
-| 1. 멤버 | domain.member | `member` |
-| 2. 기수 | domain.member | `generation`, `member_generation` |
-| 3. 기술 스택 | domain.team | `tech_stack` |
-| 4. 멤버 기술스택 | domain.team | `member_tech_stack` |
-| 5. 팀 | domain.team | `team_profile`, `team_member`, `team_member_role`, `team_tech_stack`, `team_image` |
-| 6. 활동 기록 | domain.activity | `activity` |
+| 1. 멤버 | 세인 | `member` |
+| 2. 기수 | 세인 | `generation`, `member_generation` |
+| 3. 기술 스택 | 시현 | `tech_stack` |
+| 4. 멤버 기술스택 | 시현 | `member_tech_stack` |
+| 5. 팀 | 시현 | `team_profile`, `team_member`, `team_member_role`, `team_tech_stack`, `team_image` |
+| 6. 활동 기록 | 근엽 | `activity` |
 
 ---
 
@@ -86,7 +86,7 @@
 ---
 
 ## 1. 멤버 (Members)
-> **담당: domain.member**
+> **담당: 세인**
 
 ### 1-1. 내 프로필 조회
 
@@ -253,7 +253,7 @@ GET /profile/members/me/teams
 ---
 
 ## 2. 기수 (Generations)
-> **담당: domain.member**
+> **담당: 세인**
 
 ### 2-1. 기수 목록 조회
 
@@ -394,7 +394,7 @@ POST /profile/generations/{generationId}/members
 ---
 
 ## 3. 기술 스택 (Tech Stacks)
-> **담당: domain.team**
+> **담당: 시현**
 >
 > 기술 스택은 시드 데이터로 제공된다 (`tech_stack_seed.json`). 일반 사용자는 읽기만 가능하고, 관리자만 추가/수정/삭제할 수 있다.
 
@@ -478,7 +478,7 @@ DELETE /profile/tech-stacks/{techStackId}
 ---
 
 ## 4. 멤버 기술 스택 (Member Tech Stacks)
-> **담당: domain.team**
+> **담당: 시현**
 
 ### 4-1. 멤버 기술 스택 조회
 
@@ -538,7 +538,7 @@ PUT /profile/members/me/tech-stacks
 ---
 
 ## 5. 팀 (Teams)
-> **담당: domain.team**
+> **담당: 시현**
 >
 ### 5-1. 팀 목록 조회
 
@@ -845,7 +845,7 @@ DELETE /profile/teams/{teamId}/members/me
 ---
 
 ## 6. 활동 기록 (Activities)
-> **담당: domain.activity**
+> **담당: 근엽**
 >
 > 활동 기록은 blog / qna / sessionboard 도메인에서 이벤트 방식으로 자동 적재된다. 이 섹션은 **읽기 전용** API만 제공한다.
 
@@ -984,37 +984,37 @@ GET /profile/contributions/ranking
 
 ## 엔드포인트 요약
 
-| 메서드 | 경로 | 설명 | 담당 |
-|--------|------|------|------|
-| `GET` | `/profile/members/me` | 내 프로필 조회 | member |
-| `PATCH` | `/profile/members/me` | 내 프로필 수정 | member |
-| `GET` | `/profile/members/me/teams` | 내가 속한 팀 목록 | team |
-| `GET` | `/profile/members` | 멤버 목록 | member |
-| `GET` | `/profile/members/{memberId}` | 멤버 상세 | member |
-| `GET` | `/profile/generations` | 기수 목록 | member |
-| `POST` | `/profile/generations` | 기수 생성 (관리자) | member |
-| `GET` | `/profile/generations/{generationId}` | 기수 상세 | member |
-| `PATCH` | `/profile/generations/{generationId}` | 기수 수정 (관리자) | member |
-| `GET` | `/profile/generations/{generationId}/members` | 기수 멤버 목록 | member |
-| `POST` | `/profile/generations/{generationId}/members` | 기수에 멤버 등록 (관리자) | member |
-| `GET` | `/profile/tech-stacks` | 기술 스택 목록 | team |
-| `POST` | `/profile/tech-stacks` | 기술 스택 등록 (관리자) | team |
-| `PATCH` | `/profile/tech-stacks/{techStackId}` | 기술 스택 수정 (관리자) | team |
-| `DELETE` | `/profile/tech-stacks/{techStackId}` | 기술 스택 삭제 (관리자) | team |
-| `GET` | `/profile/members/{memberId}/tech-stacks` | 멤버 기술 스택 조회 | team |
-| `PUT` | `/profile/members/me/tech-stacks` | 내 기술 스택 수정 | team |
-| `GET` | `/profile/teams` | 팀 목록 | team |
-| `POST` | `/profile/teams` | 팀 생성 | team |
-| `GET` | `/profile/teams/{teamId}` | 팀 상세 | team |
-| `PATCH` | `/profile/teams/{teamId}` | 팀 정보 수정 (팀장) | team |
-| `DELETE` | `/profile/teams/{teamId}` | 팀 삭제 (팀장) | team |
-| `GET` | `/profile/teams/{teamId}/invite-code` | 초대 코드 조회 (팀장) | team |
-| `POST` | `/profile/teams/{teamId}/invite-code/regenerate` | 초대 코드 재생성 (팀장) | team |
-| `POST` | `/profile/teams/join` | 초대 코드로 팀 가입 | team |
-| `PATCH` | `/profile/teams/{teamId}/lead` | 팀장 양도 (팀장) | team |
-| `PUT` | `/profile/teams/{teamId}/members/{memberId}/roles` | 팀원 역할 수정 (팀장) | team |
-| `DELETE` | `/profile/teams/{teamId}/members/{memberId}` | 팀원 강퇴 (팀장) | team |
-| `DELETE` | `/profile/teams/{teamId}/members/me` | 팀 탈퇴 | team |
-| `GET` | `/profile/members/{memberId}/activities` | 멤버 활동 목록 | activity |
-| `GET` | `/profile/members/{memberId}/contributions` | 멤버 기여도 요약 | activity |
-| `GET` | `/profile/contributions/ranking` | 기여도 랭킹 | activity |
+| 구현 | 메서드 | 경로 | 설명 | 담당 |
+|---|--------|------|------|------|
+| [ ] | `GET` | `/profile/members/me` | 내 프로필 조회 | 세인 |
+| [ ] | `PATCH` | `/profile/members/me` | 내 프로필 수정 | 세인 |
+| [ ] | `GET` | `/profile/members/me/teams` | 내가 속한 팀 목록 | 시현 |
+| [ ] | `GET` | `/profile/members` | 멤버 목록 | 세인 |
+| [ ] | `GET` | `/profile/members/{memberId}` | 멤버 상세 | 세인 |
+| [ ] | `GET` | `/profile/generations` | 기수 목록 | 세인 |
+| [ ] | `POST` | `/profile/generations` | 기수 생성 (관리자) | 세인 |
+| [ ] | `GET` | `/profile/generations/{generationId}` | 기수 상세 | 세인 |
+| [ ] | `PATCH` | `/profile/generations/{generationId}` | 기수 수정 (관리자) | 세인 |
+| [ ] | `GET` | `/profile/generations/{generationId}/members` | 기수 멤버 목록 | 세인 |
+| [ ] | `POST` | `/profile/generations/{generationId}/members` | 기수에 멤버 등록 (관리자) | 세인 |
+| ✅ | `GET` | `/profile/tech-stacks` | 기술 스택 목록 | 시현 |
+| [ ] | `POST` | `/profile/tech-stacks` | 기술 스택 등록 (관리자) | 시현 |
+| [ ] | `PATCH` | `/profile/tech-stacks/{techStackId}` | 기술 스택 수정 (관리자) | 시현 |
+| [ ] | `DELETE` | `/profile/tech-stacks/{techStackId}` | 기술 스택 삭제 (관리자) | 시현 |
+| [ ] | `GET` | `/profile/members/{memberId}/tech-stacks` | 멤버 기술 스택 조회 | 시현 |
+| [ ] | `PUT` | `/profile/members/me/tech-stacks` | 내 기술 스택 수정 | 시현 |
+| [ ] | `GET` | `/profile/teams` | 팀 목록 | 시현 |
+| [ ] | `POST` | `/profile/teams` | 팀 생성 | 시현 |
+| [ ] | `GET` | `/profile/teams/{teamId}` | 팀 상세 | 시현 |
+| [ ] | `PATCH` | `/profile/teams/{teamId}` | 팀 정보 수정 (팀장) | 시현 |
+| [ ] | `DELETE` | `/profile/teams/{teamId}` | 팀 삭제 (팀장) | 시현 |
+| [ ] | `GET` | `/profile/teams/{teamId}/invite-code` | 초대 코드 조회 (팀장) | 시현 |
+| [ ] | `POST` | `/profile/teams/{teamId}/invite-code/regenerate` | 초대 코드 재생성 (팀장) | 시현 |
+| [ ] | `POST` | `/profile/teams/join` | 초대 코드로 팀 가입 | 시현 |
+| [ ] | `PATCH` | `/profile/teams/{teamId}/lead` | 팀장 양도 (팀장) | 시현 |
+| [ ] | `PUT` | `/profile/teams/{teamId}/members/{memberId}/roles` | 팀원 역할 수정 (팀장) | 시현 |
+| [ ] | `DELETE` | `/profile/teams/{teamId}/members/{memberId}` | 팀원 강퇴 (팀장) | 시현 |
+| [ ] | `DELETE` | `/profile/teams/{teamId}/members/me` | 팀 탈퇴 | 시현 |
+| [ ] | `GET` | `/profile/members/{memberId}/activities` | 멤버 활동 목록 | 근엽 |
+| [ ] | `GET` | `/profile/members/{memberId}/contributions` | 멤버 기여도 요약 | 근엽 |
+| [ ] | `GET` | `/profile/contributions/ranking` | 기여도 랭킹 | 근엽 |

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -1,3 +1,86 @@
 package com.study.profile.application;
 
-public class TeamService {}
+import com.study.profile.application.dto.TeamDto.TeamCreateRequest;
+import com.study.profile.application.dto.TeamDto.TeamCreateResponse;
+import com.study.profile.domain.generation.Generation;
+import com.study.profile.domain.member.Member;
+import com.study.profile.domain.team.TeamMember;
+import com.study.profile.domain.team.TeamProfile;
+import com.study.profile.domain.techstack.TechStack;
+import com.study.profile.infrastructure.GenerationRepository;
+import com.study.profile.infrastructure.MemberRepository;
+import com.study.profile.infrastructure.TeamMemberRepository;
+import com.study.profile.infrastructure.TeamRepository;
+import com.study.profile.infrastructure.TechStackRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class TeamService {
+
+  private final TeamRepository teamRepository;
+  private final TeamMemberRepository teamMemberRepository;
+  private final MemberRepository memberRepository;
+  private final GenerationRepository generationRepository;
+  private final TechStackRepository techStackRepository;
+
+  @Transactional
+  public TeamCreateResponse createTeam(TeamCreateRequest req, Long userId) {
+    // 1. 요청한 유저의 Member 조회
+    Member member =
+        memberRepository
+            .findByUserId(userId)
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "멤버를 찾을 수 없습니다."));
+
+    // 2. generationId가 있으면 Generation 조회, 없으면 null
+    Generation generation = null;
+    if (req.generationId() != null) {
+      generation =
+          generationRepository
+              .findById(req.generationId())
+              .orElseThrow(
+                  () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "기수를 찾을 수 없습니다."));
+    }
+
+    // 3. 초대 코드 생성 (UUID 앞 8자리, 대문자)
+    String inviteCode = UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase();
+    Instant inviteCodeExpiresAt = Instant.now().plus(3, ChronoUnit.DAYS);
+
+    // 4. TeamProfile 생성
+    TeamProfile team =
+        TeamProfile.create(
+            generation,
+            req.name(),
+            req.description(),
+            req.projectUrl(),
+            req.githubUrl(),
+            inviteCode,
+            inviteCodeExpiresAt);
+
+    // 5. 이미지 추가
+    team.updateImages(req.imageUrls());
+
+    // 6. 기술 스택 추가
+    if (req.techStackIds() != null && !req.techStackIds().isEmpty()) {
+      List<TechStack> techStacks = techStackRepository.findAllById(req.techStackIds());
+      team.updateTechStacks(techStacks);
+    }
+
+    teamRepository.save(team);
+
+    // 7. 팀 생성자를 팀장으로 등록 (isLead=true, status=accepted)
+    TeamMember teamMember = TeamMember.create(team, member, null, true);
+    teamMemberRepository.save(teamMember);
+
+    return new TeamCreateResponse(team.getId(), team.getInviteCode(), team.getInviteCodeExpiresAt());
+  }
+}

--- a/src/main/java/com/study/profile/application/TechStackService.java
+++ b/src/main/java/com/study/profile/application/TechStackService.java
@@ -26,8 +26,6 @@ public class TechStackService {
   public TechStackListResponse getTechStacks(String category) {
     List<TechStackResponse> list;
 
-    // 11. category 파라미터가 없으면(null 또는 빈 문자열) 전체 조회
-    //     있으면 해당 카테고리로 필터링해서 조회
     // 11. 전체 목록을 한 번에 조회한 뒤 Java에서 필터링
     //     PostgreSQL 커스텀 ENUM 타입(tech_stack_category)을 WHERE 절에 직접 쓰면
     //     타입 불일치 오류가 발생하므로 애플리케이션 레벨에서 필터링한다.

--- a/src/main/java/com/study/profile/application/dto/TeamDto.java
+++ b/src/main/java/com/study/profile/application/dto/TeamDto.java
@@ -1,3 +1,18 @@
 package com.study.profile.application.dto;
 
-public class TeamDto {}
+import java.time.Instant;
+import java.util.List;
+
+public class TeamDto {
+
+  public record TeamCreateRequest(
+      String name,
+      String description,
+      String projectUrl,
+      String githubUrl,
+      Long generationId,
+      List<String> imageUrls,
+      List<Long> techStackIds) {}
+
+  public record TeamCreateResponse(Long id, String inviteCode, Instant inviteCodeExpiresAt) {}
+}

--- a/src/main/java/com/study/profile/domain/activity/Activity.java
+++ b/src/main/java/com/study/profile/domain/activity/Activity.java
@@ -38,7 +38,6 @@ public class Activity {
   @Column(name = "type", nullable = false)
   private ActivityType type;
 
-  // 외부 BC가 관리하는 식별자 (post.id 등)
   @Column(name = "reference_id")
   private Long referenceId;
 

--- a/src/main/java/com/study/profile/domain/team/TeamMember.java
+++ b/src/main/java/com/study/profile/domain/team/TeamMember.java
@@ -16,6 +16,8 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -66,6 +68,7 @@ public class TeamMember {
   private boolean isLead = false; // 팀장 여부 (true면 팀장, false면 일반 팀원)
 
   @Enumerated(EnumType.STRING)
+  @JdbcTypeCode(SqlTypes.NAMED_ENUM)
   @Column(name = "status", nullable = false)
   private TeamMemberStatus status; // 팀원 가입 상태 (pending/accepted/rejected/left/kicked)
 

--- a/src/main/java/com/study/profile/domain/techstack/TechStack.java
+++ b/src/main/java/com/study/profile/domain/techstack/TechStack.java
@@ -46,7 +46,7 @@ public class TechStack {
   private String name; // 기술 스택 이름 (예: "Java", "React") — 중복 불가
 
   @Enumerated(EnumType.STRING)
-  @Column(name = "category", nullable = false, columnDefinition = "tech_stack_category")
+  @Column(name = "category", nullable = false)
   private TechStackCategory category; // 분류 (language/framework/ai/design/tool/infra/etc)
 
   @Column(name = "logo_url")

--- a/src/main/java/com/study/profile/infrastructure/GenerationRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/GenerationRepository.java
@@ -1,0 +1,6 @@
+package com.study.profile.infrastructure;
+
+import com.study.profile.domain.generation.Generation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GenerationRepository extends JpaRepository<Generation, Long> {}

--- a/src/main/java/com/study/profile/infrastructure/MemberRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/MemberRepository.java
@@ -1,3 +1,10 @@
 package com.study.profile.infrastructure;
 
-public interface MemberRepository {}
+import com.study.profile.domain.member.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+  Optional<Member> findByUserId(Long userId);
+}

--- a/src/main/java/com/study/profile/infrastructure/TeamMemberRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/TeamMemberRepository.java
@@ -1,0 +1,6 @@
+package com.study.profile.infrastructure;
+
+import com.study.profile.domain.team.TeamMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {}

--- a/src/main/java/com/study/profile/infrastructure/TeamRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/TeamRepository.java
@@ -1,3 +1,10 @@
 package com.study.profile.infrastructure;
 
-public interface TeamRepository {}
+import com.study.profile.domain.team.TeamProfile;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamRepository extends JpaRepository<TeamProfile, Long> {
+
+  Optional<TeamProfile> findByInviteCode(String inviteCode);
+}

--- a/src/main/java/com/study/profile/presentation/TeamController.java
+++ b/src/main/java/com/study/profile/presentation/TeamController.java
@@ -1,3 +1,31 @@
 package com.study.profile.presentation;
 
-public class TeamController {}
+import com.study.auth.infrastructure.security.CurrentUser;
+import com.study.auth.infrastructure.security.CustomUserDetails;
+import com.study.profile.application.TeamService;
+import com.study.profile.application.dto.TeamDto.TeamCreateRequest;
+import com.study.profile.application.dto.TeamDto.TeamCreateResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/profile/teams")
+@RequiredArgsConstructor
+public class TeamController {
+
+  private final TeamService teamService;
+
+  @PostMapping
+  @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
+  public ResponseEntity<TeamCreateResponse> createTeam(
+      @RequestBody TeamCreateRequest req, @CurrentUser CustomUserDetails user) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(teamService.createTeam(req, user.userId()));
+  }
+}


### PR DESCRIPTION
## 변경 사항                                                                                                                                                                                   
                                                            
  ### 1. Repository 추가                                                                                                                                                                         
  - `TeamRepository` — `findByInviteCode()` 추가
  - `TeamMemberRepository` — 신규                                                                                                                                                                
  - `MemberRepository` — `findByUserId()` 추가                                                                                                                                                   
  - `GenerationRepository` — 신규                                                                                                                                                                
                                                                                                                                                                                                 
  ### 2. `TeamDto` 작성                                     
  - `TeamCreateRequest` — name, description, projectUrl, githubUrl, generationId, imageUrls, techStackIds                                                                                        
  - `TeamCreateResponse` — id, inviteCode, inviteCodeExpiresAt                                                                                                                                   
   
  ### 3. `TeamService` 구현                                                                                                                                                                      
  1. userId → Member 조회                                   
  2. generationId → Generation 조회 (없으면 null)                                                                                                                                                
  3. 초대 코드 생성 (UUID 앞 8자리 대문자, 만료 현재 시각 + 3일)                                                                                                                                 
  4. TeamProfile 생성 + 이미지/기술스택 추가                                                                                                                                                     
  5. 팀 생성자를 팀장(`isLead=true`, `status=accepted`)으로 TeamMember 저장                                                                                                                      
                                                                                                                                                                                                 
  ### 4. `TeamController` 구현                                                                                                                                                                   
  - `POST /api/profile/teams` — 인증된 유저만 호출 가능                                                                                                                                          
                                                                                                                                                                                                 
  ### 5. PostgreSQL 커스텀 ENUM 타입 오류 수정                                                                                                                                                   
  - `TeamMember.status` 필드에 `@JdbcTypeCode(SqlTypes.NAMED_ENUM)` 적용                                                                                                                         
  - `columnDefinition`은 DDL 생성 시에만 적용되며 INSERT/WHERE 파라미터 바인딩에는 효과 없음을 확인                                                                                              
  - Hibernate 6 + PostgreSQL 커스텀 ENUM 타입 불일치 문제 해결                                                                                                                                   
                                                                                                                                                                                                 
  ## 테스트                                                                                                                                                                                      
  - `POST /api/profile/teams` 요청 후 RDS `team_profile`, `team_member` 행 직접 확인                                                                                                             
    - `team_profile` — 팀 생성, 고유 초대 코드, 만료일 3일 후 정상 저장                                                                                                                          
    - `team_member` — 생성자 `is_lead=true`, `status=accepted` 정상 저장                                                                                                                         
                                                                                                                                                                                                 
  ## 추후 할 일                                                                                                                                                                                  
  - `session_type`, `role_in_gen` 등 다른 엔티티의 PostgreSQL 커스텀 ENUM 필드에도 동일한 `@JdbcTypeCode(SqlTypes.NAMED_ENUM)` 적용 필요                                                         
  