### PR TITLE
fix(test): 테스트 실행 시 공용 RDS users 테이블 전체 삭제 버그 수정

### DIFF
--- a/src/main/java/com/study/auth/infrastructure/RefreshTokenRepository.java
+++ b/src/main/java/com/study/auth/infrastructure/RefreshTokenRepository.java
@@ -44,4 +44,7 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
           + " WHERE r.userId = :userId"
           + " AND r.status = com.study.auth.domain.RefreshTokenStatus.ACTIVE")
   int revokeAllByUserId(@Param("userId") Long userId);
+
+  /** 테스트 정리용 — 특정 유저의 토큰 행을 물리 삭제한다. */
+  void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/study/auth/infrastructure/RefreshTokenRepository.java
+++ b/src/main/java/com/study/auth/infrastructure/RefreshTokenRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
@@ -46,5 +47,8 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
   int revokeAllByUserId(@Param("userId") Long userId);
 
   /** 테스트 정리용 — 특정 유저의 토큰 행을 물리 삭제한다. */
-  void deleteByUserId(Long userId);
+  @Transactional
+  @Modifying
+  @Query("DELETE FROM RefreshToken r WHERE r.userId = :userId")
+  void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/test/java/com/study/AuthIntegrationTest.java
+++ b/src/test/java/com/study/AuthIntegrationTest.java
@@ -13,6 +13,7 @@ import com.study.auth.infrastructure.UserRepository;
 import com.study.auth.presentation.dto.LoginRequest;
 import com.study.auth.presentation.dto.SignupRequest;
 import jakarta.servlet.http.Cookie;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -36,6 +37,11 @@ import org.springframework.test.web.servlet.MvcResult;
 @AutoConfigureMockMvc
 class AuthIntegrationTest {
 
+  // 이 테스트에서 사용하는 이메일 목록 — cleanUp 시 해당 유저만 삭제한다.
+  // deleteAll()을 쓰면 공용 RDS의 실제 데이터가 전부 날아가므로 금지.
+  private static final List<String> TEST_EMAILS =
+      List.of("test@khu.ac.kr", "dup@khu.ac.kr", "user@khu.ac.kr", "pending@khu.ac.kr");
+
   @Autowired private MockMvc mockMvc;
   @Autowired private ObjectMapper objectMapper;
   @Autowired private UserRepository userRepository;
@@ -44,9 +50,16 @@ class AuthIntegrationTest {
 
   @BeforeEach
   void cleanUp() {
-    // RDS 사용 시 @Transactional 롤백이 MockMvc 요청 단위로 작동하지 않으므로 직접 정리
-    refreshTokenRepository.deleteAll();
-    userRepository.deleteAll();
+    // 테스트에서 사용하는 이메일 유저만 정리 — 공용 RDS의 다른 데이터를 건드리지 않는다.
+    TEST_EMAILS.forEach(
+        email ->
+            userRepository
+                .findByLoginEmail(email)
+                .ifPresent(
+                    user -> {
+                      refreshTokenRepository.deleteByUserId(user.getId());
+                      userRepository.delete(user);
+                    }));
   }
 
   private static final String SIGNUP_URL = "/api/auth/signup";


### PR DESCRIPTION
## 문제

`AuthIntegrationTest`가 매 테스트 실행 전 `@BeforeEach`에서 `userRepository.deleteAll()`을 호출하고 있었다.

이 레포는 공용 RDS에 직접 연결되어 테스트를 돌리기 때문에, 누구든 로컬에서 테스트를 실행하면 **실제 서비스의 users 테이블 전체가 삭제**되는 상황이 반복되고 있었다.

```java
// 기존 — 테이블 전체 삭제
@BeforeEach
void cleanUp() {
    refreshTokenRepository.deleteAll();
    userRepository.deleteAll();  // ← 공용 RDS 전체 삭제
}
```

## 원인

`@SpringBootTest` + MockMvc 환경에서는\`@Transactional` 롤백이 MockMvc 요청 단위로 작동하지 않아 수동 정리가 필요하다. 그러나 \`deleteAll()\`은 테스트 데이터만이 아닌 테이블 전체를 날린다.

## 해결

\`deleteAll()\` 대신 이 테스트에서 실제로 사용하는 이메일만 타겟 삭제한다.

```java
private static final List<String> TEST_EMAILS =
    List.of("test@khu.ac.kr", "dup@khu.ac.kr", "user@khu.ac.kr", "pending@khu.ac.kr");

@BeforeEach
void cleanUp() {
    TEST_EMAILS.forEach(email ->
        userRepository.findByLoginEmail(email).ifPresent(user -> {
            refreshTokenRepository.deleteByUserId(user.getId());
            userRepository.delete(user);
        }));
}
```

- \`RefreshTokenRepository\`에 \`deleteByUserId()\` 추가 — user 삭제 전 refresh_token FK 순서 보장
- \`TEST_EMAILS\` 상수로 테스트 대상 이메일을 명시적으로 관리 — 새 테스트 케이스 추가 시 이 목록에 추가