### PR TITLE
 feat(profile): Activity 통합 1단계 — 이벤트 발행 요청

### DIFF
--- a/docs/db/profile/erd-cloud.sql
+++ b/docs/db/profile/erd-cloud.sql
@@ -140,13 +140,12 @@ CREATE TABLE team_image
 -- 11. 활동 점수 및 로그 테이블
 CREATE TABLE activity
 (
-    id             BIGINT   NOT NULL AUTO_INCREMENT,
-    member_id      BIGINT   NOT NULL,
-    type           ENUM ('blog_post','blog_comment','qna_answer','qna_question','qna_accepted','other') NOT NULL,
-    reference_id   BIGINT,
-    reference_type VARCHAR(255),
-    score          INT      NOT NULL DEFAULT 0,
-    created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    id           BIGINT   NOT NULL AUTO_INCREMENT,
+    member_id    BIGINT   NOT NULL,
+    type         ENUM ('blog_post','blog_comment','blog_post_like','blog_post_like_received','qna_question','qna_answer','qna_accepted','qna_comment','session_speak','session_event_post','session_event_comment','session_event_post_like','session_event_post_like_received') NOT NULL,
+    reference_id BIGINT,
+    score        INT      NOT NULL DEFAULT 0,
+    created_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (id),
     FOREIGN KEY (member_id) REFERENCES member (id) ON DELETE CASCADE
 );

