### PR TITLE
🐛 fix(profile): enum 관련 오류 수정 / generation number를 pk로 변경

### DIFF
--- a/docs/db/profile/erd-cloud.sql
+++ b/docs/db/profile/erd-cloud.sql
@@ -20,14 +20,13 @@ CREATE TABLE member
 -- 2. 기수 테이블
 CREATE TABLE generation
 (
-    id         BIGINT       NOT NULL AUTO_INCREMENT,
+    number     INT          NOT NULL,
     label      VARCHAR(255) NOT NULL,
-    number     INT          NOT NULL UNIQUE,
     start_date DATE         NOT NULL,
     end_date   DATE,
     is_current BOOLEAN      NOT NULL DEFAULT FALSE,
     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (id)
+    PRIMARY KEY (number)
 );
 
 -- generation.is_current는 PostgreSQL의 partial unique index로 1개만 TRUE 보장
@@ -36,15 +35,15 @@ CREATE TABLE generation
 -- 3. 멤버-기수 연결 테이블
 CREATE TABLE member_generation
 (
-    id            BIGINT   NOT NULL AUTO_INCREMENT,
-    member_id     BIGINT   NOT NULL,
-    generation_id BIGINT   NOT NULL,
-    role_in_gen   ENUM ('member','operating') NOT NULL DEFAULT 'member',
-    joined_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    id                BIGINT   NOT NULL AUTO_INCREMENT,
+    member_id         BIGINT   NOT NULL,
+    generation_number INT      NOT NULL,
+    role_in_gen       ENUM ('member','operating') NOT NULL DEFAULT 'member',
+    joined_at         DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (id),
-    UNIQUE KEY uq_member_generation (member_id, generation_id),
+    UNIQUE KEY uq_member_generation (member_id, generation_number),
     FOREIGN KEY (member_id) REFERENCES member (id) ON DELETE CASCADE,
-    FOREIGN KEY (generation_id) REFERENCES generation (id) ON DELETE CASCADE
+    FOREIGN KEY (generation_number) REFERENCES generation (number) ON DELETE CASCADE
 );
 
 -- 4. 공통 기술 스택 마스터 테이블
@@ -76,7 +75,7 @@ CREATE TABLE member_tech_stack
 CREATE TABLE team_profile
 (
     id                     BIGINT       NOT NULL AUTO_INCREMENT,
-    generation_id          BIGINT,
+    generation_number      INT,
     name                   VARCHAR(255) NOT NULL,
     description            TEXT,
     project_url            TEXT,
@@ -86,7 +85,7 @@ CREATE TABLE team_profile
     created_at             DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at             DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (id),
-    FOREIGN KEY (generation_id) REFERENCES generation (id) ON DELETE SET NULL
+    FOREIGN KEY (generation_number) REFERENCES generation (number) ON DELETE SET NULL
 );
 
 -- 7. 팀별 사용 기술 스택

