### PR TITLE
✨feat(profile): GET /api/profile/teams 팀 목록·상세 조회 구현

### DIFF
--- a/docs/db/profile/erd-cloud.sql
+++ b/docs/db/profile/erd-cloud.sql
@@ -5,7 +5,7 @@ CREATE TABLE member
     user_id           BIGINT       NOT NULL UNIQUE,
     name              VARCHAR(255) NOT NULL,
     department        VARCHAR(255),
-    session_type      ENUM ('backend','frontend','design','ai','pm','etc') NOT NULL,
+    session_type      VARCHAR(50) NOT NULL,
     profile_image_url TEXT,
     github_url        TEXT,
     displayed_email   TEXT,
@@ -37,7 +37,7 @@ CREATE TABLE member_generation
     id                BIGINT   NOT NULL AUTO_INCREMENT,
     member_id         BIGINT   NOT NULL,
     generation_number INT      NOT NULL,
-    role_in_gen       ENUM ('member','operating') NOT NULL DEFAULT 'member',
+    role_in_gen       VARCHAR(50) NOT NULL DEFAULT 'member',
     joined_at         DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (id),
     UNIQUE KEY uq_member_generation (member_id, generation_number),
@@ -50,7 +50,7 @@ CREATE TABLE tech_stack
 (
     id         BIGINT       NOT NULL AUTO_INCREMENT,
     name       VARCHAR(255) NOT NULL UNIQUE,
-    category   ENUM ('language','framework','ai','design','tool','infra','etc') NOT NULL,
+    category   VARCHAR(50) NOT NULL,
     logo_url   TEXT,
     created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (id)
@@ -106,7 +106,7 @@ CREATE TABLE team_member
     team_id    BIGINT   NOT NULL,
     member_id  BIGINT   NOT NULL,
     is_lead    BOOLEAN  NOT NULL DEFAULT FALSE,
-    status     ENUM ('pending','accepted','rejected','left','kicked') NOT NULL DEFAULT 'pending',
+    status     VARCHAR(50) NOT NULL DEFAULT 'pending',
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (id),
     UNIQUE KEY uq_team_member (team_id, member_id),
@@ -119,7 +119,7 @@ CREATE TABLE team_member_role
 (
     id             BIGINT NOT NULL AUTO_INCREMENT,
     team_member_id BIGINT NOT NULL,
-    role           ENUM ('backend','frontend','design','ai','pm','infra','etc') NOT NULL,
+    role           VARCHAR(50) NOT NULL,
     PRIMARY KEY (id),
     FOREIGN KEY (team_member_id) REFERENCES team_member (id) ON DELETE CASCADE
 );
@@ -140,7 +140,7 @@ CREATE TABLE activity
 (
     id           BIGINT   NOT NULL AUTO_INCREMENT,
     member_id    BIGINT   NOT NULL,
-    type         ENUM ('blog_post','blog_comment','blog_post_like','blog_post_like_received','qna_question','qna_answer','qna_accepted','qna_comment','session_speak','session_event_post','session_event_comment','session_event_post_like','session_event_post_like_received') NOT NULL,
+    type         VARCHAR(50) NOT NULL,
     reference_id BIGINT,
     actor_id     BIGINT,
     score        INT      NOT NULL DEFAULT 0,

--- a/docs/db/profile/migrations/2026-05-13-enum-to-varchar.sql
+++ b/docs/db/profile/migrations/2026-05-13-enum-to-varchar.sql
@@ -1,0 +1,47 @@
+-- native enum → VARCHAR(50) 마이그레이션
+-- 배경: Hibernate create-drop 테스트 환경에서 NAMED_ENUM 타입을 못 찾아 CI 실패
+-- contribution_period_type: 어떤 테이블 컬럼에도 사용되지 않음 (API 파라미터용 Java enum만 존재)
+-- activity.type: partial index(uq_activity_received, uq_activity_normal)가 enum 연산자 참조 → index 재생성 필요
+
+ALTER TABLE member ALTER COLUMN session_type TYPE VARCHAR(50) USING session_type::text;
+ALTER TABLE tech_stack ALTER COLUMN category TYPE VARCHAR(50) USING category::text;
+ALTER TABLE team_member ALTER COLUMN status TYPE VARCHAR(50) USING status::text;
+ALTER TABLE team_member_role ALTER COLUMN role TYPE VARCHAR(50) USING role::text;
+ALTER TABLE member_generation ALTER COLUMN role_in_gen TYPE VARCHAR(50) USING role_in_gen::text;
+
+-- activity.type: partial index 먼저 drop 후 ALTER, 재생성
+DROP INDEX IF EXISTS uq_activity_received;
+DROP INDEX IF EXISTS uq_activity_normal;
+ALTER TABLE activity ALTER COLUMN type TYPE VARCHAR(50) USING type::text;
+CREATE UNIQUE INDEX uq_activity_received ON activity (member_id, type, reference_id, actor_id)
+    WHERE type IN ('blog_post_like_received', 'session_event_post_like_received');
+CREATE UNIQUE INDEX uq_activity_normal ON activity (member_id, type, reference_id)
+    WHERE type NOT IN ('blog_post_like_received', 'session_event_post_like_received');
+
+-- DEFAULT 값이 enum 타입을 참조하므로 먼저 문자열 리터럴로 교체 후 DROP
+ALTER TABLE member_generation ALTER COLUMN role_in_gen SET DEFAULT 'member';
+ALTER TABLE team_member ALTER COLUMN status SET DEFAULT 'pending';
+
+DROP TYPE IF EXISTS session_type;
+DROP TYPE IF EXISTS generation_role;
+DROP TYPE IF EXISTS tech_stack_category;
+DROP TYPE IF EXISTS activity_type;
+DROP TYPE IF EXISTS contribution_period_type;
+DROP TYPE IF EXISTS role_in_team;
+DROP TYPE IF EXISTS team_member_status;
+
+-- ===================== 롤백 SQL =====================
+-- CREATE TYPE session_type AS ENUM ('backend','frontend','design','ai','pm','etc');
+-- CREATE TYPE generation_role AS ENUM ('member','operating');
+-- CREATE TYPE tech_stack_category AS ENUM ('language','framework','ai','design','tool','infra','etc');
+-- CREATE TYPE activity_type AS ENUM ('blog_post','blog_comment','blog_post_like','blog_post_like_received','qna_question','qna_answer','qna_accepted','qna_comment','session_speak','session_event_post','session_event_comment','session_event_post_like','session_event_post_like_received');
+-- CREATE TYPE contribution_period_type AS ENUM ('month','three_month','year','all');
+-- CREATE TYPE role_in_team AS ENUM ('backend','frontend','design','ai','pm','infra','etc');
+-- CREATE TYPE team_member_status AS ENUM ('pending','accepted','rejected','left','kicked');
+--
+-- ALTER TABLE member ALTER COLUMN session_type TYPE session_type USING session_type::session_type;
+-- ALTER TABLE activity ALTER COLUMN type TYPE activity_type USING type::activity_type;
+-- ALTER TABLE tech_stack ALTER COLUMN category TYPE tech_stack_category USING category::tech_stack_category;
+-- ALTER TABLE team_member ALTER COLUMN status TYPE team_member_status USING status::team_member_status;
+-- ALTER TABLE team_member_role ALTER COLUMN role TYPE role_in_team USING role::role_in_team;
+-- ALTER TABLE member_generation ALTER COLUMN role_in_gen TYPE generation_role USING role_in_gen::generation_role;

--- a/docs/db/profile/profile-ddl.sql
+++ b/docs/db/profile/profile-ddl.sql
@@ -1,20 +1,11 @@
--- 1. ENUM 타입 설정 (DB 레벨의 예외 방지)
-CREATE TYPE session_type AS ENUM ('backend', 'frontend', 'design', 'ai', 'pm', 'etc');
-CREATE TYPE generation_role AS ENUM ('member', 'operating');
-CREATE TYPE tech_stack_category AS ENUM ('language', 'framework', 'ai', 'design', 'tool', 'infra', 'etc');
-CREATE TYPE activity_type AS ENUM ('blog_post', 'blog_comment', 'blog_post_like', 'blog_post_like_received', 'qna_question', 'qna_answer', 'qna_accepted', 'qna_comment', 'session_speak', 'session_event_post', 'session_event_comment', 'session_event_post_like', 'session_event_post_like_received');
-CREATE TYPE contribution_period_type AS ENUM ('month', 'three_month', 'year', 'all');
-CREATE TYPE role_in_team AS ENUM ('backend', 'frontend', 'design', 'ai', 'pm', 'infra', 'etc');
-CREATE TYPE team_member_status AS ENUM ('pending', 'accepted', 'rejected', 'left', 'kicked');
-
--- 2. 핵심 테이블 생성 (PK: BIGINT / Long)
+-- 1. 핵심 테이블 생성 (PK: BIGINT / Long)
 -- 전제: users 테이블은 auth 팀 DDL이 먼저 생성해야 한다.
 CREATE TABLE member (
     id                BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     user_id           BIGINT NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
     name              TEXT NOT NULL,
     department        TEXT,
-    session_type      session_type NOT NULL,
+    session_type      VARCHAR(50) NOT NULL,
     profile_image_url TEXT,
     github_url        TEXT,
     displayed_email   TEXT,
@@ -40,7 +31,7 @@ CREATE TABLE member_generation (
     id                BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     member_id         BIGINT NOT NULL REFERENCES member(id) ON DELETE CASCADE,
     generation_number INT NOT NULL REFERENCES generation(number) ON DELETE CASCADE,
-    role_in_gen       generation_role NOT NULL DEFAULT 'member',
+    role_in_gen       VARCHAR(50) NOT NULL DEFAULT 'member',
     joined_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT uq_member_generation UNIQUE (member_id, generation_number)
 );
@@ -48,7 +39,7 @@ CREATE TABLE member_generation (
 CREATE TABLE tech_stack (
     id         BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     name       TEXT NOT NULL UNIQUE,
-    category   tech_stack_category NOT NULL,
+    category   VARCHAR(50) NOT NULL,
     logo_url   TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
@@ -87,7 +78,7 @@ CREATE TABLE team_member (
     team_id    BIGINT NOT NULL REFERENCES team_profile(id) ON DELETE CASCADE,
     member_id  BIGINT NOT NULL REFERENCES member(id) ON DELETE CASCADE,
     is_lead    BOOLEAN NOT NULL DEFAULT FALSE,
-    status     team_member_status NOT NULL DEFAULT 'pending',
+    status     VARCHAR(50) NOT NULL DEFAULT 'pending',
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT uq_team_member UNIQUE (team_id, member_id)
 );
@@ -95,7 +86,7 @@ CREATE TABLE team_member (
 CREATE TABLE team_member_role (
     id             BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     team_member_id BIGINT NOT NULL REFERENCES team_member(id) ON DELETE CASCADE,
-    role           role_in_team NOT NULL
+    role           VARCHAR(50) NOT NULL
 );
 
 CREATE TABLE team_image (
@@ -108,7 +99,7 @@ CREATE TABLE team_image (
 CREATE TABLE activity (
     id           BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     member_id    BIGINT NOT NULL REFERENCES member(id) ON DELETE CASCADE,
-    type         activity_type NOT NULL,
+    type         VARCHAR(50) NOT NULL,
     reference_id BIGINT,
     actor_id     BIGINT,
     score        INT NOT NULL DEFAULT 0,

--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -550,7 +550,7 @@ GET /profile/teams
 
 | 파라미터 | 타입 | 필수 | 설명 |
 |----------|------|------|------|
-| `generationId` | `number` | 아니오 | 기수 필터 |
+| `generationNumber` | `number` | 아니오 | 기수 필터 |
 
 **Response `200 OK`**
 ```json
@@ -559,7 +559,7 @@ GET /profile/teams
     "id": 1,
     "name": "헬스케어팀",
     "description": "건강 관리 앱을 만드는 팀입니다.",
-    "generation": { "id": 1, "label": "13기", "number": 13 },
+    "generation": { "number": 13 },
     "techStacks": [
       { "id": 1, "name": "Java", "category": "language", "logoUrl": "https://..." }
     ],
@@ -590,7 +590,7 @@ POST /profile/teams
   "description": "건강 관리 앱을 만드는 팀입니다.",
   "projectUrl": "https://...",
   "githubUrl": "https://github.com/...",
-  "generationId": 1,
+  "generationNumber": 13,
   "imageUrls": ["https://...", "https://..."],
   "techStackIds": [1, 2, 3]
 }
@@ -602,7 +602,7 @@ POST /profile/teams
 | `description` | `string` | 아니오 | — |
 | `projectUrl` | `string` | 아니오 | — |
 | `githubUrl` | `string` | 아니오 | — |
-| `generationId` | `number` | 아니오 | 존재하는 generation id |
+| `generationNumber` | `number` | 아니오 | 존재하는 generation number |
 | `imageUrls` | `string[]` | 아니오 | — |
 | `techStackIds` | `number[]` | 아니오 | 존재하는 tech_stack id 목록 |
 
@@ -631,7 +631,7 @@ GET /profile/teams/{teamId}
   "description": "건강 관리 앱을 만드는 팀입니다.",
   "projectUrl": "https://...",
   "githubUrl": "https://github.com/...",
-  "generation": { "id": 1, "label": "13기", "number": 13 },
+  "generation": { "number": 13 },
   "imageUrls": ["https://...", "https://..."],
   "techStacks": [
     { "id": 1, "name": "Java", "category": "language", "logoUrl": "https://..." }
@@ -643,14 +643,16 @@ GET /profile/teams/{teamId}
       "sessionType": "backend",
       "profileImageUrl": "https://...",
       "isLead": true,
-      "roles": ["backend", "infra"],
-      "status": "accepted"
+      "roles": ["backend", "infra"]
     }
   ],
-  "createdAt": "2025-05-01T10:00:00Z",
+  "inviteCode": "A1B2C3D4",
+  "inviteCodeExpiresAt": "2025-05-10T10:00:00Z",
   "updatedAt": "2025-05-07T10:00:00Z"
 }
 ```
+
+> `inviteCode` / `inviteCodeExpiresAt` 는 요청자가 해당 팀의 팀원(`accepted`)인 경우에만 반환되며, 그 외에는 `null`.
 
 ---
 
@@ -1003,9 +1005,9 @@ GET /profile/contributions/ranking
 | [ ] | `DELETE` | `/profile/tech-stacks/{techStackId}` | 기술 스택 삭제 (관리자) | 시현 |
 | [ ] | `GET` | `/profile/members/{memberId}/tech-stacks` | 멤버 기술 스택 조회 | 시현 |
 | [ ] | `PUT` | `/profile/members/me/tech-stacks` | 내 기술 스택 수정 | 시현 |
-| [ ] | `GET` | `/profile/teams` | 팀 목록 | 시현 |
+| ✅ | `GET` | `/profile/teams` | 팀 목록 | 시현 |
 | ✅ | `POST` | `/profile/teams` | 팀 생성 | 시현 |
-| [ ] | `GET` | `/profile/teams/{teamId}` | 팀 상세 | 시현 |
+| ✅ | `GET` | `/profile/teams/{teamId}` | 팀 상세 | 시현 |
 | [ ] | `PATCH` | `/profile/teams/{teamId}` | 팀 정보 수정 (팀장) | 시현 |
 | [ ] | `DELETE` | `/profile/teams/{teamId}` | 팀 삭제 (팀장) | 시현 |
 | [ ] | `GET` | `/profile/teams/{teamId}/invite-code` | 초대 코드 조회 (팀장) | 시현 |

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -1,10 +1,18 @@
 package com.study.profile.application;
 
+import com.study.profile.application.dto.TeamDto.GenerationSummary;
 import com.study.profile.application.dto.TeamDto.TeamCreateRequest;
 import com.study.profile.application.dto.TeamDto.TeamCreateResponse;
+import com.study.profile.application.dto.TeamDto.TeamDetailResponse;
+import com.study.profile.application.dto.TeamDto.TeamListResponse;
+import com.study.profile.application.dto.TeamDto.TeamMemberSummary;
+import com.study.profile.application.dto.TeamDto.TechStackSummary;
+import com.study.profile.domain.techstack.TeamTechStack;
 import com.study.profile.domain.generation.Generation;
 import com.study.profile.domain.member.Member;
+import com.study.profile.domain.team.TeamImage;
 import com.study.profile.domain.team.TeamMember;
+import com.study.profile.domain.team.TeamMemberStatus;
 import com.study.profile.domain.team.TeamProfile;
 import com.study.profile.domain.techstack.TechStack;
 import com.study.profile.infrastructure.GenerationRepository;
@@ -82,5 +90,98 @@ public class TeamService {
 
     return new TeamCreateResponse(
         team.getId(), team.getInviteCode(), team.getInviteCodeExpiresAt());
+  }
+
+  @Transactional(readOnly = true)
+  public List<TeamListResponse> getTeams(Integer generationNumber) {
+    List<TeamProfile> teams =
+        generationNumber != null
+            ? teamRepository.findByGenerationNumber(generationNumber)
+            : teamRepository.findAll();
+
+    return teams.stream().map(this::toListResponse).toList();
+  }
+
+  @Transactional(readOnly = true)
+  public TeamDetailResponse getTeamDetail(Long teamId, Long userId) {
+    TeamProfile team =
+        teamRepository
+            .findById(teamId)
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다."));
+
+    List<TeamMember> acceptedMembers =
+        teamMemberRepository.findByTeamIdAndStatus(teamId, TeamMemberStatus.accepted);
+
+    boolean isTeamMember =
+        userId != null
+            && acceptedMembers.stream()
+                .anyMatch(tm -> tm.getMember().getUser().getId().equals(userId));
+
+    GenerationSummary generation =
+        team.getGeneration() != null
+            ? new GenerationSummary(team.getGeneration().getNumber())
+            : null;
+
+    List<TechStackSummary> techStacks =
+        team.getTechStacks().stream()
+            .map(TeamTechStack::getTechStack)
+            .map(
+                ts ->
+                    new TechStackSummary(
+                        ts.getId(), ts.getName(), ts.getCategory().name(), ts.getLogoUrl()))
+            .toList();
+
+    List<String> imageUrls =
+        team.getImages().stream().map(TeamImage::getImageUrl).toList();
+
+    List<TeamMemberSummary> members =
+        acceptedMembers.stream()
+            .map(
+                tm ->
+                    new TeamMemberSummary(
+                        tm.getMember().getId(),
+                        tm.getMember().getName(),
+                        tm.getMember().getSessionType().name(),
+                        tm.getMember().getProfileImageUrl(),
+                        tm.isLead(),
+                        tm.getRoles().stream().map(r -> r.getRole().name()).toList()))
+            .toList();
+
+    return new TeamDetailResponse(
+        team.getId(),
+        team.getName(),
+        team.getDescription(),
+        team.getProjectUrl(),
+        team.getGithubUrl(),
+        generation,
+        techStacks,
+        imageUrls,
+        members,
+        isTeamMember ? team.getInviteCode() : null,
+        isTeamMember ? team.getInviteCodeExpiresAt() : null,
+        team.getUpdatedAt());
+  }
+
+  private TeamListResponse toListResponse(TeamProfile team) {
+    GenerationSummary generation =
+        team.getGeneration() != null
+            ? new GenerationSummary(team.getGeneration().getNumber())
+            : null;
+
+    List<TechStackSummary> techStacks =
+        team.getTechStacks().stream()
+            .map(TeamTechStack::getTechStack)
+            .map(ts -> new TechStackSummary(ts.getId(), ts.getName(), ts.getCategory().name(), ts.getLogoUrl()))
+            .toList();
+
+    String thumbUrl =
+        team.getImages().isEmpty() ? null : team.getImages().get(0).getImageUrl();
+
+    int memberCount = team.getMembers().size();
+
+    return new TeamListResponse(
+        team.getId(), team.getName(), team.getDescription(),
+        generation, techStacks, memberCount, thumbUrl);
   }
 }

--- a/src/main/java/com/study/profile/application/dto/TeamDto.java
+++ b/src/main/java/com/study/profile/application/dto/TeamDto.java
@@ -15,4 +15,39 @@ public class TeamDto {
       List<Long> techStackIds) {}
 
   public record TeamCreateResponse(Long id, String inviteCode, Instant inviteCodeExpiresAt) {}
+
+  public record GenerationSummary(Integer number) {}
+
+  public record TechStackSummary(Long id, String name, String category, String logoUrl) {}
+
+  public record TeamListResponse(
+      Long id,
+      String name,
+      String description,
+      GenerationSummary generation,
+      List<TechStackSummary> techStacks,
+      int memberCount,
+      String thumbUrl) {}
+
+  public record TeamMemberSummary(
+      Long memberId,
+      String name,
+      String sessionType,
+      String profileImageUrl,
+      boolean isLead,
+      List<String> roles) {}
+
+  public record TeamDetailResponse(
+      Long id,
+      String name,
+      String description,
+      String projectUrl,
+      String githubUrl,
+      GenerationSummary generation,
+      List<TechStackSummary> techStacks,
+      List<String> imageUrls,
+      List<TeamMemberSummary> members,
+      String inviteCode,
+      Instant inviteCodeExpiresAt,
+      Instant updatedAt) {}
 }

--- a/src/main/java/com/study/profile/domain/activity/Activity.java
+++ b/src/main/java/com/study/profile/domain/activity/Activity.java
@@ -17,8 +17,6 @@ import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
 /** 멤버 활동 이력 엔티티. 각 행 단위로 점수 부여 → 기여도 랭킹 산정에 활용. */
 @Entity
@@ -37,7 +35,6 @@ public class Activity {
   private Member member;
 
   @Enumerated(EnumType.STRING)
-  @JdbcTypeCode(SqlTypes.NAMED_ENUM)
   @Column(name = "type", nullable = false)
   private ActivityType type;
 

--- a/src/main/java/com/study/profile/domain/generation/MemberGeneration.java
+++ b/src/main/java/com/study/profile/domain/generation/MemberGeneration.java
@@ -18,8 +18,6 @@ import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
 /**
  * 멤버-기수 연결 엔티티 (중간 테이블).
@@ -58,7 +56,6 @@ public class MemberGeneration {
   private Generation generation; // 참여한 기수
 
   @Enumerated(EnumType.STRING)
-  @JdbcTypeCode(SqlTypes.NAMED_ENUM)
   @Column(name = "role_in_gen", nullable = false)
   private GenerationRole roleInGen = GenerationRole.member; // 해당 기수에서의 역할 (일반멤버/운영진)
 

--- a/src/main/java/com/study/profile/domain/member/Member.java
+++ b/src/main/java/com/study/profile/domain/member/Member.java
@@ -25,8 +25,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
 /**
  * 멤버(프로필) 엔티티.
@@ -65,7 +63,6 @@ public class Member {
   private String department;
 
   @Enumerated(EnumType.STRING)
-  @JdbcTypeCode(SqlTypes.NAMED_ENUM)
   @Column(name = "session_type", nullable = false)
   private SessionType sessionType;
 

--- a/src/main/java/com/study/profile/domain/team/TeamMember.java
+++ b/src/main/java/com/study/profile/domain/team/TeamMember.java
@@ -22,8 +22,6 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
 /**
  * 팀-멤버 연결 엔티티 (중간 테이블).
@@ -68,7 +66,6 @@ public class TeamMember {
   private boolean isLead = false; // 팀장 여부 (true면 팀장, false면 일반 팀원)
 
   @Enumerated(EnumType.STRING)
-  @JdbcTypeCode(SqlTypes.NAMED_ENUM)
   @Column(name = "status", nullable = false)
   private TeamMemberStatus status; // 팀원 가입 상태 (pending/accepted/rejected/left/kicked)
 

--- a/src/main/java/com/study/profile/domain/team/TeamMemberRole.java
+++ b/src/main/java/com/study/profile/domain/team/TeamMemberRole.java
@@ -14,8 +14,6 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
 /**
  * 팀원 역할 엔티티.
@@ -45,7 +43,6 @@ public class TeamMemberRole {
   private TeamMember teamMember;
 
   @Enumerated(EnumType.STRING)
-  @JdbcTypeCode(SqlTypes.NAMED_ENUM)
   @Column(name = "role", nullable = false)
   private RoleInTeam role; // 역할 분야 (backend/frontend/design/ai/pm/infra/etc)
 

--- a/src/main/java/com/study/profile/domain/team/TeamProfile.java
+++ b/src/main/java/com/study/profile/domain/team/TeamProfile.java
@@ -76,6 +76,9 @@ public class TeamProfile {
   @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<TeamImage> images = new ArrayList<>();
 
+  @OneToMany(mappedBy = "team")
+  private List<TeamMember> members = new ArrayList<>();
+
   /**
    * 이미지들을 추가하는 메서드
    *

--- a/src/main/java/com/study/profile/domain/techstack/TechStack.java
+++ b/src/main/java/com/study/profile/domain/techstack/TechStack.java
@@ -14,8 +14,6 @@ import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
 /**
  * 기술 스택 엔티티.
@@ -48,7 +46,6 @@ public class TechStack {
   private String name; // 기술 스택 이름 (예: "Java", "React") — 중복 불가
 
   @Enumerated(EnumType.STRING)
-  @JdbcTypeCode(SqlTypes.NAMED_ENUM)
   @Column(name = "category", nullable = false)
   private TechStackCategory category; // 분류 (language/framework/ai/design/tool/infra/etc)
 

--- a/src/main/java/com/study/profile/infrastructure/TeamMemberRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/TeamMemberRepository.java
@@ -1,6 +1,11 @@
 package com.study.profile.infrastructure;
 
 import com.study.profile.domain.team.TeamMember;
+import com.study.profile.domain.team.TeamMemberStatus;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {}
+public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
+
+  List<TeamMember> findByTeamIdAndStatus(Long teamId, TeamMemberStatus status);
+}

--- a/src/main/java/com/study/profile/infrastructure/TeamRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/TeamRepository.java
@@ -1,10 +1,13 @@
 package com.study.profile.infrastructure;
 
 import com.study.profile.domain.team.TeamProfile;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamRepository extends JpaRepository<TeamProfile, Long> {
 
   Optional<TeamProfile> findByInviteCode(String inviteCode);
+
+  List<TeamProfile> findByGenerationNumber(Integer generationNumber);
 }

--- a/src/main/java/com/study/profile/presentation/TeamController.java
+++ b/src/main/java/com/study/profile/presentation/TeamController.java
@@ -5,13 +5,19 @@ import com.study.auth.infrastructure.security.CustomUserDetails;
 import com.study.profile.application.TeamService;
 import com.study.profile.application.dto.TeamDto.TeamCreateRequest;
 import com.study.profile.application.dto.TeamDto.TeamCreateResponse;
+import com.study.profile.application.dto.TeamDto.TeamDetailResponse;
+import com.study.profile.application.dto.TeamDto.TeamListResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -20,6 +26,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class TeamController {
 
   private final TeamService teamService;
+
+  @GetMapping
+  public ResponseEntity<List<TeamListResponse>> getTeams(
+      @RequestParam(required = false) Integer generationNumber) {
+    return ResponseEntity.ok(teamService.getTeams(generationNumber));
+  }
+
+  @GetMapping("/{teamId}")
+  public ResponseEntity<TeamDetailResponse> getTeamDetail(
+      @PathVariable Long teamId, @CurrentUser CustomUserDetails user) {
+    Long userId = user != null ? user.userId() : null;
+    return ResponseEntity.ok(teamService.getTeamDetail(teamId, userId));
+  }
 
   @PostMapping
   @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")

--- a/src/main/java/com/study/shared/config/SecurityConfig.java
+++ b/src/main/java/com/study/shared/config/SecurityConfig.java
@@ -67,7 +67,9 @@ public class SecurityConfig {
                         "/api/blog/posts",
                         "/api/blog/posts/**",
                         "/api/profile/tech-stacks",
-                        "/api/profile/tech-stacks/**")
+                        "/api/profile/tech-stacks/**",
+                        "/api/profile/teams",
+                        "/api/profile/teams/**")
                     .permitAll()
                     .anyRequest()
                     .authenticated())

--- a/src/test/java/com/study/blog/integration/TestAuth.java
+++ b/src/test/java/com/study/blog/integration/TestAuth.java
@@ -15,7 +15,7 @@ final class TestAuth {
   static RequestPostProcessor asMember(Long userId) {
     return SecurityMockMvcRequestPostProcessors.authentication(
         new UsernamePasswordAuthenticationToken(
-            new CustomUserDetails(userId, UserRole.MEMBER),
+            new CustomUserDetails(userId, UserRole.MEMBER, ""),
             null,
             List.of(new SimpleGrantedAuthority("ROLE_MEMBER"))));
   }
@@ -23,7 +23,7 @@ final class TestAuth {
   static RequestPostProcessor asAdmin(Long userId) {
     return SecurityMockMvcRequestPostProcessors.authentication(
         new UsernamePasswordAuthenticationToken(
-            new CustomUserDetails(userId, UserRole.ADMIN),
+            new CustomUserDetails(userId, UserRole.ADMIN, ""),
             null,
             List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))));
   }


### PR DESCRIPTION
 ## WHAT
  - `GET /api/profile/teams` — 전체 팀 목록 조회 (generationNumber 필터 선택)
  - `GET /api/profile/teams/{teamId}` — 팀 상세 조회
    - `inviteCode` / `inviteCodeExpiresAt` : 팀원(accepted)만 응답에 포함
    - 응답에 `sessionType`, `updatedAt` 추가
  - 두 엔드포인트 모두 비인증 사용자도 접근 가능 (SecurityConfig permitAll)

  ## HOW
  - `TeamMemberRepository.findByTeamIdAndStatus()` 로 accepted 멤버만 조회
  - `TeamRepository.findByGenerationNumber()` 로 기수 필터
  - `TeamProfile`에 `@OneToMany members` 추가 (목록 조회 시 memberCount 계산용)
  - `GenerationSummary` 에서 label 제거, number만 반환


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added team listing functionality with optional generation filtering
  * Added team detail view displaying members, tech stacks, images, and project links
  * Team members can now access invite codes from team details

* **API Updates**
  * Simplified generation representation in team responses
  * Made team endpoints publicly accessible without authentication

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/likelion-khu-BE/tech-blog-be/pull/72)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->