--- a/docs/db/profile/migrations/2026-05-03-activity-cleanup.sql
+++ b/docs/db/profile/migrations/2026-05-03-activity-cleanup.sql
@@ -1,0 +1,51 @@
+-- Date: 2026-05-03
+-- Context: PR #2 (외부 BC 통합 이벤트 + ActivityType 13종 정리) 머지 시점에 RDS에 적용.
+--
+-- 목적:
+--   1. activity.reference_type 컬럼 제거 (PR #1 잠정 ADD COLUMN 잔존 — 본 코드엔 referenceType 필드 없음)
+--   2. activity_type ENUM 정리:
+--      - 제거: session_note
+--      - 추가: blog_post_like, blog_post_like_received, qna_comment,
+--              session_event_post_like, session_event_post_like_received
+--      - 유지: blog_post, blog_comment, qna_question, qna_answer, qna_accepted,
+--              session_speak, session_event_post, session_event_comment
+--
+-- 주의: PostgreSQL ENUM은 DROP VALUE 미지원 → 새 ENUM 만들어 swap.
+-- 운영 데이터 없는 dev RDS 전제. 데이터 있으면 step 2 전에 clean-up 필요.
+
+BEGIN;
+
+-- 1. 잠정 컬럼 제거
+ALTER TABLE activity DROP COLUMN IF EXISTS reference_type;
+
+-- 2. ENUM 교체
+-- 2-1. (옵션) 제거 대상 enum 사용 행 정리. dev 단계라 보통 0건.
+DELETE FROM activity WHERE type IN ('session_note');
+
+-- 2-2. 새 ENUM 생성 (13종 — 좋아요 누름/받음 양방향 포함)
+CREATE TYPE activity_type_new AS ENUM (
+  'blog_post',
+  'blog_comment',
+  'blog_post_like',
+  'blog_post_like_received',
+  'qna_question',
+  'qna_answer',
+  'qna_accepted',
+  'qna_comment',
+  'session_speak',
+  'session_event_post',
+  'session_event_comment',
+  'session_event_post_like',
+  'session_event_post_like_received'
+);
+
+-- 2-3. 컬럼 타입 교체
+ALTER TABLE activity
+  ALTER COLUMN type TYPE activity_type_new
+  USING type::text::activity_type_new;
+
+-- 2-4. 옛 ENUM 삭제 + rename
+DROP TYPE activity_type;
+ALTER TYPE activity_type_new RENAME TO activity_type;
+
+COMMIT;

--- a/docs/db/profile/profile-ddl.sql
+++ b/docs/db/profile/profile-ddl.sql
@@ -2,7 +2,7 @@
 CREATE TYPE session_type AS ENUM ('backend', 'frontend', 'design', 'ai', 'pm', 'etc');
 CREATE TYPE generation_role AS ENUM ('member', 'operating');
 CREATE TYPE tech_stack_category AS ENUM ('language', 'framework', 'ai', 'design', 'tool', 'infra', 'etc');
-CREATE TYPE activity_type AS ENUM ('blog_post', 'blog_comment', 'qna_answer', 'qna_question', 'qna_accepted', 'other');
+CREATE TYPE activity_type AS ENUM ('blog_post', 'blog_comment', 'blog_post_like', 'blog_post_like_received', 'qna_question', 'qna_answer', 'qna_accepted', 'qna_comment', 'session_speak', 'session_event_post', 'session_event_comment', 'session_event_post_like', 'session_event_post_like_received');
 CREATE TYPE contribution_period_type AS ENUM ('month', 'three_month', 'year', 'all');
 CREATE TYPE role_in_team AS ENUM ('backend', 'frontend', 'design', 'ai', 'pm', 'infra', 'etc');
 CREATE TYPE team_member_status AS ENUM ('pending', 'accepted', 'rejected', 'left', 'kicked');
@@ -108,11 +108,10 @@ CREATE TABLE team_image (
 );
 
 CREATE TABLE activity (
-    id             BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-    member_id      BIGINT NOT NULL REFERENCES member(id) ON DELETE CASCADE,
-    type           activity_type NOT NULL,
-    reference_id   BIGINT,
-    reference_type TEXT,
-    score          INT NOT NULL DEFAULT 0,
-    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    id           BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    member_id    BIGINT NOT NULL REFERENCES member(id) ON DELETE CASCADE,
+    type         activity_type NOT NULL,
+    reference_id BIGINT,
+    score        INT NOT NULL DEFAULT 0,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -54,8 +54,13 @@
 
 ### ActivityType
 ```
-"blog_post" | "blog_comment" | "qna_question" | "qna_answer" | "qna_accepted" | "other"
+"blog_post" | "blog_comment" | "blog_post_like" | "blog_post_like_received" |
+"qna_question" | "qna_answer" | "qna_accepted" | "qna_comment" |
+"session_speak" | "session_event_post" | "session_event_comment" |
+"session_event_post_like" | "session_event_post_like_received"
 ```
+
+> 좋아요는 양방향 — 누른 사람(`*_like`) / 받은 사람(`*_like_received`) 별도.
 
 ### ContributionPeriodType
 ```
@@ -842,18 +847,25 @@ DELETE /profile/teams/{teamId}/members/me
 ## 6. 활동 기록 (Activities)
 > **담당: domain.activity**
 >
-> 활동 기록은 blog / qna 도메인에서 이벤트 방식으로 자동 적재된다. 이 섹션은 **읽기 전용** API만 제공한다.
+> 활동 기록은 blog / qna / sessionboard 도메인에서 이벤트 방식으로 자동 적재된다. 이 섹션은 **읽기 전용** API만 제공한다.
 
 ### 점수 기준
 
 | ActivityType | 점수 |
 |---|---|
-| `blog_post` | +10 |
-| `blog_comment` | +5 |
-| `qna_question` | +5 |
-| `qna_answer` | +5 |
-| `qna_accepted` | +10 |
-| `other` | 별도 지정 |
+| `blog_post` | +30 |
+| `blog_comment` | +3 |
+| `blog_post_like` | +1 |
+| `blog_post_like_received` | +1 |
+| `qna_question` | +10 |
+| `qna_answer` | +10 |
+| `qna_accepted` | +25 |
+| `qna_comment` | +3 |
+| `session_speak` | +50 |
+| `session_event_post` | +30 |
+| `session_event_comment` | +3 |
+| `session_event_post_like` | +1 |
+| `session_event_post_like_received` | +1 |
 
 ---
 
@@ -879,8 +891,7 @@ GET /profile/members/{memberId}/activities
       "id": 1,
       "type": "blog_post",
       "referenceId": 42,
-      "referenceType": "blog_post",
-      "score": 10,
+      "score": 30,
       "createdAt": "2025-05-01T10:00:00Z"
     }
   ],
@@ -914,14 +925,21 @@ GET /profile/members/{memberId}/contributions
   "memberId": 1,
   "name": "홍길동",
   "period": "month",
-  "totalScore": 55,
+  "totalScore": 214,
   "breakdown": {
-    "blog_post": 30,
-    "blog_comment": 5,
-    "qna_question": 5,
-    "qna_answer": 5,
-    "qna_accepted": 10,
-    "other": 0
+    "blog_post": 60,
+    "blog_comment": 3,
+    "blog_post_like": 3,
+    "blog_post_like_received": 12,
+    "qna_question": 10,
+    "qna_answer": 20,
+    "qna_accepted": 50,
+    "qna_comment": 3,
+    "session_speak": 50,
+    "session_event_post": 0,
+    "session_event_comment": 3,
+    "session_event_post_like": 0,
+    "session_event_post_like_received": 0
   }
 }
 ```

--- a/src/main/java/com/study/profile/domain/activity/Activity.java
+++ b/src/main/java/com/study/profile/domain/activity/Activity.java
@@ -18,17 +18,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * 멤버 활동 이력 엔티티.
- *
- * <p>멤버가 블로그 글 작성, Q&A 답변, 세션 발표 등 활동을 할 때마다 그 기록을 이 테이블에 한 행씩 쌓는다. 각 활동에는 점수(score)가 부여되어 기여도 랭킹
- * 등에 활용된다.
- *
- * <p>[예시 데이터] member_id=1(홍길동), type=blog_post, score=10 → "홍길동이 블로그 글을 써서 10점 획득"
- * member_id=1(홍길동), type=qna_accepted, score=5 → "홍길동의 답변이 채택되어 5점 획득"
- *
- * <p>[DB 테이블: activity]
- */
+/** 멤버 활동 이력 엔티티. 각 행 단위로 점수 부여 → 기여도 랭킹 산정에 활용. */
 @Entity
 @Table(name = "activity")
 @Getter
@@ -38,50 +28,35 @@ public class Activity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "id")
-  private Long id; // DB가 자동으로 부여하는 고유 번호
+  private Long id;
 
-  // 어떤 멤버의 활동인지
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id", nullable = false)
   private Member member;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "type", nullable = false)
-  private ActivityType type; // 활동 종류 (blog_post/../other)
+  private ActivityType type;
 
-  // 이 서비스(profile 모듈)가 아닌 외부 모듈(blog, qna 등)에서 관리하는 ID이므로
+  // 외부 BC가 관리하는 식별자 (post.id 등)
   @Column(name = "reference_id")
   private Long referenceId;
 
-  // 참조 타입 이름. 어떤 종류의 콘텐츠를 가리키는지 구분하는 문자열.
-  // 예) "blog_post", "qna_answer" — referenceId와 함께 "어디서 온 ID인지" 맥락을 제공한다.
-  @Column(name = "reference_type")
-  private String referenceType;
-
   @Column(name = "score", nullable = false)
-  private Integer score = 0; // 이 활동으로 얻은 점수 (기본값 0)
+  private Integer score = 0;
 
   @Column(name = "created_at", nullable = false, updatable = false)
-  private Instant createdAt; // 활동이 기록된 시각
+  private Instant createdAt;
 
