### PR TITLE
feat: Q&A 질문 수정·상태 변경 API 및 동적 목록 조회 구현

### DIFF
--- a/src/main/java/com/study/qna/application/AnswerService.java
+++ b/src/main/java/com/study/qna/application/AnswerService.java
@@ -10,6 +10,7 @@ import com.study.qna.domain.Question;
 import com.study.qna.domain.QuestionStatus;
 import com.study.qna.domain.exception.AnswerNotFoundException;
 import com.study.qna.domain.exception.ForbiddenQnaActionException;
+import com.study.qna.domain.exception.QuestionAlreadyClosedException;
 import com.study.qna.domain.exception.QuestionNotFoundException;
 import com.study.qna.infrastructure.AnswerRepository;
 import com.study.qna.infrastructure.QuestionRepository;
@@ -50,7 +51,7 @@ public class AnswerService {
             .orElseThrow(() -> new QuestionNotFoundException(questionId));
 
     if (question.getStatus() == QuestionStatus.CLOSED) {
-      throw new ForbiddenQnaActionException();
+      throw new QuestionAlreadyClosedException(questionId);
     }
 
     Answer answer = Answer.create(question, userId, request.content());

--- a/src/main/java/com/study/qna/application/CommentService.java
+++ b/src/main/java/com/study/qna/application/CommentService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service("qnaCommentService")
 @RequiredArgsConstructor
 public class CommentService {
+
   private final CommentRepository commentRepository;
   private final AnswerRepository answerRepository;
 

--- a/src/main/java/com/study/qna/application/QuestionService.java
+++ b/src/main/java/com/study/qna/application/QuestionService.java
@@ -1,16 +1,24 @@
 package com.study.qna.application;
 
 import com.study.qna.application.dto.request.question.QuestionCreateRequest;
+import com.study.qna.application.dto.request.question.QuestionSearchCondition;
+import com.study.qna.application.dto.request.question.QuestionStatusUpdateRequest;
+import com.study.qna.application.dto.request.question.QuestionUpdateRequest;
 import com.study.qna.application.dto.response.common.MemberSummaryResponse;
 import com.study.qna.application.dto.response.question.QuestionDetailResponse;
 import com.study.qna.application.dto.response.question.QuestionSummaryResponse;
 import com.study.qna.application.dto.response.tag.TagResponse;
 import com.study.qna.domain.Question;
+import com.study.qna.domain.QuestionStatus;
+import com.study.qna.domain.Tag;
 import com.study.qna.domain.exception.ForbiddenQnaActionException;
 import com.study.qna.domain.exception.QuestionNotFoundException;
+import com.study.qna.domain.exception.TagNotFoundException;
 import com.study.qna.infrastructure.QuestionRepository;
 import com.study.qna.infrastructure.TagRepository;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,8 +33,10 @@ public class QuestionService {
   private final QuestionRepository questionRepository;
   private final TagRepository tagRepository;
 
-  public List<QuestionSummaryResponse> getQuestions() {
-    return questionRepository.findAllWithTags().stream().map(this::toSummaryResponse).toList();
+  public List<QuestionSummaryResponse> getQuestions(QuestionSearchCondition condition) {
+    return questionRepository.searchQuestions(condition).stream()
+        .map(this::toSummaryResponse)
+        .toList();
   }
 
   public QuestionDetailResponse getQuestion(Long questionId) {
@@ -46,11 +56,57 @@ public class QuestionService {
     Question question = Question.create(userId, request.title(), request.content(), 0);
 
     if (request.tagIds() != null && !request.tagIds().isEmpty()) {
-      tagRepository.findAllByIdIn(request.tagIds()).forEach(question::addTag);
+      List<Tag> tags = fetchAndValidateTags(request.tagIds());
+      tags.forEach(question::addTag);
     }
 
     Question saved = questionRepository.save(question);
     return toDetailResponse(saved);
+  }
+
+  @Transactional
+  public QuestionDetailResponse updateQuestion(
+      Long questionId, QuestionUpdateRequest request, Long userId) {
+    Question question =
+        questionRepository
+            .findByIdWithTags(questionId)
+            .orElseThrow(() -> new QuestionNotFoundException(questionId));
+
+    if (!question.isAuthor(userId)) {
+      throw new ForbiddenQnaActionException();
+    }
+
+    question.update(request.title(), request.content());
+
+    if (request.tagIds() != null) {
+      question.getQuestionTags().clear();
+      if (!request.tagIds().isEmpty()) {
+        List<Tag> tags = fetchAndValidateTags(request.tagIds());
+        tags.forEach(question::addTag);
+      }
+    }
+
+    return toDetailResponse(question);
+  }
+
+  @Transactional
+  public QuestionDetailResponse closeQuestion(
+      Long questionId, QuestionStatusUpdateRequest request, Long userId) {
+    Question question =
+        questionRepository
+            .findByIdWithTags(questionId)
+            .orElseThrow(() -> new QuestionNotFoundException(questionId));
+
+    if (!question.isAuthor(userId)) {
+      throw new ForbiddenQnaActionException();
+    }
+
+    QuestionStatus targetStatus = QuestionStatus.valueOf(request.status());
+    if (targetStatus == QuestionStatus.CLOSED) {
+      question.close();
+    }
+
+    return toDetailResponse(question);
   }
 
   @Transactional
@@ -65,6 +121,17 @@ public class QuestionService {
     }
 
     questionRepository.delete(question);
+  }
+
+  private List<Tag> fetchAndValidateTags(List<Long> tagIds) {
+    List<Tag> tags = tagRepository.findAllByIdIn(tagIds);
+    if (tags.size() != tagIds.size()) {
+      Set<Long> foundIds = tags.stream().map(Tag::getId).collect(Collectors.toSet());
+      Long missingId =
+          tagIds.stream().filter(id -> !foundIds.contains(id)).findFirst().orElseThrow();
+      throw new TagNotFoundException(missingId);
+    }
+    return tags;
   }
 
   private QuestionSummaryResponse toSummaryResponse(Question question) {

--- a/src/main/java/com/study/qna/application/dto/request/question/QuestionSearchCondition.java
+++ b/src/main/java/com/study/qna/application/dto/request/question/QuestionSearchCondition.java
@@ -1,0 +1,11 @@
+package com.study.qna.application.dto.request.question;
+
+/** 질문 목록 동적 검색 조건. */
+public record QuestionSearchCondition(
+    String keyword,
+    String status,
+    Long tagId,
+    Integer generation,
+    String sort,
+    int page,
+    int size) {}

--- a/src/main/java/com/study/qna/domain/exception/QuestionAlreadyClosedException.java
+++ b/src/main/java/com/study/qna/domain/exception/QuestionAlreadyClosedException.java
@@ -1,0 +1,8 @@
+package com.study.qna.domain.exception;
+
+public class QuestionAlreadyClosedException extends QnaException {
+
+  public QuestionAlreadyClosedException(Long questionId) {
+    super("이미 종료된 질문입니다: " + questionId);
+  }
+}

--- a/src/main/java/com/study/qna/infrastructure/CommentRepository.java
+++ b/src/main/java/com/study/qna/infrastructure/CommentRepository.java
@@ -7,5 +7,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository("qnaCommentRepository")
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
   List<Comment> findByAnswer_IdOrderByCreatedAtAsc(Long answerId);
 }

--- a/src/main/java/com/study/qna/infrastructure/QuestionRepository.java
+++ b/src/main/java/com/study/qna/infrastructure/QuestionRepository.java
@@ -9,7 +9,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface QuestionRepository extends JpaRepository<Question, Long> {
+public interface QuestionRepository
+    extends JpaRepository<Question, Long>, QuestionRepositoryCustom {
 
   @Query(
       """

--- a/src/main/java/com/study/qna/infrastructure/QuestionRepositoryCustom.java
+++ b/src/main/java/com/study/qna/infrastructure/QuestionRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.study.qna.infrastructure;
+
+import com.study.qna.application.dto.request.question.QuestionSearchCondition;
+import com.study.qna.domain.Question;
+import java.util.List;
+
+public interface QuestionRepositoryCustom {
+
+  List<Question> searchQuestions(QuestionSearchCondition condition);
+
+  long countQuestions(QuestionSearchCondition condition);
+}

--- a/src/main/java/com/study/qna/infrastructure/QuestionRepositoryImpl.java
+++ b/src/main/java/com/study/qna/infrastructure/QuestionRepositoryImpl.java
@@ -1,0 +1,123 @@
+package com.study.qna.infrastructure;
+
+import com.study.qna.application.dto.request.question.QuestionSearchCondition;
+import com.study.qna.domain.Question;
+import com.study.qna.domain.QuestionStatus;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
+
+  @PersistenceContext private EntityManager em;
+
+  @Override
+  public List<Question> searchQuestions(QuestionSearchCondition condition) {
+    List<Long> ids = getPagedIds(condition);
+    if (ids.isEmpty()) {
+      return List.of();
+    }
+
+    List<Question> questions =
+        em.createQuery(
+                """
+                SELECT DISTINCT q FROM QnaQuestion q
+                LEFT JOIN FETCH q.questionTags qt
+                LEFT JOIN FETCH qt.tag
+                WHERE q.id IN :ids
+                """,
+                Question.class)
+            .setParameter("ids", ids)
+            .getResultList();
+
+    Map<Long, Question> questionMap =
+        questions.stream().collect(Collectors.toMap(Question::getId, q -> q));
+    return ids.stream().map(questionMap::get).filter(Objects::nonNull).toList();
+  }
+
+  @Override
+  public long countQuestions(QuestionSearchCondition condition) {
+    StringBuilder jpql = new StringBuilder("SELECT COUNT(q) FROM QnaQuestion q");
+    List<String> predicates = buildPredicates(condition);
+
+    if (condition.tagId() != null) {
+      jpql.append(" JOIN q.questionTags qt");
+    }
+    if (!predicates.isEmpty()) {
+      jpql.append(" WHERE ").append(String.join(" AND ", predicates));
+    }
+
+    TypedQuery<Long> query = em.createQuery(jpql.toString(), Long.class);
+    applyParameters(query, condition);
+    return query.getSingleResult();
+  }
+
+  private List<Long> getPagedIds(QuestionSearchCondition condition) {
+    StringBuilder jpql = new StringBuilder("SELECT q.id FROM QnaQuestion q");
+    List<String> predicates = buildPredicates(condition);
+
+    if (condition.tagId() != null) {
+      jpql.append(" JOIN q.questionTags qt");
+    }
+    if (!predicates.isEmpty()) {
+      jpql.append(" WHERE ").append(String.join(" AND ", predicates));
+    }
+
+    jpql.append(" ORDER BY ").append(orderClause(condition.sort()));
+
+    TypedQuery<Long> query =
+        em.createQuery(jpql.toString(), Long.class)
+            .setFirstResult(condition.page() * condition.size())
+            .setMaxResults(condition.size());
+    applyParameters(query, condition);
+    return query.getResultList();
+  }
+
+  private List<String> buildPredicates(QuestionSearchCondition condition) {
+    List<String> predicates = new ArrayList<>();
+
+    if (condition.status() != null && !condition.status().isBlank()) {
+      predicates.add("q.status = :status");
+    }
+    if (condition.generation() != null) {
+      predicates.add("q.generation = :generation");
+    }
+    if (condition.keyword() != null && !condition.keyword().isBlank()) {
+      predicates.add(
+          "(LOWER(q.title) LIKE LOWER(:keyword) OR LOWER(q.content) LIKE LOWER(:keyword))");
+    }
+    if (condition.tagId() != null) {
+      predicates.add("qt.tag.id = :tagId");
+    }
+
+    return predicates;
+  }
+
+  private String orderClause(String sort) {
+    return switch (sort) {
+      case "vote" -> "q.answerCount DESC, q.createdAt DESC";
+      case "unanswered" -> "q.answerCount ASC, q.createdAt DESC";
+      default -> "q.createdAt DESC";
+    };
+  }
+
+  private void applyParameters(TypedQuery<?> query, QuestionSearchCondition condition) {
+    if (condition.status() != null && !condition.status().isBlank()) {
+      query.setParameter("status", QuestionStatus.valueOf(condition.status()));
+    }
+    if (condition.generation() != null) {
+      query.setParameter("generation", condition.generation());
+    }
+    if (condition.keyword() != null && !condition.keyword().isBlank()) {
+      query.setParameter("keyword", "%" + condition.keyword() + "%");
+    }
+    if (condition.tagId() != null) {
+      query.setParameter("tagId", condition.tagId());
+    }
+  }
+}

--- a/src/main/java/com/study/qna/presentation/CommentController.java
+++ b/src/main/java/com/study/qna/presentation/CommentController.java
@@ -10,12 +10,18 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController("qnaCommentController")
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/answers/{answerId}/comments")
 public class CommentController {
+
   private final CommentService commentService;
 
   @GetMapping

--- a/src/main/java/com/study/qna/presentation/QuestionController.java
+++ b/src/main/java/com/study/qna/presentation/QuestionController.java
@@ -4,6 +4,9 @@ import com.study.auth.infrastructure.security.CurrentUser;
 import com.study.auth.infrastructure.security.CustomUserDetails;
 import com.study.qna.application.QuestionService;
 import com.study.qna.application.dto.request.question.QuestionCreateRequest;
+import com.study.qna.application.dto.request.question.QuestionSearchCondition;
+import com.study.qna.application.dto.request.question.QuestionStatusUpdateRequest;
+import com.study.qna.application.dto.request.question.QuestionUpdateRequest;
 import com.study.qna.application.dto.response.question.QuestionDetailResponse;
 import com.study.qna.application.dto.response.question.QuestionSummaryResponse;
 import jakarta.validation.Valid;
@@ -13,10 +16,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -27,8 +32,17 @@ public class QuestionController {
   private final QuestionService questionService;
 
   @GetMapping
-  public ResponseEntity<List<QuestionSummaryResponse>> getQuestions() {
-    return ResponseEntity.ok(questionService.getQuestions());
+  public ResponseEntity<List<QuestionSummaryResponse>> getQuestions(
+      @RequestParam(required = false) String keyword,
+      @RequestParam(required = false) String status,
+      @RequestParam(required = false) Long tagId,
+      @RequestParam(required = false) Integer generation,
+      @RequestParam(defaultValue = "latest") String sort,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "20") int size) {
+    QuestionSearchCondition condition =
+        new QuestionSearchCondition(keyword, status, tagId, generation, sort, page, size);
+    return ResponseEntity.ok(questionService.getQuestions(condition));
   }
 
   @GetMapping("/{questionId}")
@@ -41,6 +55,22 @@ public class QuestionController {
       @CurrentUser CustomUserDetails user, @Valid @RequestBody QuestionCreateRequest request) {
     QuestionDetailResponse result = questionService.createQuestion(request, user.userId());
     return ResponseEntity.status(HttpStatus.CREATED).body(result);
+  }
+
+  @PatchMapping("/{questionId}")
+  public ResponseEntity<QuestionDetailResponse> updateQuestion(
+      @PathVariable Long questionId,
+      @CurrentUser CustomUserDetails user,
+      @Valid @RequestBody QuestionUpdateRequest request) {
+    return ResponseEntity.ok(questionService.updateQuestion(questionId, request, user.userId()));
+  }
+
+  @PatchMapping("/{questionId}/status")
+  public ResponseEntity<QuestionDetailResponse> closeQuestion(
+      @PathVariable Long questionId,
+      @CurrentUser CustomUserDetails user,
+      @Valid @RequestBody QuestionStatusUpdateRequest request) {
+    return ResponseEntity.ok(questionService.closeQuestion(questionId, request, user.userId()));
   }
 
   @DeleteMapping("/{questionId}")

--- a/src/main/java/com/study/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/study/shared/exception/GlobalExceptionHandler.java
@@ -5,6 +5,13 @@ import com.study.auth.domain.exception.InvalidCredentialsException;
 import com.study.auth.domain.exception.InvalidTokenException;
 import com.study.auth.domain.exception.TokenReusedException;
 import com.study.auth.domain.exception.UserNotActiveException;
+import com.study.qna.domain.exception.AnswerNotFoundException;
+import com.study.qna.domain.exception.CommentNotFoundException;
+import com.study.qna.domain.exception.ForbiddenQnaActionException;
+import com.study.qna.domain.exception.QuestionAlreadyClosedException;
+import com.study.qna.domain.exception.QuestionNotFoundException;
+import com.study.qna.domain.exception.TagAlreadyExistsException;
+import com.study.qna.domain.exception.TagNotFoundException;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -48,6 +55,49 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(InvalidTokenException.class)
   public ResponseEntity<Map<String, Object>> handleInvalidToken(InvalidTokenException e) {
     return errorResponse(HttpStatus.UNAUTHORIZED, e.getMessage());
+  }
+
+  @ExceptionHandler(QuestionNotFoundException.class)
+  public ResponseEntity<Map<String, Object>> handleQuestionNotFound(QuestionNotFoundException e) {
+    return errorResponse(HttpStatus.NOT_FOUND, e.getMessage());
+  }
+
+  @ExceptionHandler(AnswerNotFoundException.class)
+  public ResponseEntity<Map<String, Object>> handleAnswerNotFound(AnswerNotFoundException e) {
+    return errorResponse(HttpStatus.NOT_FOUND, e.getMessage());
+  }
+
+  @ExceptionHandler(CommentNotFoundException.class)
+  public ResponseEntity<Map<String, Object>> handleCommentNotFound(CommentNotFoundException e) {
+    return errorResponse(HttpStatus.NOT_FOUND, e.getMessage());
+  }
+
+  @ExceptionHandler(TagNotFoundException.class)
+  public ResponseEntity<Map<String, Object>> handleTagNotFound(TagNotFoundException e) {
+    return errorResponse(HttpStatus.NOT_FOUND, e.getMessage());
+  }
+
+  @ExceptionHandler(TagAlreadyExistsException.class)
+  public ResponseEntity<Map<String, Object>> handleTagAlreadyExists(TagAlreadyExistsException e) {
+    return errorResponse(HttpStatus.CONFLICT, e.getMessage());
+  }
+
+  @ExceptionHandler(ForbiddenQnaActionException.class)
+  public ResponseEntity<Map<String, Object>> handleForbiddenQnaAction(
+      ForbiddenQnaActionException e) {
+    return errorResponse(HttpStatus.FORBIDDEN, e.getMessage());
+  }
+
+  @ExceptionHandler(QuestionAlreadyClosedException.class)
+  public ResponseEntity<Map<String, Object>> handleQuestionAlreadyClosed(
+      QuestionAlreadyClosedException e) {
+    return errorResponse(HttpStatus.CONFLICT, e.getMessage());
+  }
+
+  @ExceptionHandler(IllegalStateException.class)
+  public ResponseEntity<Map<String, Object>> handleIllegalState(IllegalStateException e) {
+    log.warn("IllegalStateException: {}", e.getMessage(), e);
+    return errorResponse(HttpStatus.BAD_REQUEST, e.getMessage());
   }
 
   @ExceptionHandler(IllegalArgumentException.class)


### PR DESCRIPTION
## 개요

  Q&A 질문 CRUD 및 상태 관리의 미구현 항목을 완성
  질문 수정, 상태 변경, 동적 목록 조회 API를 추가하고 QnA 도메인 예외 처리를 통일

  ## 변경 사항

  ### 신규 API
  - `PATCH /api/v1/questions/{questionId}` — 질문 수정 (제목·본문·태그, 작성자 검증)
  - `PATCH /api/v1/questions/{questionId}/status` — 질문 상태 CLOSED 전환 (작성자 검증)

  ### 목록 조회 개선
  - `GET /api/v1/questions`에 필터·정렬·페이징 파라미터 추가
    - 필터: `keyword`, `status`, `tagId`, `generation`
    - 정렬: `latest`(기본) / `vote` / `unanswered`
    - 페이징: `page`, `size`
  - 페이지네이션 + Collection FETCH JOIN 문제를 **2-phase 쿼리**로 해결
    - Phase 1: 필터·정렬·페이징 적용해 ID 목록 조회
    - Phase 2: 해당 ID로 FETCH JOIN 후 ID 순서 복원

  ### 예외 처리
  - `GlobalExceptionHandler`에 QnA 예외 핸들러 7종 추가
    - `QuestionNotFoundException` → 404
    - `AnswerNotFoundException` → 404
    - `CommentNotFoundException` → 404
    - `TagNotFoundException` → 404
    - `TagAlreadyExistsException` → 409
    - `ForbiddenQnaActionException` → 403
    - `QuestionAlreadyClosedException` → 409
  - `IllegalStateException` → 400 핸들러 추가 (상태 전이 실패 대응)
  - `QuestionAlreadyClosedException` 신규 정의
  - CLOSED 질문에 답변 등록 시 기존 `ForbiddenQnaActionException`(403) → `QuestionAlreadyClosedException`(409)으로 교체

  ### 기타
  - 태그 ID 목록에 존재하지 않는 ID 포함 시 `TagNotFoundException` 발생 (기존: 무시)
