### PR TITLE
feat: Swagger UI 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // Swagger UI
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/study/shared/config/SecurityConfig.java
+++ b/src/main/java/com/study/shared/config/SecurityConfig.java
@@ -57,7 +57,10 @@ public class SecurityConfig {
                         "/api/auth/refresh",
                         "/api/auth/logout",
                         "/api/health",
-                        "/api/health/**")
+                        "/api/health/**",
+                        "/swagger-ui/**",
+                        "/v3/api-docs/**",
+                        "/swagger-ui.html")
                     .permitAll()
                     .requestMatchers(
                         org.springframework.http.HttpMethod.GET,

--- a/src/main/java/com/study/shared/config/SwaggerConfig.java
+++ b/src/main/java/com/study/shared/config/SwaggerConfig.java
@@ -1,0 +1,28 @@
+package com.study.shared.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    SecurityScheme bearerAuth =
+        new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT");
+
+    return new OpenAPI()
+        .info(
+            new Info()
+                .title("Tech Blog API")
+                .description("경희대 멋쟁이사자처럼 Tech Blog API")
+                .version("v1"))
+        .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+        .components(new Components().addSecuritySchemes("bearerAuth", bearerAuth));
+  }
+}


### PR DESCRIPTION
### 📌 도입 배경

현재 팀 내 API 테스트 방식이 Postman 또는 `curl` 명령어에 의존하고 있어, 팀원 간 **API 명세 공유와 수동 테스트에 반복적인 비용**이 발생하고 있었습니다. 또한 blog, qna, profile팀 각각이 다른 팀의 API 목록을 파악하기 어려워 다른 모듈에 영향을 작업을 해야 할 때 일일이 물어보며 작업을 해야 해 비효율적이였습니다.

blog, qna, profile 등 모듈별로 API가 늘어남에 따라:
-  blog, qna, profile팀 각각이 다른 팀의 API 목록을 파악하기 어려움
- 프론트엔드 작업을 하게 될 때 req, res 스펙을 일일이 확인 해야 함
- JWT 인증이 필요한 엔드포인트를 테스트할 때 토큰 세팅이 번거로움

이를 해결하기 위해 **Swagger UI(springdoc-openapi 2.8.8)** 를 도입합니다.

---

### 🔧 변경 사항

| 파일 | 변경 내용 |
|---|---|
| `build.gradle` | `springdoc-openapi-starter-webmvc-ui:2.8.8` 의존성 추가 |
| `SecurityConfig.java` | `/swagger-ui/**`, `/v3/api-docs/**`, `/swagger-ui.html` permitAll 추가 |
| `shared/config/SwaggerConfig.java` | OpenAPI 빈 신규 생성 (JWT Bearer 인증 스킴 포함) |

---

### 🚀 사용 방법

**1. 서버 실행 후 접속**
```
http://localhost:8080/swagger-ui/index.html
```

**2. JWT 인증이 필요한 API 테스트 방법**
1. `/api/auth/login` 엔드포인트로 로그인 → `accessToken` 복사
2. 우측 상단 **Authorize 🔒 버튼** 클릭
3. `bearerAuth` 항목에 복사한 토큰 붙여넣기 (Bearer 접두사 없이 토큰만 입력)
4. Authorize → Close
5. 이후 모든 API 요청에 자동으로 `Authorization: Bearer {token}` 헤더 포함

**3. 컨트롤러에 문서 추가하기 (선택)**
```java
// 컨트롤러 클래스에
@Tag(name = "Blog", description = "블로그 게시글 API")

// 메서드에
@Operation(summary = "게시글 목록 조회", description = "커서 기반 페이지네이션으로 게시글을 조회합니다.")
```
> 어노테이션 없이도 기본 동작하며, 팀원들이 점진적으로 문서를 보강할 수 있습니다.

---

### ✅ 확인 사항
- [ ] 로컬에서 `/swagger-ui/index.html` 접속 확인
- [ ] 인증 없는 API (`/api/health` 등) 정상 응답 확인
- [ ] 로그인 후 토큰 입력 → 인증 필요 API 호출 확인
- [ ] 운영 환경 배포 시 Swagger 노출 여부 논의 필요 (필요 시 `@Profile("!prod")` 적용 검토)