-  /**
-   * 새 활동 기록을 생성할 때 사용하는 정적 팩토리 메서드.
-   *
-   * <p>예) Activity.create(홍길동, ActivityType.blog_post, 글UUID, "blog_post", 10) → "홍길동이 해당 블로그 글을
-   * 작성해 10점 획득"을 기록
-   */
-  public static Activity create(
-      Member member, ActivityType type, Long referenceId, String referenceType, int score) {
+  public static Activity create(Member member, ActivityType type, Long referenceId, int score) {
     Activity activity = new Activity();
     activity.member = member;
     activity.type = type;
     activity.referenceId = referenceId;
-    activity.referenceType = referenceType;
     activity.score = score;
     return activity;
   }
 
-  /** DB 저장 직전에 JPA가 자동으로 현재 시각을 createdAt에 넣어준다. */
   @PrePersist
   void prePersist() {
     this.createdAt = Instant.now();

--- a/src/main/java/com/study/profile/domain/activity/ActivityType.java
+++ b/src/main/java/com/study/profile/domain/activity/ActivityType.java
@@ -1,16 +1,22 @@
 package com.study.profile.domain.activity;
 
 /**
- * 활동마다 점수(score)가 다르게 부여된다.
+ * 활동 종류. 점수 매핑은 ActivityRecorder.scoreOf 참조.
  *
- * <p>blog_post : 블로그 글 작성 +10 blog_comment : 블로그 글 댓글 작성 +5 qna_question : Q&A 질문 등록 +5 qna_answer
- * : Q&A 질문에 답변 작성 +5 qna_accepted : 작성한 답변이 채택됨 (추가 점수 부여) +10 other : 기타 활동
+ * 좋아요는 양방향 — 누른 사람({@code *_like})·받은 사람({@code *_like_received}) 별도 type.
  */
 public enum ActivityType {
   blog_post,
   blog_comment,
+  blog_post_like,
+  blog_post_like_received,
   qna_question,
   qna_answer,
   qna_accepted,
-  other
+  qna_comment,
+  session_speak,
+  session_event_post,
+  session_event_comment,
+  session_event_post_like,
+  session_event_post_like_received
 }

--- a/src/main/java/com/study/profile/infrastructure/ActivityRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/ActivityRepository.java
@@ -1,3 +1,7 @@
 package com.study.profile.infrastructure;
 
-public interface ActivityRepository {}
+import com.study.profile.domain.activity.Activity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Activity 엔티티 Repository — 활동 이력 저장. */
+public interface ActivityRepository extends JpaRepository<Activity, Long> {}

--- a/src/main/java/com/study/shared/config/AsyncConfig.java
+++ b/src/main/java/com/study/shared/config/AsyncConfig.java
@@ -1,0 +1,38 @@
+package com.study.shared.config;
+
+import java.util.Arrays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+/**
+ * {@code @Async} 활성화 + 미잡힌 예외 처리.
+ *
+ * <p>현재 사용처: {@code ActivityEventListener} — 외부 BC 통합 이벤트 후처리.
+ *
+ * <p>{@code TaskExecutor}는 Spring Boot 자동 구성 사용. 트래픽·튜닝 필요 시점에 명시 빈 추가.
+ *
+ * <p>uncaught handler: async listener에서 throw된 예외는 호출자에 전파되지 않으므로 여기서 ERROR 로그로 잡는다. ADR 0003
+ * §처리 실패 시 복구 전략의 "단순 throw + ERROR 로그 + alert"의 로그 부분.
+ */
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+  private static final Logger log = LoggerFactory.getLogger(AsyncConfig.class);
+
+  @Override
+  public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+    return (ex, method, params) ->
+        log.error(
+            "Async listener 실패: {}.{} params={} message={}",
+            method.getDeclaringClass().getSimpleName(),
+            method.getName(),
+            Arrays.toString(params),
+            ex.getMessage(),
+            ex);
+  }
+}

--- a/src/main/java/com/study/shared/extevent/blog/BlogCommentCreated.java
+++ b/src/main/java/com/study/shared/extevent/blog/BlogCommentCreated.java
@@ -1,0 +1,9 @@
+package com.study.shared.extevent.blog;
+
+/**
+ * 블로그 댓글 작성 사건.
+ *
+ * @param userId 작성자 (auth.User.id)
+ * @param commentId 작성된 댓글
+ */
+public record BlogCommentCreated(Long userId, Long commentId) {}

--- a/src/main/java/com/study/shared/extevent/blog/BlogCommentDeleted.java
+++ b/src/main/java/com/study/shared/extevent/blog/BlogCommentDeleted.java
@@ -1,0 +1,9 @@
+package com.study.shared.extevent.blog;
+
+/**
+ * 블로그 댓글 삭제 사건.
+ *
+ * @param userId 작성자 (auth.User.id)
+ * @param commentId 삭제된 댓글
+ */
+public record BlogCommentDeleted(Long userId, Long commentId) {}

--- a/src/main/java/com/study/shared/extevent/blog/BlogPostCreated.java
+++ b/src/main/java/com/study/shared/extevent/blog/BlogPostCreated.java
@@ -1,11 +1,9 @@
 package com.study.shared.extevent.blog;
 
 /**
- * 블로그 글이 발행됐다는 도메인 사실.
+ * 블로그 글 발행 사건.
  *
- * <p>blog 모듈이 글 저장 직후 발행. profile 모듈이 받아 활동 이력·점수에 반영.
- *
- * @param userId 글 작성자 (auth.User.id — 모든 BC 공유 키)
- * @param postId 작성된 글의 식별자 (활동 카드 클릭 시 라우팅용)
+ * @param userId 작성자 (auth.User.id)
+ * @param postId 발행된 글
  */
 public record BlogPostCreated(Long userId, Long postId) {}