--- a/docs/db/profile/erd-cloud.sql
+++ b/docs/db/profile/erd-cloud.sql
@@ -21,7 +21,6 @@ CREATE TABLE member
 CREATE TABLE generation
 (
     number     INT          NOT NULL,
-    label      VARCHAR(255) NOT NULL,
     start_date DATE         NOT NULL,
     end_date   DATE,
     is_current BOOLEAN      NOT NULL DEFAULT FALSE,

--- a/docs/db/profile/profile-ddl.sql
+++ b/docs/db/profile/profile-ddl.sql
@@ -25,9 +25,8 @@ CREATE TABLE member (
 );
 
 CREATE TABLE generation (
-    id         BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    number     INT PRIMARY KEY,
     label      TEXT NOT NULL,
-    number     INT NOT NULL UNIQUE,
     start_date DATE NOT NULL,
     end_date   DATE,
     is_current BOOLEAN NOT NULL DEFAULT FALSE,
@@ -39,12 +38,12 @@ CREATE UNIQUE INDEX uq_generation_is_current ON generation (is_current) WHERE is
 
 -- 3. 관계 및 활동 테이블
 CREATE TABLE member_generation (
-    id            BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-    member_id     BIGINT NOT NULL REFERENCES member(id) ON DELETE CASCADE,
-    generation_id BIGINT NOT NULL REFERENCES generation(id) ON DELETE CASCADE,
-    role_in_gen   generation_role NOT NULL DEFAULT 'member',
-    joined_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    CONSTRAINT uq_member_generation UNIQUE (member_id, generation_id)
+    id                BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    member_id         BIGINT NOT NULL REFERENCES member(id) ON DELETE CASCADE,
+    generation_number INT NOT NULL REFERENCES generation(number) ON DELETE CASCADE,
+    role_in_gen       generation_role NOT NULL DEFAULT 'member',
+    joined_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_member_generation UNIQUE (member_id, generation_number)
 );
 
 CREATE TABLE tech_stack (
@@ -66,7 +65,7 @@ CREATE TABLE member_tech_stack (
 
 CREATE TABLE team_profile (
     id                     BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-    generation_id          BIGINT REFERENCES generation(id) ON DELETE SET NULL,
+    generation_number      INT REFERENCES generation(number) ON DELETE SET NULL,
     name                   TEXT NOT NULL,
     description            TEXT,
     project_url            TEXT,

--- a/docs/db/profile/profile-ddl.sql
+++ b/docs/db/profile/profile-ddl.sql
@@ -26,7 +26,6 @@ CREATE TABLE member (
 
 CREATE TABLE generation (
     number     INT PRIMARY KEY,
-    label      TEXT NOT NULL,
     start_date DATE NOT NULL,
     end_date   DATE,
     is_current BOOLEAN NOT NULL DEFAULT FALSE,

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -40,12 +40,12 @@ public class TeamService {
             .findByUserId(userId)
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "멤버를 찾을 수 없습니다."));
 
-    // 2. generationId가 있으면 Generation 조회, 없으면 null
+    // 2. generationNumber가 있으면 Generation 조회, 없으면 null
     Generation generation = null;
-    if (req.generationId() != null) {
+    if (req.generationNumber() != null) {
       generation =
           generationRepository
-              .findById(req.generationId())
+              .findById(req.generationNumber())
               .orElseThrow(
                   () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "기수를 찾을 수 없습니다."));
     }

--- a/src/main/java/com/study/profile/application/dto/TeamDto.java
+++ b/src/main/java/com/study/profile/application/dto/TeamDto.java
@@ -10,7 +10,7 @@ public class TeamDto {
       String description,
       String projectUrl,
       String githubUrl,
-      Long generationId,
+      Integer generationNumber,
       List<String> imageUrls,
       List<Long> techStackIds) {}
 

--- a/src/main/java/com/study/profile/domain/activity/Activity.java
+++ b/src/main/java/com/study/profile/domain/activity/Activity.java
@@ -5,6 +5,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -35,6 +37,7 @@ public class Activity {
   private Member member;
 
   @Enumerated(EnumType.STRING)
+  @JdbcTypeCode(SqlTypes.NAMED_ENUM)
   @Column(name = "type", nullable = false)
   private ActivityType type;
 

--- a/src/main/java/com/study/profile/domain/generation/Generation.java
+++ b/src/main/java/com/study/profile/domain/generation/Generation.java
@@ -28,9 +28,6 @@ public class Generation {
   @Column(name = "number", nullable = false)
   private Integer number; // 기수 번호 (예: 13, 14) — PK
 
-  @Column(name = "label", nullable = false)
-  private String label; // 기수 표시명 (예: "13기", "14기")
-
   @Column(name = "start_date", nullable = false)
   private LocalDate startDate; // 기수 활동 시작일 (날짜만, 시각 제외)
 
@@ -46,10 +43,9 @@ public class Generation {
 
   /** 새 기수를 생성할 때 호출하는 정적 팩토리 메서드. 처음 만들 때는 isCurrent = false로 시작하고, 필요 시 markAsCurrent()로 변경한다. */
   public static Generation create(
-      Integer number, String label, LocalDate startDate, LocalDate endDate, Boolean isCurrent) {
+      Integer number, LocalDate startDate, LocalDate endDate, Boolean isCurrent) {
     Generation generation = new Generation();
     generation.number = number;
-    generation.label = label;
     generation.startDate = startDate;
     generation.endDate = endDate;
     generation.isCurrent = isCurrent != null ? isCurrent : false;
@@ -57,9 +53,8 @@ public class Generation {
   }
 
   public void update(
-      Integer number, String label, LocalDate startDate, LocalDate endDate, Boolean isCurrent) {
+      Integer number, LocalDate startDate, LocalDate endDate, Boolean isCurrent) {
     this.number = number;
-    this.label = label;
     this.startDate = startDate;
     this.endDate = endDate;
     this.isCurrent = isCurrent != null ? isCurrent : false;

--- a/src/main/java/com/study/profile/domain/generation/Generation.java
+++ b/src/main/java/com/study/profile/domain/generation/Generation.java
@@ -2,10 +2,7 @@ package com.study.profile.domain.generation;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import java.time.Instant;
@@ -22,26 +19,17 @@ import lombok.NoArgsConstructor;
  * <p>[DB 테이블: generation] 이 클래스의 필드 하나하나가 DB 테이블의 컬럼(열) 하나씩에 대응된다.
  */
 @Entity
-@Table(
-    name = "generation",
-    indexes = {
-      // number 컬럼에 인덱스를 걸어 기수 번호로 빠르게 검색하고, 중복 기수 번호를 방지한다.
-      @Index(name = "idx_generation_number", columnList = "number", unique = true)
-    })
+@Table(name = "generation")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Generation {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "id")
-  private Long id; // DB가 자동으로 부여하는 고유 식별 번호
+  @Column(name = "number", nullable = false)
+  private Integer number; // 기수 번호 (예: 13, 14) — PK
 
   @Column(name = "label", nullable = false)
   private String label; // 기수 표시명 (예: "13기", "14기")
-
-  @Column(name = "number", nullable = false, unique = true)
-  private Integer number; // 기수 번호 (예: 13, 14) — 중복 불가
 
   @Column(name = "start_date", nullable = false)
   private LocalDate startDate; // 기수 활동 시작일 (날짜만, 시각 제외)
@@ -58,10 +46,10 @@ public class Generation {
 
   /** 새 기수를 생성할 때 호출하는 정적 팩토리 메서드. 처음 만들 때는 isCurrent = false로 시작하고, 필요 시 markAsCurrent()로 변경한다. */
   public static Generation create(
-      String label, Integer number, LocalDate startDate, LocalDate endDate, Boolean isCurrent) {
+      Integer number, String label, LocalDate startDate, LocalDate endDate, Boolean isCurrent) {
     Generation generation = new Generation();
-    generation.label = label;
     generation.number = number;
+    generation.label = label;
     generation.startDate = startDate;
     generation.endDate = endDate;
     generation.isCurrent = isCurrent != null ? isCurrent : false;
@@ -69,9 +57,9 @@ public class Generation {
   }
 
   public void update(
-      String label, Integer number, LocalDate startDate, LocalDate endDate, Boolean isCurrent) {
-    this.label = label;
+      Integer number, String label, LocalDate startDate, LocalDate endDate, Boolean isCurrent) {
     this.number = number;
+    this.label = label;
     this.startDate = startDate;
     this.endDate = endDate;
     this.isCurrent = isCurrent != null ? isCurrent : false;

--- a/src/main/java/com/study/profile/domain/generation/MemberGeneration.java
+++ b/src/main/java/com/study/profile/domain/generation/MemberGeneration.java
@@ -38,7 +38,7 @@ import lombok.NoArgsConstructor;
     uniqueConstraints =
         @UniqueConstraint(
             name = "uq_member_generation",
-            columnNames = {"member_id", "generation_id"}))
+            columnNames = {"member_id", "generation_number"})) // generation number로 시현 수정
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberGeneration {

--- a/src/main/java/com/study/profile/domain/generation/MemberGeneration.java
+++ b/src/main/java/com/study/profile/domain/generation/MemberGeneration.java
@@ -5,6 +5,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -56,6 +58,7 @@ public class MemberGeneration {
   private Generation generation; // 참여한 기수
 
   @Enumerated(EnumType.STRING)
+  @JdbcTypeCode(SqlTypes.NAMED_ENUM)
   @Column(name = "role_in_gen", nullable = false)
   private GenerationRole roleInGen = GenerationRole.member; // 해당 기수에서의 역할 (일반멤버/운영진)
 

--- a/src/main/java/com/study/profile/domain/generation/MemberGeneration.java
+++ b/src/main/java/com/study/profile/domain/generation/MemberGeneration.java
@@ -54,7 +54,7 @@ public class MemberGeneration {
   private Member member; // 참여한 멤버
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "generation_id", nullable = false)
+  @JoinColumn(name = "generation_number", nullable = false)
   private Generation generation; // 참여한 기수
 
   @Enumerated(EnumType.STRING)

--- a/src/main/java/com/study/profile/domain/member/Member.java
+++ b/src/main/java/com/study/profile/domain/member/Member.java
@@ -7,6 +7,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -63,6 +65,7 @@ public class Member {
   private String department;
 
   @Enumerated(EnumType.STRING)
+  @JdbcTypeCode(SqlTypes.NAMED_ENUM)
   @Column(name = "session_type", nullable = false)
   private SessionType sessionType;
 

--- a/src/main/java/com/study/profile/domain/team/TeamMember.java
+++ b/src/main/java/com/study/profile/domain/team/TeamMember.java
@@ -16,6 +16,8 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/study/profile/domain/team/TeamMemberRole.java
+++ b/src/main/java/com/study/profile/domain/team/TeamMemberRole.java
@@ -4,6 +4,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -43,6 +45,7 @@ public class TeamMemberRole {
   private TeamMember teamMember;
 
   @Enumerated(EnumType.STRING)
+  @JdbcTypeCode(SqlTypes.NAMED_ENUM)
   @Column(name = "role", nullable = false)
   private RoleInTeam role; // 역할 분야 (backend/frontend/design/ai/pm/infra/etc)
 

--- a/src/main/java/com/study/profile/domain/team/TeamProfile.java
+++ b/src/main/java/com/study/profile/domain/team/TeamProfile.java
@@ -46,7 +46,7 @@ public class TeamProfile {
 
   // 이 팀이 속한 기수 — ON DELETE SET NULL이므로 기수가 삭제돼도 팀은 남고 generation만 null이 된다.
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "generation_id")
+  @JoinColumn(name = "generation_number")
   private Generation generation;
 
   @Column(name = "name", nullable = false)

--- a/src/main/java/com/study/profile/domain/techstack/TechStack.java
+++ b/src/main/java/com/study/profile/domain/techstack/TechStack.java
@@ -4,6 +4,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -46,6 +48,7 @@ public class TechStack {
   private String name; // 기술 스택 이름 (예: "Java", "React") — 중복 불가
 
   @Enumerated(EnumType.STRING)
+  @JdbcTypeCode(SqlTypes.NAMED_ENUM)
   @Column(name = "category", nullable = false)
   private TechStackCategory category; // 분류 (language/framework/ai/design/tool/infra/etc)
 

--- a/src/main/java/com/study/profile/infrastructure/GenerationRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/GenerationRepository.java
@@ -3,4 +3,4 @@ package com.study.profile.infrastructure;
 import com.study.profile.domain.generation.Generation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface GenerationRepository extends JpaRepository<Generation, Long> {}
+public interface GenerationRepository extends JpaRepository<Generation, Integer> {}

--- a/src/main/java/com/study/sessionboard/application/event/EventPostService.java
+++ b/src/main/java/com/study/sessionboard/application/event/EventPostService.java
@@ -34,11 +34,11 @@ public class EventPostService {
   }
 
   public PageWrapper<EventPostSummaryResponse> getEventPosts(
-      Long generationId, EventPostType type, Pageable pageable) {
+      Integer generationNumber, EventPostType type, Pageable pageable) { // generation number로 시현 수정
 
     Page<EventPost> posts =
         eventPostRepository.findAllWithFilters(
-            generationId, EventPostStatus.PUBLISHED, type, pageable);
+            generationNumber, EventPostStatus.PUBLISHED, type, pageable);
 
     List<Long> postIds = posts.map(EventPost::getId).toList();
 

--- a/src/main/java/com/study/sessionboard/domain/event/EventPost.java
+++ b/src/main/java/com/study/sessionboard/domain/event/EventPost.java
@@ -35,7 +35,7 @@ public class EventPost {
   private Member author;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "generation_id", nullable = false)
+  @JoinColumn(name = "generation_number", nullable = false) // generation number로 시현 수정
   private Generation generation;
 
   @Enumerated(EnumType.STRING)

--- a/src/main/java/com/study/sessionboard/domain/session/Session.java
+++ b/src/main/java/com/study/sessionboard/domain/session/Session.java
@@ -28,7 +28,7 @@ public class Session {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "generation_id", nullable = false)
+  @JoinColumn(name = "generation_number", nullable = false) // generation number로 시현 수정
   private Generation generation;
 
   @Column(name = "week_label")

--- a/src/main/java/com/study/sessionboard/infrastructure/event/EventPostRepository.java
+++ b/src/main/java/com/study/sessionboard/infrastructure/event/EventPostRepository.java
@@ -15,13 +15,13 @@ public interface EventPostRepository extends JpaRepository<EventPost, Long> {
       """
       SELECT p FROM EventPost p
       JOIN FETCH p.author
-      WHERE p.generation.id = :generationId
+      WHERE p.generation.number = :generationNumber
         AND p.status = :status
         AND (:type IS NULL OR p.type = :type)
       ORDER BY p.createdAt DESC
       """)
   Page<EventPost> findAllWithFilters(
-      @Param("generationId") Long generationId,
+      @Param("generationNumber") Integer generationNumber, // generation number로 시현 수정
       @Param("status") EventPostStatus status,
       @Param("type") EventPostType type,
       Pageable pageable);

--- a/src/main/java/com/study/sessionboard/presentation/event/EventPostController.java
+++ b/src/main/java/com/study/sessionboard/presentation/event/EventPostController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/session-board/{generationId}/event-posts")
+@RequestMapping("/api/session-board/{generationNumber}/event-posts") // generation number로 시현 수정
 public class EventPostController {
 
   private final EventPostService eventPostService;
@@ -26,10 +26,10 @@ public class EventPostController {
 
   @GetMapping
   public ResponseEntity<PageWrapper<EventPostSummaryResponse>> getEventPosts(
-      @PathVariable Long generationId,
+      @PathVariable Integer generationNumber, // generation number로 시현 수정
       @RequestParam(required = false) EventPostType type,
       @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
           Pageable pageable) {
-    return ResponseEntity.ok(eventPostService.getEventPosts(generationId, type, pageable));
+    return ResponseEntity.ok(eventPostService.getEventPosts(generationNumber, type, pageable));
   }
 }


### PR DESCRIPTION
### 🐛 PostgreSQL 네이티브 enum 타입 불일치 수정

기술 스택 조회와 팀 생성 API를 개발하는데 있어서 enum 관련하여 동일한 오류를 겪었습니다.
해당 오류를 확인하였을 때, enum 관련하여 전체적인 수정이 필요하다고 판단하였습니다.

PostgreSQL은 CREATE TYPE ... AS ENUM으로 선언된 커스텀 enum 타입을 사용하는데, Hibernate 기본 설정(@Enumerated(EnumType.STRING))은 이를 VARCHAR로 인식해 타입 불일치 오류가 발생했습니다.

profile 도메인의 모든 네이티브 enum 컬럼에 @JdbcTypeCode(SqlTypes.NAMED_ENUM) 어노테이션을 추가했습니다.

---                                                                                                                                                                                                          
### ♻️ generation PK를 id → number로 변경

경로에서 generationId(PK)와 generation.number(실제 기수 번호)의 혼동을 막기 위해 number를 PK로 변경했습니다.

변경 내용
- Generation 엔티티: id 제거, number를 @Id로 승격
- 자식 테이블 FK 컬럼명: generation_id → generation_number
- GenerationRepository: 타입 Long → Integer
- TeamDto: generationId → generationNumber
- DDL 파일 (profile-ddl.sql, erd-cloud.sql) 동기화
                                                            
  ▎ RDS 반영 미완료 — 다른 팀들의 테이블도 generation_id FK를 가지고 있어 해당 팀 코드 변경 후 함께 반영 예정

```java
  @Id
  @Column(name = "number", nullable = false)
  private Integer number; // 기수 번호 (예: 13, 14) — PK

  @Column(name = "label", nullable = false)
  private String label; // 기수 표시명 (예: "13기", "14기")
```