### PR TITLE
feat : 이벤트 자식 레코드 부모ID 추가 & QnA 답변 vote 활동 이벤트 추가

### DIFF
--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -55,12 +55,14 @@
 ### ActivityType
 ```
 "blog_post" | "blog_comment" | "blog_post_like" | "blog_post_like_received" |
-"qna_question" | "qna_answer" | "qna_accepted" | "qna_comment" |
+"qna_question" | "qna_answer" | "qna_accepted" | "qna_answer_upvote" |
+"qna_answer_downvote" | "qna_comment" |
 "session_speak" | "session_event_post" | "session_event_comment" |
 "session_event_post_like" | "session_event_post_like_received"
 ```
 
 > 좋아요는 양방향 — 누른 사람(`*_like`) / 받은 사람(`*_like_received`) 별도.
+> Q&A 답변 vote는 참여 자체로 활동(+1) — upvote/downvote 무관. 답변 받는 측엔 활동 X (채택 시스템이 별도 보상).
 
 ### ContributionPeriodType
 ```
@@ -860,6 +862,8 @@ DELETE /profile/teams/{teamId}/members/me
 | `qna_question` | +10 |
 | `qna_answer` | +10 |
 | `qna_accepted` | +25 |
+| `qna_answer_upvote` | +1 |
+| `qna_answer_downvote` | +1 |
 | `qna_comment` | +3 |
 | `session_speak` | +50 |
 | `session_event_post` | +30 |

--- a/src/main/java/com/study/profile/application/activity/ActivityEventListener.java
+++ b/src/main/java/com/study/profile/application/activity/ActivityEventListener.java
@@ -10,7 +10,11 @@ import com.study.shared.extevent.blog.BlogPostUnliked;
 import com.study.shared.extevent.qna.QnaAnswerAccepted;
 import com.study.shared.extevent.qna.QnaAnswerCreated;
 import com.study.shared.extevent.qna.QnaAnswerDeleted;
+import com.study.shared.extevent.qna.QnaAnswerDownvoteWithdrawn;
+import com.study.shared.extevent.qna.QnaAnswerDownvoted;
 import com.study.shared.extevent.qna.QnaAnswerUnaccepted;
+import com.study.shared.extevent.qna.QnaAnswerUpvoteWithdrawn;
+import com.study.shared.extevent.qna.QnaAnswerUpvoted;
 import com.study.shared.extevent.qna.QnaCommentCreated;
 import com.study.shared.extevent.qna.QnaCommentDeleted;
 import com.study.shared.extevent.qna.QnaQuestionCreated;
@@ -129,6 +133,18 @@ public class ActivityEventListener {
 
   @Async
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void onQnaAnswerUpvoted(QnaAnswerUpvoted event) {
+    activityService.record(event.voterId(), ActivityType.qna_answer_upvote, event.answerId());
+  }
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void onQnaAnswerDownvoted(QnaAnswerDownvoted event) {
+    activityService.record(event.voterId(), ActivityType.qna_answer_downvote, event.answerId());
+  }
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void onQnaCommentCreated(QnaCommentCreated event) {
     activityService.record(event.userId(), ActivityType.qna_comment, event.commentId());
   }
@@ -145,12 +161,26 @@ public class ActivityEventListener {
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void onQnaAnswerDeleted(QnaAnswerDeleted event) {
     activityService.revoke(ActivityType.qna_answer, event.answerId());
+    activityService.revoke(ActivityType.qna_answer_upvote, event.answerId());
+    activityService.revoke(ActivityType.qna_answer_downvote, event.answerId());
   }
 
   @Async
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void onQnaAnswerUnaccepted(QnaAnswerUnaccepted event) {
     activityService.revoke(ActivityType.qna_accepted, event.answerId());
+  }
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void onQnaAnswerUpvoteWithdrawn(QnaAnswerUpvoteWithdrawn event) {
+    activityService.revokeLike(ActivityType.qna_answer_upvote, event.answerId(), event.voterId());
+  }
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void onQnaAnswerDownvoteWithdrawn(QnaAnswerDownvoteWithdrawn event) {
+    activityService.revokeLike(ActivityType.qna_answer_downvote, event.answerId(), event.voterId());
   }
 
   @Async

--- a/src/main/java/com/study/profile/domain/activity/ActivityType.java
+++ b/src/main/java/com/study/profile/domain/activity/ActivityType.java
@@ -17,6 +17,8 @@ public enum ActivityType {
   qna_question(10),
   qna_answer(10),
   qna_accepted(25),
+  qna_answer_upvote(1),
+  qna_answer_downvote(1),
   qna_comment(3),
   session_speak(50),
   session_event_post(30),

--- a/src/main/java/com/study/shared/extevent/blog/BlogCommentCreated.java
+++ b/src/main/java/com/study/shared/extevent/blog/BlogCommentCreated.java
@@ -4,6 +4,7 @@ package com.study.shared.extevent.blog;
  * 블로그 댓글 작성 사건.
  *
  * @param userId 작성자 (auth.User.id)
+ * @param postId 댓글이 달린 글 (consumer가 활동 응답 라우팅에 사용)
  * @param commentId 작성된 댓글
  */
-public record BlogCommentCreated(Long userId, Long commentId) {}
+public record BlogCommentCreated(Long userId, Long postId, Long commentId) {}

--- a/src/main/java/com/study/shared/extevent/blog/BlogCommentDeleted.java
+++ b/src/main/java/com/study/shared/extevent/blog/BlogCommentDeleted.java
@@ -4,6 +4,7 @@ package com.study.shared.extevent.blog;
  * 블로그 댓글 삭제 사건.
  *
  * @param userId 작성자 (auth.User.id)
+ * @param postId 댓글이 달린 글 (consumer 활용은 자유 — 시그니처 일관 유지용)
  * @param commentId 삭제된 댓글
  */
-public record BlogCommentDeleted(Long userId, Long commentId) {}
+public record BlogCommentDeleted(Long userId, Long postId, Long commentId) {}

--- a/src/main/java/com/study/shared/extevent/blog/README.md
+++ b/src/main/java/com/study/shared/extevent/blog/README.md
@@ -6,8 +6,8 @@
 |---|---|---|
 | `BlogPostCreated` | 글 저장 직후 | `(userId, postId)` |
 | `BlogPostDeleted` | 글 삭제 직후 | `(userId, postId)` |
-| `BlogCommentCreated` | 댓글 저장 직후 | `(userId, commentId)` |
-| `BlogCommentDeleted` | 댓글 삭제 직후 | `(userId, commentId)` |
+| `BlogCommentCreated` | 댓글 저장 직후 | `(userId, postId, commentId)` |
+| `BlogCommentDeleted` | 댓글 삭제 직후 | `(userId, postId, commentId)` |
 | `BlogPostLiked` | 좋아요 켜질 때 | `(likerId, postId, postOwnerId)` |
 | `BlogPostUnliked` | 좋아요 꺼질 때 | `(likerId, postId, postOwnerId)` |
 

--- a/src/main/java/com/study/shared/extevent/qna/QnaAnswerAccepted.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaAnswerAccepted.java
@@ -4,6 +4,7 @@ package com.study.shared.extevent.qna;
  * QnA 답변 채택 사건. userId는 채택된 답변 작성자 (점수 받는 사람).
  *
  * @param userId 답변 작성자 (auth.User.id)
+ * @param questionId 답변이 달린 질문 (consumer가 활동 응답 라우팅에 사용)
  * @param answerId 채택된 답변
  */
-public record QnaAnswerAccepted(Long userId, Long answerId) {}
+public record QnaAnswerAccepted(Long userId, Long questionId, Long answerId) {}

--- a/src/main/java/com/study/shared/extevent/qna/QnaAnswerCreated.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaAnswerCreated.java
@@ -4,6 +4,7 @@ package com.study.shared.extevent.qna;
  * QnA 답변 작성 사건.
  *
  * @param userId 작성자 (auth.User.id)
+ * @param questionId 답변이 달린 질문 (consumer가 활동 응답 라우팅에 사용)
  * @param answerId 작성된 답변
  */
-public record QnaAnswerCreated(Long userId, Long answerId) {}
+public record QnaAnswerCreated(Long userId, Long questionId, Long answerId) {}

--- a/src/main/java/com/study/shared/extevent/qna/QnaAnswerDeleted.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaAnswerDeleted.java
@@ -4,6 +4,7 @@ package com.study.shared.extevent.qna;
  * QnA 답변 삭제 사건.
  *
  * @param userId 작성자 (auth.User.id)
+ * @param questionId 답변이 달린 질문 (consumer 활용은 자유 — 시그니처 일관 유지용)
  * @param answerId 삭제된 답변
  */
-public record QnaAnswerDeleted(Long userId, Long answerId) {}
+public record QnaAnswerDeleted(Long userId, Long questionId, Long answerId) {}

--- a/src/main/java/com/study/shared/extevent/qna/QnaAnswerDownvoteWithdrawn.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaAnswerDownvoteWithdrawn.java
@@ -1,0 +1,15 @@
+package com.study.shared.extevent.qna;
+
+/**
+ * QnA 답변 비추천(downvote) 탈출 사건.
+ *
+ * <p>발행 시점: Vote가 downvote 상태에서 빠져나갈 때 — 직접 취소 또는 downvote → upvote 전환. 전환의 경우 {@link
+ * QnaAnswerUpvoted}도 같이 발행.
+ *
+ * <p>답변 삭제 시 vote 일괄 제거는 별도 발행 불필요 — consumer가 {@link QnaAnswerDeleted}를 받아 cascade 처리.
+ *
+ * @param voterId 비추천 취소한 사람 (auth.User.id)
+ * @param questionId 답변이 달린 질문 (consumer가 활동 응답 라우팅에 사용)
+ * @param answerId 대상 답변
+ */
+public record QnaAnswerDownvoteWithdrawn(Long voterId, Long questionId, Long answerId) {}

--- a/src/main/java/com/study/shared/extevent/qna/QnaAnswerDownvoted.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaAnswerDownvoted.java
@@ -1,0 +1,15 @@
+package com.study.shared.extevent.qna;
+
+/**
+ * QnA 답변 비추천(downvote) 진입 사건.
+ *
+ * <p>발행 시점: Vote가 downvote 상태로 들어올 때 — 신규 downvote 생성 또는 upvote → downvote 전환. 전환의 경우 {@link
+ * QnaAnswerUpvoteWithdrawn}도 같이 발행.
+ *
+ * <p>활동 type: {@code qna_answer_downvote} (+1). 답변 퀄리티 평가는 채택 시스템이 별도로 처리하므로 답변 받는 측엔 활동 X.
+ *
+ * @param voterId 비추천 누른 사람 (auth.User.id)
+ * @param questionId 답변이 달린 질문 (consumer가 활동 응답 라우팅에 사용)
+ * @param answerId 대상 답변
+ */
+public record QnaAnswerDownvoted(Long voterId, Long questionId, Long answerId) {}

--- a/src/main/java/com/study/shared/extevent/qna/QnaAnswerUnaccepted.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaAnswerUnaccepted.java
@@ -4,6 +4,7 @@ package com.study.shared.extevent.qna;
  * QnA 답변 채택 취소 사건. userId는 답변 작성자 (점수 회수되는 사람).
  *
  * @param userId 답변 작성자 (auth.User.id)
+ * @param questionId 답변이 달린 질문 (consumer 활용은 자유 — 시그니처 일관 유지용)
  * @param answerId 채택 취소된 답변
  */
-public record QnaAnswerUnaccepted(Long userId, Long answerId) {}
+public record QnaAnswerUnaccepted(Long userId, Long questionId, Long answerId) {}

--- a/src/main/java/com/study/shared/extevent/qna/QnaAnswerUpvoteWithdrawn.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaAnswerUpvoteWithdrawn.java
@@ -1,0 +1,15 @@
+package com.study.shared.extevent.qna;
+
+/**
+ * QnA 답변 추천(upvote) 탈출 사건.
+ *
+ * <p>발행 시점: Vote가 upvote 상태에서 빠져나갈 때 — 직접 취소 또는 upvote → downvote 전환. 전환의 경우 {@link
+ * QnaAnswerDownvoted}도 같이 발행.
+ *
+ * <p>답변 삭제 시 vote 일괄 제거는 별도 발행 불필요 — consumer가 {@link QnaAnswerDeleted}를 받아 cascade 처리.
+ *
+ * @param voterId 추천 취소한 사람 (auth.User.id)
+ * @param questionId 답변이 달린 질문 (consumer가 활동 응답 라우팅에 사용)
+ * @param answerId 대상 답변
+ */
+public record QnaAnswerUpvoteWithdrawn(Long voterId, Long questionId, Long answerId) {}

--- a/src/main/java/com/study/shared/extevent/qna/QnaAnswerUpvoted.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaAnswerUpvoted.java
@@ -1,0 +1,15 @@
+package com.study.shared.extevent.qna;
+
+/**
+ * QnA 답변 추천(upvote) 진입 사건.
+ *
+ * <p>발행 시점: Vote가 upvote 상태로 들어올 때 — 신규 upvote 생성 또는 downvote → upvote 전환. 전환의 경우 {@link
+ * QnaAnswerDownvoteWithdrawn}도 같이 발행.
+ *
+ * <p>활동 type: {@code qna_answer_upvote} (+1).
+ *
+ * @param voterId 추천 누른 사람 (auth.User.id)
+ * @param questionId 답변이 달린 질문 (consumer가 활동 응답 라우팅에 사용)
+ * @param answerId 대상 답변
+ */
+public record QnaAnswerUpvoted(Long voterId, Long questionId, Long answerId) {}

--- a/src/main/java/com/study/shared/extevent/qna/QnaCommentCreated.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaCommentCreated.java
@@ -1,9 +1,11 @@
 package com.study.shared.extevent.qna;
 
 /**
- * QnA 댓글 작성 사건.
+ * QnA 댓글 작성 사건. 질문 댓글 또는 답변 댓글 둘 다 처리.
  *
  * @param userId 작성자 (auth.User.id)
+ * @param questionId 댓글이 속한 질문 (질문 댓글: 직접 / 답변 댓글: 답변의 부모 질문)
+ * @param answerId 답변 댓글이면 그 답변의 id, 질문 댓글이면 null
  * @param commentId 작성된 댓글
  */
-public record QnaCommentCreated(Long userId, Long commentId) {}
+public record QnaCommentCreated(Long userId, Long questionId, Long answerId, Long commentId) {}

--- a/src/main/java/com/study/shared/extevent/qna/QnaCommentDeleted.java
+++ b/src/main/java/com/study/shared/extevent/qna/QnaCommentDeleted.java
@@ -1,9 +1,11 @@
 package com.study.shared.extevent.qna;
 
 /**
- * QnA 댓글 삭제 사건.
+ * QnA 댓글 삭제 사건. 질문 댓글 또는 답변 댓글 둘 다 처리.
  *
  * @param userId 작성자 (auth.User.id)
+ * @param questionId 댓글이 속한 질문 (질문 댓글: 직접 / 답변 댓글: 답변의 부모 질문)
+ * @param answerId 답변 댓글이면 그 답변의 id, 질문 댓글이면 null
  * @param commentId 삭제된 댓글
  */
-public record QnaCommentDeleted(Long userId, Long commentId) {}
+public record QnaCommentDeleted(Long userId, Long questionId, Long answerId, Long commentId) {}

--- a/src/main/java/com/study/shared/extevent/qna/README.md
+++ b/src/main/java/com/study/shared/extevent/qna/README.md
@@ -2,15 +2,23 @@
 
 QnA BC가 발행하는 도메인 사건 record.
 
+> 시그니처 컬럼 순서 규칙: **actor → 부모(트리 깊이 순) → 자식(자체 ID)**
+
 | record | 발행 시점 | 시그니처 |
 |---|---|---|
 | `QnaQuestionCreated` | 질문 저장 직후 | `(userId, questionId)` |
 | `QnaQuestionDeleted` | 질문 삭제 직후 | `(userId, questionId)` |
-| `QnaAnswerCreated` | 답변 저장 직후 | `(userId, answerId)` |
-| `QnaAnswerDeleted` | 답변 삭제 직후 | `(userId, answerId)` |
-| `QnaAnswerAccepted` | 답변 채택 시 | `(userId, answerId)` ※ userId = 답변 작성자 |
-| `QnaAnswerUnaccepted` | 채택 취소 시 | `(userId, answerId)` ※ userId = 답변 작성자 |
-| `QnaCommentCreated` | 댓글 저장 직후 | `(userId, commentId)` |
-| `QnaCommentDeleted` | 댓글 삭제 직후 | `(userId, commentId)` |
+| `QnaAnswerCreated` | 답변 저장 직후 | `(userId, questionId, answerId)` |
+| `QnaAnswerDeleted` | 답변 삭제 직후 | `(userId, questionId, answerId)` |
+| `QnaAnswerAccepted` | 답변 채택 시 | `(userId, questionId, answerId)` ※ userId = 답변 작성자 |
+| `QnaAnswerUnaccepted` | 채택 취소 시 | `(userId, questionId, answerId)` ※ userId = 답변 작성자 |
+| `QnaAnswerUpvoted` | Vote가 upvote 상태로 진입 (신규 upvote / downvote → upvote 전환) | `(voterId, questionId, answerId)` |
+| `QnaAnswerDownvoted` | Vote가 downvote 상태로 진입 (신규 downvote / upvote → downvote 전환) | `(voterId, questionId, answerId)` |
+| `QnaAnswerUpvoteWithdrawn` | Vote가 upvote 상태에서 탈출 (직접 취소 / upvote → downvote 전환) | `(voterId, questionId, answerId)` |
+| `QnaAnswerDownvoteWithdrawn` | Vote가 downvote 상태에서 탈출 (직접 취소 / downvote → upvote 전환) | `(voterId, questionId, answerId)` |
+| `QnaCommentCreated` | 댓글 저장 직후 | `(userId, questionId, answerId, commentId)` ※ 질문 댓글이면 answerId=null, 답변 댓글이면 그 답변의 id |
+| `QnaCommentDeleted` | 댓글 삭제 직후 | `(userId, questionId, answerId, commentId)` ※ 동일 |
+
+Answer 사건 시리즈는 시그니처 일관을 위해 모두 `questionId` 포함 (cascade 트리거 이벤트도 동일).
 
 작성 규칙: [docs/conventions/통합-이벤트.md](../../../../../../../../docs/conventions/통합-이벤트.md)

--- a/src/main/java/com/study/shared/extevent/sessionboard/README.md
+++ b/src/main/java/com/study/shared/extevent/sessionboard/README.md
@@ -6,8 +6,8 @@ sessionboard BC가 발행하는 도메인 사건 record.
 |---|---|---|
 | `SessionEventPostCreated` | EventPost 저장 직후 | `(userId, postId)` |
 | `SessionEventPostDeleted` | EventPost 삭제 직후 | `(userId, postId)` |
-| `SessionEventCommentCreated` | EventPostComment 저장 직후 | `(userId, commentId)` |
-| `SessionEventCommentDeleted` | EventPostComment 삭제 직후 | `(userId, commentId)` |
+| `SessionEventCommentCreated` | EventPostComment 저장 직후 | `(userId, postId, commentId)` |
+| `SessionEventCommentDeleted` | EventPostComment 삭제 직후 | `(userId, postId, commentId)` |
 | `SessionEventPostLiked` | 좋아요 켜질 때 | `(likerId, postId, postOwnerId)` |
 | `SessionEventPostUnliked` | 좋아요 꺼질 때 | `(likerId, postId, postOwnerId)` |
 | `SessionSpeakerRegistered` | 발표자 등록 시 | `(userId, sessionId)` |

--- a/src/main/java/com/study/shared/extevent/sessionboard/SessionEventCommentCreated.java
+++ b/src/main/java/com/study/shared/extevent/sessionboard/SessionEventCommentCreated.java
@@ -4,6 +4,7 @@ package com.study.shared.extevent.sessionboard;
  * 행사 게시글 댓글 작성 사건.
  *
  * @param userId 작성자 (auth.User.id)
+ * @param postId 댓글이 달린 행사 게시글 (consumer가 활동 응답 라우팅에 사용)
  * @param commentId 작성된 댓글
  */
-public record SessionEventCommentCreated(Long userId, Long commentId) {}
+public record SessionEventCommentCreated(Long userId, Long postId, Long commentId) {}

--- a/src/main/java/com/study/shared/extevent/sessionboard/SessionEventCommentDeleted.java
+++ b/src/main/java/com/study/shared/extevent/sessionboard/SessionEventCommentDeleted.java
@@ -4,6 +4,7 @@ package com.study.shared.extevent.sessionboard;
  * 행사 게시글 댓글 삭제 사건.
  *
  * @param userId 작성자 (auth.User.id)
+ * @param postId 댓글이 달린 행사 게시글 (consumer 활용은 자유 — 시그니처 일관 유지용)
  * @param commentId 삭제된 댓글
  */
-public record SessionEventCommentDeleted(Long userId, Long commentId) {}
+public record SessionEventCommentDeleted(Long userId, Long postId, Long commentId) {}

--- a/src/test/java/com/study/profile/application/activity/ActivityEventListenerTest.java
+++ b/src/test/java/com/study/profile/application/activity/ActivityEventListenerTest.java
@@ -13,7 +13,11 @@ import com.study.shared.extevent.blog.BlogPostUnliked;
 import com.study.shared.extevent.qna.QnaAnswerAccepted;
 import com.study.shared.extevent.qna.QnaAnswerCreated;
 import com.study.shared.extevent.qna.QnaAnswerDeleted;
+import com.study.shared.extevent.qna.QnaAnswerDownvoteWithdrawn;
+import com.study.shared.extevent.qna.QnaAnswerDownvoted;
 import com.study.shared.extevent.qna.QnaAnswerUnaccepted;
+import com.study.shared.extevent.qna.QnaAnswerUpvoteWithdrawn;
+import com.study.shared.extevent.qna.QnaAnswerUpvoted;
 import com.study.shared.extevent.qna.QnaCommentCreated;
 import com.study.shared.extevent.qna.QnaCommentDeleted;
 import com.study.shared.extevent.qna.QnaQuestionCreated;
@@ -56,7 +60,7 @@ class ActivityEventListenerTest {
     @Test
     @DisplayName("BlogCommentCreated → record(userId, blog_comment, commentId)")
     void onBlogCommentCreated() {
-      listener.onBlogCommentCreated(new BlogCommentCreated(1L, 7L));
+      listener.onBlogCommentCreated(new BlogCommentCreated(1L, 42L, 7L));
 
       then(activityService).should().record(1L, ActivityType.blog_comment, 7L);
     }
@@ -88,7 +92,7 @@ class ActivityEventListenerTest {
     @Test
     @DisplayName("BlogCommentDeleted → revoke(blog_comment, commentId)")
     void onBlogCommentDeleted() {
-      listener.onBlogCommentDeleted(new BlogCommentDeleted(1L, 7L));
+      listener.onBlogCommentDeleted(new BlogCommentDeleted(1L, 42L, 7L));
 
       then(activityService).should().revoke(ActivityType.blog_comment, 7L);
     }
@@ -120,7 +124,7 @@ class ActivityEventListenerTest {
     @Test
     @DisplayName("QnaAnswerCreated → record(userId, qna_answer, answerId)")
     void onQnaAnswerCreated() {
-      listener.onQnaAnswerCreated(new QnaAnswerCreated(1L, 20L));
+      listener.onQnaAnswerCreated(new QnaAnswerCreated(1L, 100L, 20L));
 
       then(activityService).should().record(1L, ActivityType.qna_answer, 20L);
     }
@@ -128,15 +132,31 @@ class ActivityEventListenerTest {
     @Test
     @DisplayName("QnaAnswerAccepted → record(답변자, qna_accepted, answerId)")
     void onQnaAnswerAccepted() {
-      listener.onQnaAnswerAccepted(new QnaAnswerAccepted(5L, 20L));
+      listener.onQnaAnswerAccepted(new QnaAnswerAccepted(5L, 100L, 20L));
 
       then(activityService).should().record(5L, ActivityType.qna_accepted, 20L);
     }
 
     @Test
+    @DisplayName("QnaAnswerUpvoted → record(voterId, qna_answer_upvote, answerId)")
+    void onQnaAnswerUpvoted() {
+      listener.onQnaAnswerUpvoted(new QnaAnswerUpvoted(99L, 100L, 20L));
+
+      then(activityService).should().record(99L, ActivityType.qna_answer_upvote, 20L);
+    }
+
+    @Test
+    @DisplayName("QnaAnswerDownvoted → record(voterId, qna_answer_downvote, answerId)")
+    void onQnaAnswerDownvoted() {
+      listener.onQnaAnswerDownvoted(new QnaAnswerDownvoted(99L, 100L, 20L));
+
+      then(activityService).should().record(99L, ActivityType.qna_answer_downvote, 20L);
+    }
+
+    @Test
     @DisplayName("QnaCommentCreated → record(userId, qna_comment, commentId)")
     void onQnaCommentCreated() {
-      listener.onQnaCommentCreated(new QnaCommentCreated(1L, 30L));
+      listener.onQnaCommentCreated(new QnaCommentCreated(1L, 10L, null, 30L));
 
       then(activityService).should().record(1L, ActivityType.qna_comment, 30L);
     }
@@ -155,25 +175,44 @@ class ActivityEventListenerTest {
     }
 
     @Test
-    @DisplayName("QnaAnswerDeleted → revoke(qna_answer, answerId)")
+    @DisplayName(
+        "QnaAnswerDeleted → revoke(qna_answer) + revoke(qna_answer_upvote) + revoke(qna_answer_downvote) cascade")
     void onQnaAnswerDeleted() {
-      listener.onQnaAnswerDeleted(new QnaAnswerDeleted(1L, 20L));
+      listener.onQnaAnswerDeleted(new QnaAnswerDeleted(1L, 100L, 20L));
 
       then(activityService).should().revoke(ActivityType.qna_answer, 20L);
+      then(activityService).should().revoke(ActivityType.qna_answer_upvote, 20L);
+      then(activityService).should().revoke(ActivityType.qna_answer_downvote, 20L);
     }
 
     @Test
     @DisplayName("QnaAnswerUnaccepted → revoke(qna_accepted, answerId)")
     void onQnaAnswerUnaccepted() {
-      listener.onQnaAnswerUnaccepted(new QnaAnswerUnaccepted(5L, 20L));
+      listener.onQnaAnswerUnaccepted(new QnaAnswerUnaccepted(5L, 100L, 20L));
 
       then(activityService).should().revoke(ActivityType.qna_accepted, 20L);
     }
 
     @Test
+    @DisplayName("QnaAnswerUpvoteWithdrawn → revokeLike(qna_answer_upvote, answerId, voterId)")
+    void onQnaAnswerUpvoteWithdrawn() {
+      listener.onQnaAnswerUpvoteWithdrawn(new QnaAnswerUpvoteWithdrawn(99L, 100L, 20L));
+
+      then(activityService).should().revokeLike(ActivityType.qna_answer_upvote, 20L, 99L);
+    }
+
+    @Test
+    @DisplayName("QnaAnswerDownvoteWithdrawn → revokeLike(qna_answer_downvote, answerId, voterId)")
+    void onQnaAnswerDownvoteWithdrawn() {
+      listener.onQnaAnswerDownvoteWithdrawn(new QnaAnswerDownvoteWithdrawn(99L, 100L, 20L));
+
+      then(activityService).should().revokeLike(ActivityType.qna_answer_downvote, 20L, 99L);
+    }
+
+    @Test
     @DisplayName("QnaCommentDeleted → revoke(qna_comment, commentId)")
     void onQnaCommentDeleted() {
-      listener.onQnaCommentDeleted(new QnaCommentDeleted(1L, 30L));
+      listener.onQnaCommentDeleted(new QnaCommentDeleted(1L, 10L, null, 30L));
 
       then(activityService).should().revoke(ActivityType.qna_comment, 30L);
     }
@@ -194,7 +233,7 @@ class ActivityEventListenerTest {
     @Test
     @DisplayName("SessionEventCommentCreated → record(userId, session_event_comment, commentId)")
     void onSessionEventCommentCreated() {
-      listener.onSessionEventCommentCreated(new SessionEventCommentCreated(1L, 60L));
+      listener.onSessionEventCommentCreated(new SessionEventCommentCreated(1L, 50L, 60L));
 
       then(activityService).should().record(1L, ActivityType.session_event_comment, 60L);
     }
@@ -234,7 +273,7 @@ class ActivityEventListenerTest {
     @Test
     @DisplayName("SessionEventCommentDeleted → revoke(session_event_comment, commentId)")
     void onSessionEventCommentDeleted() {
-      listener.onSessionEventCommentDeleted(new SessionEventCommentDeleted(1L, 60L));
+      listener.onSessionEventCommentDeleted(new SessionEventCommentDeleted(1L, 50L, 60L));
 
       then(activityService).should().revoke(ActivityType.session_event_comment, 60L);
     }


### PR DESCRIPTION
### WHY

1. 64번 pr 에서 요청했던 이벤트에 문제를 발견했습니다!

ex) 블로그의 댓글 목록 조회 : `GET /api/blog/posts/{postId}/comments`

블로그 댓글의 레코드 시그니처 : `(userId, commentId)`

블로그-댓글, 질문-답변 같이 부모-자식 관계에서
자식 이벤트는 본인 id만으로는 부모 콘텐츠 위치 라우팅이 불가능함을 확인했습니다.

그래서 모든 자식 이벤트 레코드에 부모ID를 추가하는 작업을 진행했습니다!

2. QnA에 답변 vote 기능이 있는데 통합 이벤트로 발행되지 않아 활동 점수에 잡히지 않는 상태였습니다.

이왕 손대는 김에 vote 활동도 함께 도입했습니다.

---

### WHAT

**1. 자식 사건 레코드에 부모 ID 추가**

- `QnaAnswer{Created/Accepted/Deleted/Unaccepted}` → `questionId`
- `BlogComment{Created/Deleted}` / `SessionEventComment{Created/Deleted}` → `postId`
- `QnaComment{Created/Deleted}` → `questionId + answerId(nullable)`


**2. QnA 답변 vote 활동 신설** (`qna_answer_upvote`, `qna_answer_downvote` — 둘 다 +1)

- upvote/downvote 모두 "참여 자체"가 활동이라 +1점 입니다
- 답변 우수도의 평가는 채택 시스템이 하기 때문에 vote 수는 답변자의 기여에 영향이 없습니다


### HOW

- `shared/extevent/qna/` 12 레코드: Answer 4 수정 / vote 4 신규 / Comment 2 수정 / Question 2 그대로
- `shared/extevent/blog/` `BlogComment{Created,Deleted}` postId 추가
- `shared/extevent/sessionboard/` `SessionEventComment{Created,Deleted}` postId 추가
- README 3개 (blog/qna/sessionboard) 시그니처 표 갱신
- `ActivityType.java` 에 `qna_answer_upvote(+1)`, `qna_answer_downvote(+1)` 추가
- `ActivityEventListener.java` vote 핸들러 4 신규 + `onQnaAnswerDeleted` cascade에 vote 2 줄 추가
- `profile-api.md` ActivityType enum + §6 점수 기준 표 갱신
- `ActivityEventListenerTest.java` 시그니처 갱신 + vote 핸들러 테스트 4 신규 + Deleted cascade 검증 보강