--- a/src/main/java/com/study/shared/extevent/blog/BlogPostCreated.java
+++ b/src/main/java/com/study/shared/extevent/blog/BlogPostCreated.java
@@ -1,0 +1,11 @@
+package com.study.shared.extevent.blog;
+
+/**
+ * 블로그 글이 발행됐다는 도메인 사실.
+ *
+ * <p>blog 모듈이 글 저장 직후 발행. profile 모듈이 받아 활동 이력·점수에 반영.
+ *
+ * @param userId 글 작성자 (auth.User.id — 모든 BC 공유 키)
+ * @param postId 작성된 글의 식별자 (활동 카드 클릭 시 라우팅용)
+ */
+public record BlogPostCreated(Long userId, Long postId) {}

--- a/src/main/java/com/study/shared/extevent/blog/BlogPostDeleted.java
+++ b/src/main/java/com/study/shared/extevent/blog/BlogPostDeleted.java
@@ -1,0 +1,9 @@
+package com.study.shared.extevent.blog;
+
+/**
+ * 블로그 글 삭제 사건.
+ *
+ * @param userId 작성자 (auth.User.id)
+ * @param postId 삭제된 글
+ */
+public record BlogPostDeleted(Long userId, Long postId) {}

--- a/src/main/java/com/study/shared/extevent/blog/BlogPostLiked.java
+++ b/src/main/java/com/study/shared/extevent/blog/BlogPostLiked.java
@@ -1,0 +1,10 @@
+package com.study.shared.extevent.blog;
+
+/**
+ * 블로그 글 좋아요 사건. 양방향 — 누른 사람·받은 사람 양쪽 식별.
+ *
+ * @param likerId 좋아요 누른 사람 (auth.User.id)
+ * @param postId 글
+ * @param postOwnerId 글 작성자 (auth.User.id)
+ */
+public record BlogPostLiked(Long likerId, Long postId, Long postOwnerId) {}

--- a/src/main/java/com/study/shared/extevent/blog/BlogPostUnliked.java
+++ b/src/main/java/com/study/shared/extevent/blog/BlogPostUnliked.java
@@ -1,0 +1,10 @@
+package com.study.shared.extevent.blog;
+
+/**
+ * 블로그 글 좋아요 취소 사건. 양방향.
+ *
+ * @param likerId 좋아요 취소한 사람 (auth.User.id)
+ * @param postId 글
+ * @param postOwnerId 글 작성자 (auth.User.id)
+ */
+public record BlogPostUnliked(Long likerId, Long postId, Long postOwnerId) {}

--- a/src/main/java/com/study/shared/extevent/blog/README.md
+++ b/src/main/java/com/study/shared/extevent/blog/README.md
@@ -1,7 +1,14 @@
 # blog 통합 이벤트
 
-| 이벤트 | consumer | publish 위치 |
+블로그 BC가 발행하는 도메인 사건 record.
+
+| record | 발행 시점 | 시그니처 |
 |---|---|---|
-| `BlogPostCreated` | profile · `ActivityEventListener` | `PostService.createPost` (글 작성 시) |
+| `BlogPostCreated` | 글 저장 직후 | `(userId, postId)` |
+| `BlogPostDeleted` | 글 삭제 직후 | `(userId, postId)` |
+| `BlogCommentCreated` | 댓글 저장 직후 | `(userId, commentId)` |
+| `BlogCommentDeleted` | 댓글 삭제 직후 | `(userId, commentId)` |
+| `BlogPostLiked` | 좋아요 켜질 때 | `(likerId, postId, postOwnerId)` |
+| `BlogPostUnliked` | 좋아요 꺼질 때 | `(likerId, postId, postOwnerId)` |
 
 작성 규칙: [docs/conventions/통합-이벤트.md](../../../../../../../../docs/conventions/통합-이벤트.md)

--- a/src/main/java/com/study/shared/extevent/blog/README.md
+++ b/src/main/java/com/study/shared/extevent/blog/README.md
@@ -2,6 +2,6 @@
 
 | 이벤트 | consumer | publish 위치 |
 |---|---|---|
-| _(없음)_ | | |
+| `BlogPostCreated` | profile · `ActivityEventListener` | `PostService.createPost` (글 작성 시) |
 
 작성 규칙: [docs/conventions/통합-이벤트.md](../../../../../../../../docs/conventions/통합-이벤트.md)

--- a/src/main/java/com/study/shared/extevent/profile/README.md
+++ b/src/main/java/com/study/shared/extevent/profile/README.md
@@ -1,7 +1,9 @@
 # profile 통합 이벤트
 
-| 이벤트 | consumer | publish 위치 |
-|---|---|---|
-| _(없음)_ | | |
+profile BC가 발행하는 도메인 사건 record 자리.
+
+| record | 발행 시점 |
+|---|---|
+| _(없음)_ | 현재 발행 이벤트 없음 |
 
 작성 규칙: [docs/conventions/통합-이벤트.md](../../../../../../../../docs/conventions/통합-이벤트.md)

--- a/src/main/java/com/study/shared/extevent/qna/QnaAnswerAccepted.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaAnswerAccepted.java
@@ -1,11 +1,9 @@
 package com.study.shared.extevent.qna;
 
 /**
- * QnA 답변이 채택됐다는 도메인 사실.
+ * QnA 답변 채택 사건. userId는 채택된 답변 작성자 (점수 받는 사람).
  *
- * <p>주의: {@code userId}는 <b>채택된 답변의 작성자</b> (점수 받는 사람) — 채택을 누른 질문자가 아님.
- *
- * @param userId 채택된 답변의 작성자 (auth.User.id)
- * @param answerId 채택된 답변의 식별자
+ * @param userId 답변 작성자 (auth.User.id)
+ * @param answerId 채택된 답변
  */
 public record QnaAnswerAccepted(Long userId, Long answerId) {}

