### PR TITLE
fix: PR #52 revert 후 유효한 변경사항 재적용

### DIFF
--- a/src/main/java/com/study/auth/application/UserAdminService.java
+++ b/src/main/java/com/study/auth/application/UserAdminService.java
@@ -6,8 +6,10 @@ import com.study.auth.infrastructure.UserRepository;
 import com.study.auth.presentation.dto.UserResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @RequiredArgsConstructor
@@ -17,12 +19,19 @@ public class UserAdminService {
 
   @Transactional(readOnly = true)
   public List<UserResponse> getUsers(String status) {
-    List<User> users =
-        status != null
-            ? userRepository.findAllByStatusOrderBySignupRequestedAtDesc(
-                UserStatus.valueOf(status.toUpperCase()))
-            : userRepository.findAllByOrderBySignupRequestedAtDesc();
-    return users.stream().map(this::toResponse).toList();
+    if (status == null || status.isBlank()) {
+      return userRepository.findAllByOrderBySignupRequestedAtDesc().stream()
+          .map(this::toResponse)
+          .toList();
+    }
+    try {
+      UserStatus userStatus = UserStatus.valueOf(status.trim().toUpperCase());
+      return userRepository.findAllByStatusOrderBySignupRequestedAtDesc(userStatus).stream()
+          .map(this::toResponse)
+          .toList();
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("유효하지 않은 status 값입니다. 허용 값: PENDING, ACTIVE, REJECTED");
+    }
   }
 
   @Transactional
@@ -42,7 +51,8 @@ public class UserAdminService {
   private User findOrThrow(Long userId) {
     return userRepository
         .findById(userId)
-        .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다: " + userId));
+        .orElseThrow(
+            () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다: " + userId));
   }
 
   private UserResponse toResponse(User user) {

--- a/src/main/java/com/study/blog/application/post/PostService.java
+++ b/src/main/java/com/study/blog/application/post/PostService.java
@@ -98,7 +98,7 @@ public class PostService {
             .content(req.content())
             .board(req.board())
             .category(req.category())
-            .status(req.status())
+            .status(PostStatus.DRAFT)
             .generation(req.generation())
             .repostFromId(req.repostFromId())
             .build();
@@ -115,7 +115,7 @@ public class PostService {
       throw new BlogException(BlogErrorCode.FORBIDDEN);
     }
 
-    post.update(req.title(), req.content(), req.board(), req.category(), req.status());
+    post.update(req.title(), req.content(), req.board(), req.category(), post.getStatus());
 
     postTagRepository.deleteByPost(post);
     saveTags(post, req.tags());

--- a/src/main/java/com/study/blog/application/post/dto/PostCreateRequest.java
+++ b/src/main/java/com/study/blog/application/post/dto/PostCreateRequest.java
@@ -1,8 +1,6 @@
 package com.study.blog.application.post.dto;
 
-import com.study.blog.domain.post.PostStatus;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record PostCreateRequest(
@@ -10,7 +8,6 @@ public record PostCreateRequest(
     @NotBlank String content,
     @NotBlank String board,
     @NotBlank String category,
-    @NotNull PostStatus status,
     @NotBlank String generation,
     List<String> tags,
     Long repostFromId) {}

--- a/src/main/java/com/study/blog/application/post/dto/PostUpdateRequest.java
+++ b/src/main/java/com/study/blog/application/post/dto/PostUpdateRequest.java
@@ -1,8 +1,6 @@
 package com.study.blog.application.post.dto;
 
-import com.study.blog.domain.post.PostStatus;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record PostUpdateRequest(
@@ -10,5 +8,4 @@ public record PostUpdateRequest(
     @NotBlank String content,
     @NotBlank String board,
     @NotBlank String category,
-    @NotNull PostStatus status,
     List<String> tags) {}

--- a/src/main/java/com/study/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/study/shared/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.study.auth.domain.exception.InvalidTokenException;
 import com.study.auth.domain.exception.TokenReusedException;
 import com.study.auth.domain.exception.UserNotActiveException;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
  * <p>인증/인가 예외를 일관된 JSON 형식으로 반환한다. Spring Security의 AuthenticationEntryPoint / AccessDeniedHandler는
  * 필터 체인 레벨에서 401/403을 처리하고, 여기서는 서비스 레이어에서 발생하는 비즈니스 예외를 처리한다.
  */
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -50,7 +52,8 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(IllegalArgumentException.class)
   public ResponseEntity<Map<String, Object>> handleIllegalArgument(IllegalArgumentException e) {
-    return errorResponse(HttpStatus.BAD_REQUEST, e.getMessage());
+    log.warn("IllegalArgumentException: {}", e.getMessage(), e);
+    return errorResponse(HttpStatus.BAD_REQUEST, "요청 값이 올바르지 않습니다");
   }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/resources/db/auth-ddl.sql
+++ b/src/main/resources/db/auth-ddl.sql
@@ -8,15 +8,12 @@
 -- ------------------------------------------------------------
 -- USERS
 -- ------------------------------------------------------------
-CREATE TYPE user_role   AS ENUM ('ADMIN', 'MEMBER');
-CREATE TYPE user_status AS ENUM ('PENDING', 'ACTIVE', 'REJECTED', 'EXPIRED');
-
 CREATE TABLE users (
     id                   BIGINT      GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     login_email          TEXT        NOT NULL UNIQUE,
     password_hash        TEXT        NOT NULL,
-    role                 user_role   NOT NULL DEFAULT 'MEMBER',
-    status               user_status NOT NULL DEFAULT 'PENDING',
+    role                 VARCHAR(20) NOT NULL DEFAULT 'MEMBER',
+    status               VARCHAR(20) NOT NULL DEFAULT 'PENDING',
     signup_requested_at  TIMESTAMPTZ NOT NULL,
     approved_at          TIMESTAMPTZ,
     approved_by          BIGINT      REFERENCES users(id) ON DELETE SET NULL,
@@ -32,16 +29,14 @@ CREATE        INDEX idx_user_status      ON users(status);
 -- ------------------------------------------------------------
 -- REFRESH_TOKENS
 -- ------------------------------------------------------------
-CREATE TYPE refresh_token_status AS ENUM ('ACTIVE', 'USED', 'REVOKED');
-
 CREATE TABLE refresh_tokens (
-    id          BIGINT               GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    user_id     BIGINT               NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    token_hash  TEXT                 NOT NULL UNIQUE,
-    family_id   UUID                 NOT NULL,
-    status      refresh_token_status NOT NULL,
-    expires_at  TIMESTAMPTZ          NOT NULL,
-    created_at  TIMESTAMPTZ          NOT NULL
+    id          BIGINT      GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id     BIGINT      NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash  TEXT        NOT NULL UNIQUE,
+    family_id   UUID        NOT NULL,
+    status      VARCHAR(20) NOT NULL,
+    expires_at  TIMESTAMPTZ NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL
 );
 
 CREATE UNIQUE INDEX idx_refresh_token_hash   ON refresh_tokens(token_hash);


### PR DESCRIPTION
## 개요

PR #62에서 revert된 커밋 중 email 클레임과 무관한 유효한 변경사항을 재적용합니다.
유저 승인/반려 API는 이미 dev에 존재하므로 이 PR의 실질적인 변경은 아래 4가지입니다.

## 변경 사항

**`fix(auth)` — UserAdminService**
- `getUsers()`: 빈 문자열 입력 시 null 처리, 유효하지 않은 status 값 → 명확한 400 메시지
- `findOrThrow()`: 유저 미존재 시 `IllegalArgumentException(400)` → `ResponseStatusException(404)`

**`fix(blog)` — PostCreateRequest / PostUpdateRequest / PostService**
- 클라이언트가 status를 직접 지정하지 못하도록 `status` 필드 제거
- `createPost`: 서버에서 항상 DRAFT 고정
- `updatePost`: 기존 status 유지

**`fix(shared)` — GlobalExceptionHandler**
- `IllegalArgumentException` 응답을 일반 메시지(`"요청 값이 올바르지 않습니다"`)로 반환
- 실제 메시지는 `log.warn`으로 기록 (PR #62 revert 구간 동안 TechStack category 오류 메시지가 raw 노출됐던 것 해소)

**`chore(db)` — auth-ddl.sql**
- `users`, `refresh_tokens`의 role/status 컬럼: PostgreSQL ENUM → `VARCHAR(20)` 변경
- JPA `@Enumerated(EnumType.STRING)`과의 타입 정합성 확보

## 참고

- PR #52에서 잘못 도입된 JWT email 클레임 및 authorEmail 블로그 기능은 포함하지 않음
- PR #62 (revert) 머지 완료 후 작업

## 이후 계획

- 블로그 모듈 테스트 코드 작성 예정