--- a/src/main/java/com/study/shared/extevent/qna/QnaAnswerAccepted.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaAnswerAccepted.java
@@ -1,0 +1,11 @@
+package com.study.shared.extevent.qna;
+
+/**
+ * QnA 답변이 채택됐다는 도메인 사실.
+ *
+ * <p>주의: {@code userId}는 <b>채택된 답변의 작성자</b> (점수 받는 사람) — 채택을 누른 질문자가 아님.
+ *
+ * @param userId 채택된 답변의 작성자 (auth.User.id)
+ * @param answerId 채택된 답변의 식별자
+ */
+public record QnaAnswerAccepted(Long userId, Long answerId) {}

--- a/src/main/java/com/study/shared/extevent/qna/QnaAnswerCreated.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaAnswerCreated.java
@@ -1,0 +1,9 @@
+package com.study.shared.extevent.qna;
+
+/**
+ * QnA 답변이 작성됐다는 도메인 사실.
+ *
+ * @param userId 답변 작성자 (auth.User.id)
+ * @param answerId 작성된 답변의 식별자
+ */
+public record QnaAnswerCreated(Long userId, Long answerId) {}

--- a/src/main/java/com/study/shared/extevent/qna/QnaAnswerCreated.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaAnswerCreated.java
@@ -1,9 +1,9 @@
 package com.study.shared.extevent.qna;
 
 /**
- * QnA 답변이 작성됐다는 도메인 사실.
+ * QnA 답변 작성 사건.
  *
- * @param userId 답변 작성자 (auth.User.id)
- * @param answerId 작성된 답변의 식별자
+ * @param userId 작성자 (auth.User.id)
+ * @param answerId 작성된 답변
  */
 public record QnaAnswerCreated(Long userId, Long answerId) {}

--- a/src/main/java/com/study/shared/extevent/qna/QnaAnswerDeleted.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaAnswerDeleted.java
@@ -1,0 +1,9 @@
+package com.study.shared.extevent.qna;
+
+/**
+ * QnA 답변 삭제 사건.
+ *
+ * @param userId 작성자 (auth.User.id)
+ * @param answerId 삭제된 답변
+ */
+public record QnaAnswerDeleted(Long userId, Long answerId) {}

--- a/src/main/java/com/study/shared/extevent/qna/QnaAnswerUnaccepted.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaAnswerUnaccepted.java
@@ -1,0 +1,9 @@
+package com.study.shared.extevent.qna;
+
+/**
+ * QnA 답변 채택 취소 사건. userId는 답변 작성자 (점수 회수되는 사람).
+ *
+ * @param userId 답변 작성자 (auth.User.id)
+ * @param answerId 채택 취소된 답변
+ */
+public record QnaAnswerUnaccepted(Long userId, Long answerId) {}

--- a/src/main/java/com/study/shared/extevent/qna/QnaCommentCreated.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaCommentCreated.java
@@ -1,0 +1,9 @@
+package com.study.shared.extevent.qna;
+
+/**
+ * QnA 댓글 작성 사건.
+ *
+ * @param userId 작성자 (auth.User.id)
+ * @param commentId 작성된 댓글
+ */
+public record QnaCommentCreated(Long userId, Long commentId) {}

--- a/src/main/java/com/study/shared/extevent/qna/QnaCommentDeleted.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaCommentDeleted.java
@@ -1,0 +1,9 @@
+package com.study.shared.extevent.qna;
+
+/**
+ * QnA 댓글 삭제 사건.
+ *
+ * @param userId 작성자 (auth.User.id)
+ * @param commentId 삭제된 댓글
+ */
+public record QnaCommentDeleted(Long userId, Long commentId) {}

--- a/src/main/java/com/study/shared/extevent/qna/QnaQuestionCreated.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaQuestionCreated.java
@@ -1,0 +1,9 @@
+package com.study.shared.extevent.qna;
+
+/**
+ * QnA 질문이 등록됐다는 도메인 사실.
+ *
+ * @param userId 질문자 (auth.User.id)
+ * @param questionId 등록된 질문의 식별자
+ */
+public record QnaQuestionCreated(Long userId, Long questionId) {}

--- a/src/main/java/com/study/shared/extevent/qna/QnaQuestionCreated.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaQuestionCreated.java
@@ -1,9 +1,9 @@
 package com.study.shared.extevent.qna;
 
 /**
- * QnA 질문이 등록됐다는 도메인 사실.
+ * QnA 질문 등록 사건.
  *
- * @param userId 질문자 (auth.User.id)
- * @param questionId 등록된 질문의 식별자
+ * @param userId 작성자 (auth.User.id)
+ * @param questionId 등록된 질문
  */
 public record QnaQuestionCreated(Long userId, Long questionId) {}

--- a/src/main/java/com/study/shared/extevent/qna/QnaQuestionDeleted.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaQuestionDeleted.java
@@ -1,0 +1,9 @@
+package com.study.shared.extevent.qna;
+
+/**
+ * QnA 질문 삭제 사건.
+ *
+ * @param userId 작성자 (auth.User.id)
+ * @param questionId 삭제된 질문
+ */
+public record QnaQuestionDeleted(Long userId, Long questionId) {}

--- a/src/main/java/com/study/shared/extevent/qna/README.md
+++ b/src/main/java/com/study/shared/extevent/qna/README.md
@@ -1,9 +1,16 @@
 # qna 통합 이벤트
 
-| 이벤트 | consumer | publish 위치 |
+QnA BC가 발행하는 도메인 사건 record.
+
+| record | 발행 시점 | 시그니처 |
 |---|---|---|
-| `QnaQuestionCreated` | profile · `ActivityEventListener` | 질문 작성 시 |
-| `QnaAnswerCreated` | profile · `ActivityEventListener` | 답변 작성 시 |
-| `QnaAnswerAccepted` | profile · `ActivityEventListener` | 답변 채택 시 (채택된 답변 작성자가 점수 받음) |
+| `QnaQuestionCreated` | 질문 저장 직후 | `(userId, questionId)` |
+| `QnaQuestionDeleted` | 질문 삭제 직후 | `(userId, questionId)` |
+| `QnaAnswerCreated` | 답변 저장 직후 | `(userId, answerId)` |
+| `QnaAnswerDeleted` | 답변 삭제 직후 | `(userId, answerId)` |
+| `QnaAnswerAccepted` | 답변 채택 시 | `(userId, answerId)` ※ userId = 답변 작성자 |
+| `QnaAnswerUnaccepted` | 채택 취소 시 | `(userId, answerId)` ※ userId = 답변 작성자 |
+| `QnaCommentCreated` | 댓글 저장 직후 | `(userId, commentId)` |
+| `QnaCommentDeleted` | 댓글 삭제 직후 | `(userId, commentId)` |
 
 작성 규칙: [docs/conventions/통합-이벤트.md](../../../../../../../../docs/conventions/통합-이벤트.md)

--- a/src/main/java/com/study/shared/extevent/qna/README.md
+++ b/src/main/java/com/study/shared/extevent/qna/README.md
@@ -2,6 +2,8 @@
 
 | 이벤트 | consumer | publish 위치 |
 |---|---|---|
-| _(없음)_ | | |
+| `QnaQuestionCreated` | profile · `ActivityEventListener` | 질문 작성 시 |
+| `QnaAnswerCreated` | profile · `ActivityEventListener` | 답변 작성 시 |
+| `QnaAnswerAccepted` | profile · `ActivityEventListener` | 답변 채택 시 (채택된 답변 작성자가 점수 받음) |
 
 작성 규칙: [docs/conventions/통합-이벤트.md](../../../../../../../../docs/conventions/통합-이벤트.md)

--- a/src/main/java/com/study/shared/extevent/sessionboard/README.md
+++ b/src/main/java/com/study/shared/extevent/sessionboard/README.md
@@ -1,8 +1,16 @@
 # sessionboard 통합 이벤트
 
-| 이벤트 | consumer | publish 위치 |
+sessionboard BC가 발행하는 도메인 사건 record.
+
+| record | 발행 시점 | 시그니처 |
 |---|---|---|
-| `SessionEventPostCreated` | profile · `ActivityEventListener` | 행사 게시글 작성 시 (`EventPost` 엔티티 생성 시점) |
-| `SessionSpeakerRegistered` | profile · `ActivityEventListener` | 발표자 등록 시 (`SessionSpeaker` 엔티티 생성 시점) |
+| `SessionEventPostCreated` | EventPost 저장 직후 | `(userId, postId)` |
+| `SessionEventPostDeleted` | EventPost 삭제 직후 | `(userId, postId)` |
+| `SessionEventCommentCreated` | EventPostComment 저장 직후 | `(userId, commentId)` |
+| `SessionEventCommentDeleted` | EventPostComment 삭제 직후 | `(userId, commentId)` |
+| `SessionEventPostLiked` | 좋아요 켜질 때 | `(likerId, postId, postOwnerId)` |
+| `SessionEventPostUnliked` | 좋아요 꺼질 때 | `(likerId, postId, postOwnerId)` |
+| `SessionSpeakerRegistered` | 발표자 등록 시 | `(userId, sessionId)` |
+| `SessionSpeakerUnregistered` | 발표자 등록 취소 시 | `(userId, sessionId)` |
 
 작성 규칙: [docs/conventions/통합-이벤트.md](../../../../../../../../docs/conventions/통합-이벤트.md)

--- a/src/main/java/com/study/shared/extevent/sessionboard/README.md
+++ b/src/main/java/com/study/shared/extevent/sessionboard/README.md
@@ -2,6 +2,7 @@
 
 | 이벤트 | consumer | publish 위치 |
 |---|---|---|
-| _(없음)_ | | |
+| `SessionEventPostCreated` | profile · `ActivityEventListener` | 행사 게시글 작성 시 (`EventPost` 엔티티 생성 시점) |
+| `SessionSpeakerRegistered` | profile · `ActivityEventListener` | 발표자 등록 시 (`SessionSpeaker` 엔티티 생성 시점) |
 
 작성 규칙: [docs/conventions/통합-이벤트.md](../../../../../../../../docs/conventions/통합-이벤트.md)

--- a/src/main/java/com/study/shared/extevent/sessionboard/SessionEventCommentCreated.java
+++ b/src/main/java/com/study/shared/extevent/sessionboard/SessionEventCommentCreated.java
@@ -1,0 +1,9 @@
+package com.study.shared.extevent.sessionboard;
+
+/**
+ * 행사 게시글 댓글 작성 사건.
+ *
+ * @param userId 작성자 (auth.User.id)
+ * @param commentId 작성된 댓글
+ */
+public record SessionEventCommentCreated(Long userId, Long commentId) {}

--- a/src/main/java/com/study/shared/extevent/sessionboard/SessionEventCommentDeleted.java
+++ b/src/main/java/com/study/shared/extevent/sessionboard/SessionEventCommentDeleted.java
@@ -1,0 +1,9 @@
+package com.study.shared.extevent.sessionboard;
+
+/**
+ * 행사 게시글 댓글 삭제 사건.
+ *
+ * @param userId 작성자 (auth.User.id)
+ * @param commentId 삭제된 댓글
+ */
+public record SessionEventCommentDeleted(Long userId, Long commentId) {}

--- a/src/main/java/com/study/shared/extevent/sessionboard/SessionEventPostCreated.java
+++ b/src/main/java/com/study/shared/extevent/sessionboard/SessionEventPostCreated.java
@@ -1,14 +1,9 @@
 package com.study.shared.extevent.sessionboard;
 
 /**
- * sessionboard의 행사 게시글이 작성됐다는 도메인 사실.
+ * 행사 게시글 작성 사건. EventPost 작성 시점.
  *
- * <p>발행자는 sessionboard 모듈 — {@code EventPost} 엔티티 작성 시점 (해커톤 후기 등).
- *
- * <p>주의: 여기 "Event"는 sessionboard 도메인 용어 (행사). Spring/integration event와 별개. 클래스명에 {@code Session}
- * prefix를 붙여 use-site 모호성 방지 (enum {@code session_event_post}와 일관).
- *
- * @param userId 게시글 작성자 (auth.User.id)
- * @param postId 작성된 게시글 ID
+ * @param userId 작성자 (auth.User.id)
+ * @param postId 작성된 게시글
  */
 public record SessionEventPostCreated(Long userId, Long postId) {}

--- a/src/main/java/com/study/shared/extevent/sessionboard/SessionEventPostCreated.java
+++ b/src/main/java/com/study/shared/extevent/sessionboard/SessionEventPostCreated.java
@@ -1,0 +1,14 @@
+package com.study.shared.extevent.sessionboard;
+
+/**
+ * sessionboard의 행사 게시글이 작성됐다는 도메인 사실.
+ *
+ * <p>발행자는 sessionboard 모듈 — {@code EventPost} 엔티티 작성 시점 (해커톤 후기 등).
+ *
+ * <p>주의: 여기 "Event"는 sessionboard 도메인 용어 (행사). Spring/integration event와 별개. 클래스명에 {@code Session}
+ * prefix를 붙여 use-site 모호성 방지 (enum {@code session_event_post}와 일관).
+ *
+ * @param userId 게시글 작성자 (auth.User.id)
+ * @param postId 작성된 게시글 ID
+ */
+public record SessionEventPostCreated(Long userId, Long postId) {}

--- a/src/main/java/com/study/shared/extevent/sessionboard/SessionEventPostDeleted.java
+++ b/src/main/java/com/study/shared/extevent/sessionboard/SessionEventPostDeleted.java
@@ -1,0 +1,9 @@
+package com.study.shared.extevent.sessionboard;
+
+/**
+ * 행사 게시글 삭제 사건.
+ *
+ * @param userId 작성자 (auth.User.id)
+ * @param postId 삭제된 게시글
+ */
+public record SessionEventPostDeleted(Long userId, Long postId) {}

--- a/src/main/java/com/study/shared/extevent/sessionboard/SessionEventPostLiked.java
+++ b/src/main/java/com/study/shared/extevent/sessionboard/SessionEventPostLiked.java
@@ -1,0 +1,10 @@
+package com.study.shared.extevent.sessionboard;
+
+/**
+ * 행사 게시글 좋아요 사건. 양방향 — 누른 사람·받은 사람 양쪽 식별.
+ *
+ * @param likerId 좋아요 누른 사람 (auth.User.id)
+ * @param postId 게시글
+ * @param postOwnerId 게시글 작성자 (auth.User.id)
+ */
+public record SessionEventPostLiked(Long likerId, Long postId, Long postOwnerId) {}

--- a/src/main/java/com/study/shared/extevent/sessionboard/SessionEventPostUnliked.java
+++ b/src/main/java/com/study/shared/extevent/sessionboard/SessionEventPostUnliked.java
@@ -1,0 +1,10 @@
+package com.study.shared.extevent.sessionboard;
+
+/**
+ * 행사 게시글 좋아요 취소 사건. 양방향.
+ *
+ * @param likerId 좋아요 취소한 사람 (auth.User.id)
+ * @param postId 게시글
+ * @param postOwnerId 게시글 작성자 (auth.User.id)
+ */
+public record SessionEventPostUnliked(Long likerId, Long postId, Long postOwnerId) {}

--- a/src/main/java/com/study/shared/extevent/sessionboard/SessionSpeakerRegistered.java
+++ b/src/main/java/com/study/shared/extevent/sessionboard/SessionSpeakerRegistered.java
@@ -1,0 +1,11 @@
+package com.study.shared.extevent.sessionboard;
+
+/**
+ * 세션 발표자가 등록됐다는 도메인 사실.
+ *
+ * <p>발행자는 sessionboard 모듈 — {@code SessionSpeaker} 엔티티 등록 시점.
+ *
+ * @param userId 발표자 (auth.User.id)
+ * @param sessionId 발표 대상 세션 ID
+ */
+public record SessionSpeakerRegistered(Long userId, Long sessionId) {}

--- a/src/main/java/com/study/shared/extevent/sessionboard/SessionSpeakerUnregistered.java
+++ b/src/main/java/com/study/shared/extevent/sessionboard/SessionSpeakerUnregistered.java
@@ -1,9 +1,9 @@
 package com.study.shared.extevent.sessionboard;
 
 /**
- * 세션 발표자 등록 사건.
+ * 세션 발표자 등록 취소 사건.
  *
  * @param userId 발표자 (auth.User.id)
  * @param sessionId 세션
  */
-public record SessionSpeakerRegistered(Long userId, Long sessionId) {}
+public record SessionSpeakerUnregistered(Long userId, Long sessionId) {}


### PR DESCRIPTION
활동 통합 1단계 PR 리뷰 요청드립니다!

외부 BC(blog / qna / sessionboard) 도메인 사건을 받을 수 있는 record / 인프라 정의를 담았습니다. 
머지 이후 각 팀에서 코드를 추가해 구현하시면 됩니다!

실제 listener (`ActivityRecorder` / `ActivityEventListener`)는 Member 인프라 머지 후 후속 PR로 진행할 예정입니다.

---

## 변경 사항

- `shared/extevent/<bc>/` 아래 통합 이벤트 record 22개 신규
- `ActivityType` 13종 정의
- Activity 도메인 인프라 (엔티티, enum, ActivityRepository)
- DDL / migration 갱신 + dev RDS 반영 완료

---

## 점수 정책

| ActivityType | 점수 |
|---|---|
| `blog_post` | +30 |
| `blog_comment` | +3 |
| `blog_post_like` | +1 |
| `blog_post_like_received` | +1 |
| `qna_question` | +10 |
| `qna_answer` | +10 |
| `qna_accepted` | +25 |
| `qna_comment` | +3 |
| `session_speak` | +50 |
| `session_event_post` | +30 |
| `session_event_comment` | +3 |
| `session_event_post_like` | +1 |
| `session_event_post_like_received` | +1 |



---

## 팀별 발행 요청 사항

자세한 시그니처는  `shared/extevent/<bc>` 참조 부탁드립니다.

### blog 팀

| 이벤트 | 발행 시점 |
|---|---|
| `BlogPostCreated` | 글 저장 직후 |
| `BlogPostDeleted` | 글 삭제 직후 |
| `BlogCommentCreated` | 댓글 저장 직후 |
| `BlogCommentDeleted` | 댓글 삭제 직후 |
| `BlogPostLiked` | 좋아요 켜질 때 |
| `BlogPostUnliked` | 좋아요 꺼질 때 |

### qna 팀

| 이벤트 | 발행 시점 |
|---|---|
| `QnaQuestionCreated` | 질문 저장 직후 |
| `QnaQuestionDeleted` | 질문 삭제 직후 |
| `QnaAnswerCreated` | 답변 저장 직후 |
| `QnaAnswerDeleted` | 답변 삭제 직후 |
| `QnaAnswerAccepted` | 채택 시  |
| `QnaAnswerUnaccepted` | 채택 취소 시 |
| `QnaCommentCreated` | 댓글 저장 직후 |
| `QnaCommentDeleted` | 댓글 삭제 직후 |

### sessionboard 팀

| 이벤트 | 발행 시점 |
|---|---|
| `SessionEventPostCreated` | EventPost 저장 직후 |
| `SessionEventPostDeleted` | EventPost 삭제 직후 |
| `SessionEventCommentCreated` | EventPostComment 저장 직후 |
| `SessionEventCommentDeleted` | EventPostComment 삭제 직후 |
| `SessionEventPostLiked` | 좋아요 켜질 때 |
| `SessionEventPostUnliked` | 좋아요 꺼질 때 |
| `SessionSpeakerRegistered` | 발표자 등록 시 |
| `SessionSpeakerUnregistered` | 발표자 등록 취소 시 |

---

## ⚠️ 삭제 시 문제점 — Service cascade 구현 부탁드립니다

### 예시 시나리오

> 근엽이가 우진이의 블로그 글에 댓글을 답니다.
> → 근엽's 활동 기록 (`blog_comment` +3점)
>
> 우진이가 글을 삭제합니다.
> → DB CASCADE로 댓글 행도 자동 삭제됨 
> → `BlogCommentDeleted` 이벤트는 발행 안 됨 
> →  근엽이의 기여도 점수에 "사라진 댓글의 +3점"이 남아있음

**문제**: DB CASCADE는 DB 행만 정리하고 이벤트 발행은 못 합니다. 즉 자식 `Deleted` 이벤트가 발행되지 않아 활동 통합 입장에서 활동 회수가 누락됩니다.

**해결**: DB CASCADE는 안전망으로 그대로 두고, Service 레벨에서 자식 삭제 메서드 명시 호출 + 자식 `Deleted` 이벤트 발행 부탁드립니다.

> 중복 delete 우려는 없습니다. Service에서 자식 먼저 삭제하면 부모 삭제 시 DB CASCADE는 0 rows로 안전합니다.



---

## 리스너 없을 때 이벤트 발행?

listener가 등록되어 있지 않으면 이벤트는 즉시 사라지며, publisher 측 코드는 영향을 받지 않습니다 (`publishEvent()` 호출은 항상 성공 리턴).

본 PR은 record / 인프라 정의 단계로 listener는 후속 PR(`ActivityEventListener`)에서 도입됩니다. 
본 PR 머지 ~ 2단계 PR 사이 이벤트는 처리되지 않습니다.




---

## 후속 PR 계획

| 단계 | 내용 | 시점 |
|---|---|---|
| 2단계 | `ActivityRecorder` + `ActivityEventListener` (이벤트 listen + 활동 저장) | Member 인프라 머지 후 |
| 3단계 | 활동 read-side API (목록 / 기여도 / 랭킹) | 2단계 머지 후 |

---

## Test plan

- [x] 빌드 통과 (CI)
- [x] 팀별 이벤트 발행 승인
- [x] Service cascade 패턴 승인


---

검토 부탁드립니다. 의견 있으시면 코멘트 주세요. 부담스러운 부분은 다시 합의해도 됩니다!
