### PR TITLE
feat(profile) : activity 활동 목록 / 기여도 요약 / 기여도 랭킹 구현

### DIFF
--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -595,7 +595,7 @@ POST /profile/teams
   "techStackIds": [1, 2, 3]
 }
 ```
-
+ 
 | 필드 | 타입 | 필수 | 제약 |
 |------|------|------|------|
 | `name` | `string` | 예 | — |
@@ -875,13 +875,19 @@ DELETE /profile/teams/{teamId}/members/me
 GET /profile/members/{memberId}/activities
 ```
 
+> **노출 범위 — 호출자 본인/타인에 따라 분기**:
+> - **본인 호출** (토큰 본인의 Member.id == path memberId): 모든 활동 (작성형 + 반응형)
+> - **타인 호출**: 작성형(`blog_post`, `qna_question`, `qna_answer`, `qna_accepted`, `session_speak`, `session_event_post`)만. 반응형(댓글/좋아요/vote)은 응답에서 제외.
+>
+> 즉 타인 화면엔 "기타 활동" 영역 자체가 보이지 않음 (응답 row 없음).
+
 **Query Parameters**
 
 | 파라미터 | 타입 | 필수 | 기본값 | 설명 |
 |----------|------|------|--------|------|
-| `type` | `ActivityType` | 아니오 | — | 활동 종류 필터 |
 | `page` | `number` | 아니오 | `0` | 페이지 번호 (0-based) |
 | `size` | `number` | 아니오 | `20` | 페이지 크기 |
+| `sort` | `string` | 아니오 | `createdAt,desc` | 정렬 기준 (Spring Pageable 형식, 잘못된 필드는 400) |
 
 **Response `200 OK`**
 ```json
@@ -951,6 +957,11 @@ GET /profile/members/{memberId}/contributions
 ```
 GET /profile/contributions/ranking
 ```
+
+> **정렬 기준** (다음 순서로 정렬, 0점 멤버도 포함):
+> 1. `totalScore` 내림차순
+> 2. `activityCount` 내림차순 (활동량 많은 사람이 동률에서 위)
+> 3. `member.id` 오름차순 (가입 순)
 
 **Query Parameters**
 

--- a/src/main/java/com/study/profile/application/ActivityService.java
+++ b/src/main/java/com/study/profile/application/ActivityService.java
@@ -1,3 +1,0 @@
-package com.study.profile.application;
-
-public class ActivityService {}

--- a/src/main/java/com/study/profile/application/activity/ActivityService.java
+++ b/src/main/java/com/study/profile/application/activity/ActivityService.java
@@ -1,12 +1,27 @@
 package com.study.profile.application.activity;
 
+import com.study.profile.application.dto.ActivityDto.ActivityResponse;
+import com.study.profile.application.dto.ActivityDto.ContributionResponse;
+import com.study.profile.application.dto.ActivityDto.ContributionTypeSum;
+import com.study.profile.application.dto.ActivityDto.RankingItemResponse;
+import com.study.profile.application.dto.ActivityDto.RankingProjection;
+import com.study.profile.application.dto.PageWrapper;
 import com.study.profile.domain.activity.Activity;
 import com.study.profile.domain.activity.ActivityType;
+import com.study.profile.domain.activity.ContributionPeriodType;
+import com.study.profile.domain.exception.MemberNotFoundException;
 import com.study.profile.domain.member.Member;
 import com.study.profile.infrastructure.ActivityRepository;
 import com.study.profile.infrastructure.MemberRepository;
+import java.time.Instant;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -103,12 +118,92 @@ public class ActivityService {
         type, referenceId, ownerId, actorId);
   }
 
-  // ===== 읽기: 조회 API (후속 PR) =====
+  // ===== 읽기: 조회 API =====
 
-  // TODO: 후속 PR에서 추가
-  // - getActivities(memberId, type, pageable)
-  // - getContributions(memberId, period)
-  // - getRanking(period, generationId, limit)
+  /**
+   * §6-1 멤버 활동 목록 — 호출자 본인/타인에 따라 노출 분기.
+   *
+   * <p>본인 호출(토큰의 Member.id == path memberId): 모든 type 노출 (작성형 + 반응형).
+   *
+   * <p>타인 호출: 작성형(creation) type만 노출. 반응형(좋아요/댓글)은 UI상 "기타 활동" 영역 자체 안 보임.
+   *
+   * @throws MemberNotFoundException memberId가 존재하지 않을 때 → 404
+   */
+  @Transactional(readOnly = true)
+  public PageWrapper<ActivityResponse> getActivities(
+      Long memberId, Long viewerUserId, Pageable pageable) {
+    if (!memberRepository.existsById(memberId)) {
+      throw new MemberNotFoundException(memberId);
+    }
+
+    Long viewerMemberId =
+        memberRepository.findByUserId(viewerUserId).map(Member::getId).orElse(null);
+    boolean isOwner = memberId.equals(viewerMemberId);
+
+    Page<Activity> page =
+        isOwner
+            ? activityRepository.findByMember_Id(memberId, pageable)
+            : activityRepository.findByMember_IdAndTypeIn(
+                memberId, ActivityType.creationTypes(), pageable);
+
+    return PageWrapper.from(page.map(ActivityResponse::from));
+  }
+
+  /**
+   * §6-2 기여도 요약 — 기간 내 type별 점수 합산 + 전체 합. 응답 breakdown은 13개 {@link ActivityType} 모두 포함 (점수 0이면 0).
+   *
+   * @throws MemberNotFoundException memberId가 존재하지 않을 때 → 404
+   */
+  @Transactional(readOnly = true)
+  public ContributionResponse getContributions(Long memberId, ContributionPeriodType period) {
+    Member member =
+        memberRepository
+            .findById(memberId)
+            .orElseThrow(() -> new MemberNotFoundException(memberId));
+
+    Instant since = period.toStartInstant().orElse(null);
+    List<ContributionTypeSum> rows =
+        activityRepository.sumScoresByMemberIdGroupByType(memberId, since);
+
+    Map<ActivityType, Integer> breakdown = new EnumMap<>(ActivityType.class);
+    for (ActivityType type : ActivityType.values()) {
+      breakdown.put(type, 0);
+    }
+    for (ContributionTypeSum row : rows) {
+      breakdown.put(row.type(), row.totalScore() == null ? 0 : row.totalScore().intValue());
+    }
+    int totalScore = breakdown.values().stream().mapToInt(Integer::intValue).sum();
+
+    return new ContributionResponse(memberId, member.getName(), period, totalScore, breakdown);
+  }
+
+  /**
+   * §6-3 기여도 랭킹 — 모든 멤버 (활동 0인 멤버 포함). 정렬: score desc → activityCount desc → member.id asc.
+   *
+   * @param period 기간 필터 (null 허용 X — Controller에서 default 채움)
+   * @param generationId 기수 필터 (null이면 전체)
+   * @param limit 반환할 순위 수
+   */
+  @Transactional(readOnly = true)
+  public List<RankingItemResponse> getRanking(
+      ContributionPeriodType period, Long generationId, int limit) {
+    Instant since = period.toStartInstant().orElse(null);
+    List<RankingProjection> rows =
+        activityRepository.findRanking(since, generationId, PageRequest.of(0, limit));
+
+    return java.util.stream.IntStream.range(0, rows.size())
+        .mapToObj(
+            i -> {
+              RankingProjection r = rows.get(i);
+              return new RankingItemResponse(
+                  i + 1,
+                  r.memberId(),
+                  r.name(),
+                  r.profileImageUrl(),
+                  r.totalScore() == null ? 0 : r.totalScore().intValue());
+            })
+        .toList();
+  }
 
   // ===== 내부 helper =====
 

--- a/src/main/java/com/study/profile/application/dto/ActivityDto.java
+++ b/src/main/java/com/study/profile/application/dto/ActivityDto.java
@@ -1,3 +1,51 @@
 package com.study.profile.application.dto;
 
-public class ActivityDto {}
+import com.study.profile.domain.activity.Activity;
+import com.study.profile.domain.activity.ActivityType;
+import com.study.profile.domain.activity.ContributionPeriodType;
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Activity 도메인 DTO 모음 — 응답(Response) + Repository projection.
+ *
+ * <p>※ 컨벤션상 응답 DTO는 {@code presentation/dto/}가 정석이나, profile 기존 패턴(application/dto)을 따른다. 별도
+ * refactor PR로 전체 정리 검토.
+ */
+public class ActivityDto {
+
+  private ActivityDto() {}
+
+  // ===== Response (Service → Controller → HTTP) =====
+
+  /** §6-1 활동 목록 항목. */
+  public record ActivityResponse(
+      Long id, ActivityType type, Long referenceId, Integer score, Instant createdAt) {
+
+    public static ActivityResponse from(Activity a) {
+      return new ActivityResponse(
+          a.getId(), a.getType(), a.getReferenceId(), a.getScore(), a.getCreatedAt());
+    }
+  }
+
+  /** §6-2 기여도 요약 응답. {@code breakdown}은 13개 {@link ActivityType} 모두 포함 (점수 0이면 0으로 표시 — 명세 그대로). */
+  public record ContributionResponse(
+      Long memberId,
+      String name,
+      ContributionPeriodType period,
+      Integer totalScore,
+      Map<ActivityType, Integer> breakdown) {}
+
+  /** §6-3 기여도 랭킹 항목. {@code rank}는 1-based 순차 (Q1 정렬로 동률 자체 깨짐). */
+  public record RankingItemResponse(
+      int rank, Long memberId, String name, String profileImageUrl, Integer totalScore) {}
+
+  // ===== Projection (Repository → Service) =====
+
+  /** §6-2 type별 점수 합산 결과 (group by type). */
+  public record ContributionTypeSum(ActivityType type, Long totalScore) {}
+
+  /** §6-3 랭킹 정렬 결과 행. */
+  public record RankingProjection(
+      Long memberId, String name, String profileImageUrl, Long totalScore, Long activityCount) {}
+}

--- a/src/main/java/com/study/profile/application/dto/PageWrapper.java
+++ b/src/main/java/com/study/profile/application/dto/PageWrapper.java
@@ -1,0 +1,24 @@
+package com.study.profile.application.dto;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+/**
+ * 페이지 응답 래퍼. Spring {@link Page} JSON 직렬화 기본 형식이 클라이언트가 안 쓰는 필드 많고 키 이름 불일치 → 명세 형식으로 정리.
+ *
+ * <p>profile API 응답 명세: {@code {content, page, size, totalElements, totalPages, hasNext}}.
+ *
+ */
+public record PageWrapper<T>(
+    List<T> content, int page, int size, long totalElements, int totalPages, boolean hasNext) {
+
+  public static <T> PageWrapper<T> from(Page<T> page) {
+    return new PageWrapper<>(
+        page.getContent(),
+        page.getNumber(),
+        page.getSize(),
+        page.getTotalElements(),
+        page.getTotalPages(),
+        page.hasNext());
+  }
+}

--- a/src/main/java/com/study/profile/domain/activity/ActivityType.java
+++ b/src/main/java/com/study/profile/domain/activity/ActivityType.java
@@ -1,36 +1,65 @@
 package com.study.profile.domain.activity;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 /**
- * 활동 종류 + 점수 정책.
+ * 활동 종류 + 점수 정책 + 분류(Kind).
  *
  * <p>점수는 도메인 정책이라 type 자체에 캡슐화. 정책 변경 시 이 파일만 수정.
  *
  * <p>좋아요는 양방향 — 누른 사람({@code *_like})·받은 사람({@code *_like_received}) 별도 type.
  *
+ * <p>Kind = 작성형(CREATION) / 반응형(REACTION) 분류. 활동 목록 조회 응답은 작성형만 노출 (반응형은 DB row + 점수 정책 유지하되 §6-1
+ * 응답에서 제외). 반응형 본인 보기는 v0.2 별도 endpoint(`/me/activities/reactions`) 검토.
+ *
  * <p>점수 정책 출처: {@code docs/profile/profile-api.md} "점수 기준" 표.
  */
 public enum ActivityType {
-  blog_post(30),
-  blog_comment(3),
-  blog_post_like(1),
-  blog_post_like_received(1),
-  qna_question(10),
-  qna_answer(10),
-  qna_accepted(25),
-  qna_comment(3),
-  session_speak(50),
-  session_event_post(30),
-  session_event_comment(3),
-  session_event_post_like(1),
-  session_event_post_like_received(1);
+  blog_post(30, Kind.CREATION),
+  blog_comment(3, Kind.REACTION),
+  blog_post_like(1, Kind.REACTION),
+  blog_post_like_received(1, Kind.REACTION),
+  qna_question(10, Kind.CREATION),
+  qna_answer(10, Kind.CREATION),
+  qna_accepted(25, Kind.CREATION),
+  qna_comment(3, Kind.REACTION),
+  session_speak(50, Kind.CREATION),
+  session_event_post(30, Kind.CREATION),
+  session_event_comment(3, Kind.REACTION),
+  session_event_post_like(1, Kind.REACTION),
+  session_event_post_like_received(1, Kind.REACTION);
+
+  public enum Kind {
+    CREATION,
+    REACTION
+  }
 
   private final int score;
+  private final Kind kind;
 
-  ActivityType(int score) {
+  ActivityType(int score, Kind kind) {
     this.score = score;
+    this.kind = kind;
   }
 
   public int score() {
     return score;
+  }
+
+  public Kind kind() {
+    return kind;
+  }
+
+  public boolean isCreation() {
+    return kind == Kind.CREATION;
+  }
+
+  /** 작성형 type 집합 — 활동 목록 §6-1 응답 필터. 변경 시 자동 반영. */
+  public static Set<ActivityType> creationTypes() {
+    return Collections.unmodifiableSet(
+        Arrays.stream(values()).filter(ActivityType::isCreation).collect(Collectors.toSet()));
   }
 }

--- a/src/main/java/com/study/profile/domain/activity/ContributionPeriodType.java
+++ b/src/main/java/com/study/profile/domain/activity/ContributionPeriodType.java
@@ -1,15 +1,31 @@
 package com.study.profile.domain.activity;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
 /**
- * 기여도(활동 점수 합산)를 조회할 때 사용하는 기간 단위를 나타내는 열거형(Enum).
+ * 기여도(활동 점수 합산)를 조회할 때 사용하는 기간 단위.
  *
- * <p>예) "이번 달 기여도 TOP 5", "올해 기여도 TOP 5" 같은 조회에 사용된다.
+ * <p>예) "이번 달 기여도 TOP 5", "올해 기여도 TOP 5".
  *
- * <p>month : 최근 1개월 three_month : 최근 3개월 year : 최근 1년 all : 전체 기간
+ * <p>{@link #toStartInstant()}는 합산 시작 시점 (Instant) 반환. {@code all}은 {@link Optional#empty()} — 전체
+ * 기간이라 시간 조건 X.
  */
 public enum ContributionPeriodType {
-  month,
-  three_month,
-  year,
-  all
+  month(30L),
+  three_month(90L),
+  year(365L),
+  all(null);
+
+  private final Long days;
+
+  ContributionPeriodType(Long days) {
+    this.days = days;
+  }
+
+  /** 합산 시작 시점 (지금부터 {@code days}일 전). {@code all}이면 {@link Optional#empty()}. */
+  public Optional<Instant> toStartInstant() {
+    return Optional.ofNullable(days).map(d -> Instant.now().minus(d, ChronoUnit.DAYS));
+  }
 }

--- a/src/main/java/com/study/profile/domain/exception/MemberNotFoundException.java
+++ b/src/main/java/com/study/profile/domain/exception/MemberNotFoundException.java
@@ -1,0 +1,8 @@
+package com.study.profile.domain.exception;
+
+/** 멤버를 찾을 수 없을 때 (잘못된 memberId, 또는 profile-init 미완료 상태 userId). 404로 매핑. */
+public class MemberNotFoundException extends ProfileException {
+  public MemberNotFoundException(Long id) {
+    super("멤버를 찾을 수 없습니다: " + id);
+  }
+}

--- a/src/main/java/com/study/profile/domain/exception/ProfileException.java
+++ b/src/main/java/com/study/profile/domain/exception/ProfileException.java
@@ -1,0 +1,13 @@
+package com.study.profile.domain.exception;
+
+/**
+ * profile 도메인 예외 베이스. 모든 profile 도메인 예외는 이 클래스를 상속한다.
+ *
+ * <p>이유: GlobalExceptionHandler에서 도메인 단위로 공통 처리 가능 + 다른 BC 예외와 카탈로그 분리 (qna {@code QnaException},
+ * auth {@code AuthException} 등과 일관).
+ */
+public abstract class ProfileException extends RuntimeException {
+  protected ProfileException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/study/profile/infrastructure/ActivityRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/ActivityRepository.java
@@ -1,13 +1,23 @@
 package com.study.profile.infrastructure;
 
+import com.study.profile.application.dto.ActivityDto.ContributionTypeSum;
+import com.study.profile.application.dto.ActivityDto.RankingProjection;
 import com.study.profile.domain.activity.Activity;
 import com.study.profile.domain.activity.ActivityType;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.lang.Nullable;
 
-/** Activity 엔티티 Repository — 활동 이력 저장. */
+/** Activity 엔티티 Repository — 활동 이력 저장 + 조회. */
 public interface ActivityRepository extends JpaRepository<Activity, Long> {
+
+  // ===== 차감 (cascade) =====
 
   /** type + referenceId 매칭 row 삭제. 일반 cascade 차감(글/댓글/답변/채택/발표 등)에 사용. */
   @Modifying
@@ -36,4 +46,45 @@ public interface ActivityRepository extends JpaRepository<Activity, Long> {
           + "and a.actorId = :actorId")
   int deleteByTypeAndReferenceIdAndOwnerIdAndActorId(
       ActivityType type, Long referenceId, Long ownerId, Long actorId);
+
+  // ===== 조회 =====
+
+  /** §6-1 활동 목록 (본인 호출용) — 멤버의 모든 type 활동을 페이징. */
+  Page<Activity> findByMember_Id(Long memberId, Pageable pageable);
+
+  /** §6-1 활동 목록 (타인 호출용) — 작성형 type만 페이징. 호출 측에서 {@link ActivityType#creationTypes()} 전달. */
+  Page<Activity> findByMember_IdAndTypeIn(
+      Long memberId, Collection<ActivityType> types, Pageable pageable);
+
+  /** §6-2 기여도 — 멤버의 type별 점수 합산. {@code since=null}이면 전체 기간. 결과 없는 type은 row X (호출 측에서 0으로 채움). */
+  @Query(
+      "select new com.study.profile.application.dto.ActivityDto$ContributionTypeSum("
+          + "  a.type, sum(a.score)) "
+          + "from Activity a "
+          + "where a.member.id = :memberId "
+          + "and (:since is null or a.createdAt >= :since) "
+          + "group by a.type")
+  List<ContributionTypeSum> sumScoresByMemberIdGroupByType(Long memberId, @Nullable Instant since);
+
+  /**
+   * §6-3 기여도 랭킹 — 모든 멤버(활동 0인 멤버 포함, LEFT JOIN) × 기간/기수 필터. 정렬: score desc → activityCount desc →
+   * member.id asc (Q1 동률 처리).
+   */
+  @Query(
+      "select new com.study.profile.application.dto.ActivityDto$RankingProjection("
+          + "  m.id, m.name, m.profileImageUrl, "
+          + "  coalesce(sum(a.score), 0), "
+          + "  coalesce(count(a), 0)) "
+          + "from Member m "
+          + "left join Activity a on a.member = m "
+          + "  and (:since is null or a.createdAt >= :since) "
+          + "where :generationId is null or exists ("
+          + "  select 1 from MemberGeneration mg "
+          + "  where mg.member = m and mg.generation.id = :generationId) "
+          + "group by m.id, m.name, m.profileImageUrl "
+          + "order by coalesce(sum(a.score), 0) desc, "
+          + "         coalesce(count(a), 0) desc, "
+          + "         m.id asc")
+  List<RankingProjection> findRanking(
+      @Nullable Instant since, @Nullable Long generationId, Pageable pageable);
 }

--- a/src/main/java/com/study/profile/presentation/ActivityController.java
+++ b/src/main/java/com/study/profile/presentation/ActivityController.java
@@ -1,3 +1,70 @@
 package com.study.profile.presentation;
 
-public class ActivityController {}
+import com.study.auth.infrastructure.security.CurrentUser;
+import com.study.auth.infrastructure.security.CustomUserDetails;
+import com.study.profile.application.activity.ActivityService;
+import com.study.profile.application.dto.ActivityDto.ActivityResponse;
+import com.study.profile.application.dto.ActivityDto.ContributionResponse;
+import com.study.profile.application.dto.ActivityDto.RankingItemResponse;
+import com.study.profile.application.dto.PageWrapper;
+import com.study.profile.domain.activity.ContributionPeriodType;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 활동 조회 API — §6-1 활동 목록 / §6-2 기여도 요약 / §6-3 기여도 랭킹.
+ *
+ * <p>§6-1은 토큰 본인/타인에 따라 노출 분기: 본인이면 모든 활동, 타인이면 작성형만. §6-2/6-3은 점수 통계라 분기 X.
+ *
+ * <p>정렬: {@link PageableDefault}로 {@code createdAt DESC} 기본. 클라가 {@code ?sort=}로 override 가능.
+ */
+@RestController
+@RequestMapping("/api/profile")
+@RequiredArgsConstructor
+public class ActivityController {
+
+  private final ActivityService activityService;
+
+  // ===== §6-1 멤버 활동 목록 =====
+
+  @GetMapping("/members/{memberId}/activities")
+  @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
+  public ResponseEntity<PageWrapper<ActivityResponse>> getActivities(
+      @PathVariable Long memberId,
+      @CurrentUser CustomUserDetails user,
+      @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+          Pageable pageable) {
+    return ResponseEntity.ok(activityService.getActivities(memberId, user.userId(), pageable));
+  }
+
+  // ===== §6-2 멤버 기여도 요약 =====
+
+  @GetMapping("/members/{memberId}/contributions")
+  @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
+  public ResponseEntity<ContributionResponse> getContributions(
+      @PathVariable Long memberId,
+      @RequestParam(defaultValue = "all") ContributionPeriodType period) {
+    return ResponseEntity.ok(activityService.getContributions(memberId, period));
+  }
+
+  // ===== §6-3 기여도 랭킹 =====
+
+  @GetMapping("/contributions/ranking")
+  @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
+  public ResponseEntity<List<RankingItemResponse>> getRanking(
+      @RequestParam(defaultValue = "all") ContributionPeriodType period,
+      @RequestParam(required = false) Long generationId,
+      @RequestParam(defaultValue = "10") int limit) {
+    return ResponseEntity.ok(activityService.getRanking(period, generationId, limit));
+  }
+}

--- a/src/main/java/com/study/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/study/shared/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.study.auth.domain.exception.InvalidCredentialsException;
 import com.study.auth.domain.exception.InvalidTokenException;
 import com.study.auth.domain.exception.TokenReusedException;
 import com.study.auth.domain.exception.UserNotActiveException;
+import com.study.profile.domain.exception.MemberNotFoundException;
 import com.study.qna.domain.exception.AnswerNotFoundException;
 import com.study.qna.domain.exception.CommentNotFoundException;
 import com.study.qna.domain.exception.ForbiddenQnaActionException;
@@ -74,6 +75,11 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(TagNotFoundException.class)
   public ResponseEntity<Map<String, Object>> handleTagNotFound(TagNotFoundException e) {
+    return errorResponse(HttpStatus.NOT_FOUND, e.getMessage());
+  }
+
+  @ExceptionHandler(MemberNotFoundException.class)
+  public ResponseEntity<Map<String, Object>> handleMemberNotFound(MemberNotFoundException e) {
     return errorResponse(HttpStatus.NOT_FOUND, e.getMessage());
   }
 

--- a/src/test/java/com/study/profile/application/activity/ActivityServiceTest.java
+++ b/src/test/java/com/study/profile/application/activity/ActivityServiceTest.java
@@ -3,15 +3,23 @@ package com.study.profile.application.activity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 
+import com.study.profile.application.dto.ActivityDto.ContributionResponse;
+import com.study.profile.application.dto.ActivityDto.ContributionTypeSum;
+import com.study.profile.application.dto.ActivityDto.RankingItemResponse;
+import com.study.profile.application.dto.ActivityDto.RankingProjection;
 import com.study.profile.domain.activity.Activity;
 import com.study.profile.domain.activity.ActivityType;
+import com.study.profile.domain.activity.ContributionPeriodType;
+import com.study.profile.domain.exception.MemberNotFoundException;
 import com.study.profile.domain.member.Member;
 import com.study.profile.infrastructure.ActivityRepository;
 import com.study.profile.infrastructure.MemberRepository;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -22,6 +30,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 class ActivityServiceTest {
@@ -214,6 +225,196 @@ class ActivityServiceTest {
       assertThat(ActivityType.blog_post_like_received.score()).isEqualTo(1);
       assertThat(ActivityType.session_event_post_like.score()).isEqualTo(1);
       assertThat(ActivityType.session_event_post_like_received.score()).isEqualTo(1);
+    }
+  }
+
+  @Nested
+  @DisplayName("§6-1 활동 목록 조회 (getActivities)")
+  class GetActivities {
+
+    @Test
+    @DisplayName("본인 호출 (memberId == viewer Member.id) → 모든 type 페이징 반환")
+    void getActivities_owner_returnsAllTypes() {
+      Long memberId = 1L;
+      Long viewerUserId = 7L;
+      Pageable pageable = PageRequest.of(0, 20);
+
+      Member viewer = org.mockito.Mockito.mock(Member.class);
+      given(viewer.getId()).willReturn(memberId);
+
+      given(memberRepository.existsById(memberId)).willReturn(true);
+      given(memberRepository.findByUserId(viewerUserId)).willReturn(Optional.of(viewer));
+      given(activityRepository.findByMember_Id(eq(memberId), eq(pageable)))
+          .willReturn(new PageImpl<>(List.of(), pageable, 0));
+
+      activityService.getActivities(memberId, viewerUserId, pageable);
+
+      // findByMember_Id 호출됨 (모든 type)
+      org.mockito.Mockito.verify(activityRepository).findByMember_Id(memberId, pageable);
+      org.mockito.Mockito.verify(activityRepository, org.mockito.Mockito.never())
+          .findByMember_IdAndTypeIn(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("타인 호출 (memberId != viewer Member.id) → 작성형 type만 필터해 반환")
+    void getActivities_other_returnsCreationOnly() {
+      Long memberId = 1L;
+      Long viewerUserId = 99L;
+      Pageable pageable = PageRequest.of(0, 20);
+
+      Member viewer = org.mockito.Mockito.mock(Member.class);
+      given(viewer.getId()).willReturn(2L); // viewer.Member.id != memberId
+
+      given(memberRepository.existsById(memberId)).willReturn(true);
+      given(memberRepository.findByUserId(viewerUserId)).willReturn(Optional.of(viewer));
+      given(
+              activityRepository.findByMember_IdAndTypeIn(
+                  eq(memberId), eq(ActivityType.creationTypes()), eq(pageable)))
+          .willReturn(new PageImpl<>(List.of(), pageable, 0));
+
+      activityService.getActivities(memberId, viewerUserId, pageable);
+
+      // findByMember_IdAndTypeIn 호출됨 (작성형만)
+      org.mockito.Mockito.verify(activityRepository)
+          .findByMember_IdAndTypeIn(memberId, ActivityType.creationTypes(), pageable);
+      org.mockito.Mockito.verify(activityRepository, org.mockito.Mockito.never())
+          .findByMember_Id(any(), any());
+    }
+
+    @Test
+    @DisplayName("viewer가 profile-init 미완료 (userId의 Member 없음) → 타인 취급, 작성형만 반환")
+    void getActivities_viewerProfileNotInitialized_treatedAsOther() {
+      Long memberId = 1L;
+      Long viewerUserId = 99L;
+      Pageable pageable = PageRequest.of(0, 20);
+
+      given(memberRepository.existsById(memberId)).willReturn(true);
+      given(memberRepository.findByUserId(viewerUserId)).willReturn(Optional.empty());
+      given(activityRepository.findByMember_IdAndTypeIn(eq(memberId), any(), eq(pageable)))
+          .willReturn(new PageImpl<>(List.of(), pageable, 0));
+
+      activityService.getActivities(memberId, viewerUserId, pageable);
+
+      org.mockito.Mockito.verify(activityRepository)
+          .findByMember_IdAndTypeIn(memberId, ActivityType.creationTypes(), pageable);
+    }
+
+    @Test
+    @DisplayName("memberId 없음 → MemberNotFoundException (404)")
+    void getActivities_memberNotFound() {
+      Long memberId = 999L;
+      given(memberRepository.existsById(memberId)).willReturn(false);
+
+      assertThatThrownBy(() -> activityService.getActivities(memberId, 1L, PageRequest.of(0, 20)))
+          .isInstanceOf(MemberNotFoundException.class)
+          .hasMessageContaining("999");
+    }
+  }
+
+  @Nested
+  @DisplayName("§6-2 기여도 요약 (getContributions)")
+  class GetContributions {
+
+    @Test
+    @DisplayName("breakdown 13개 type 모두 포함 (점수 0이면 0), totalScore는 합")
+    void getContributions_breakdownAllTypes() {
+      Long memberId = 1L;
+      Member member = org.mockito.Mockito.mock(Member.class);
+      given(member.getName()).willReturn("홍길동");
+      given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+      List<ContributionTypeSum> rows =
+          List.of(
+              new ContributionTypeSum(ActivityType.blog_post, 60L),
+              new ContributionTypeSum(ActivityType.qna_accepted, 25L));
+      given(activityRepository.sumScoresByMemberIdGroupByType(eq(memberId), any()))
+          .willReturn(rows);
+
+      ContributionResponse result =
+          activityService.getContributions(memberId, ContributionPeriodType.all);
+
+      assertThat(result.name()).isEqualTo("홍길동");
+      assertThat(result.breakdown()).hasSize(ActivityType.values().length);
+      assertThat(result.breakdown().get(ActivityType.blog_post)).isEqualTo(60);
+      assertThat(result.breakdown().get(ActivityType.qna_accepted)).isEqualTo(25);
+      assertThat(result.breakdown().get(ActivityType.blog_comment)).isZero();
+      assertThat(result.totalScore()).isEqualTo(85);
+    }
+
+    @Test
+    @DisplayName("memberId 없음 → MemberNotFoundException (404)")
+    void getContributions_memberNotFound() {
+      Long memberId = 999L;
+      given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+      assertThatThrownBy(
+              () -> activityService.getContributions(memberId, ContributionPeriodType.month))
+          .isInstanceOf(MemberNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("period=all → since=null로 Repository에 전달")
+    void getContributions_periodAll_passesNullSince() {
+      Long memberId = 1L;
+      given(memberRepository.findById(memberId))
+          .willReturn(Optional.of(org.mockito.Mockito.mock(Member.class)));
+      given(activityRepository.sumScoresByMemberIdGroupByType(memberId, null))
+          .willReturn(List.of());
+
+      ContributionResponse result =
+          activityService.getContributions(memberId, ContributionPeriodType.all);
+
+      assertThat(result.totalScore()).isZero();
+    }
+  }
+
+  @Nested
+  @DisplayName("§6-3 기여도 랭킹 (getRanking)")
+  class GetRanking {
+
+    @Test
+    @DisplayName("rank 1-based 순차 (Q1 정렬로 동률 깨짐), 0점 멤버도 포함")
+    void getRanking_rankSequential_zeroIncluded() {
+      List<RankingProjection> rows =
+          List.of(
+              new RankingProjection(1L, "홍길동", "url1", 120L, 5L),
+              new RankingProjection(3L, "김지수", "url3", 95L, 4L),
+              new RankingProjection(5L, "이몽룡", "url5", 0L, 0L));
+
+      given(activityRepository.findRanking(eq(null), eq(null), any())).willReturn(rows);
+
+      List<RankingItemResponse> result =
+          activityService.getRanking(ContributionPeriodType.all, null, 10);
+
+      assertThat(result).hasSize(3);
+      assertThat(result.get(0).rank()).isEqualTo(1);
+      assertThat(result.get(0).totalScore()).isEqualTo(120);
+      assertThat(result.get(1).rank()).isEqualTo(2);
+      assertThat(result.get(2).rank()).isEqualTo(3);
+      assertThat(result.get(2).totalScore()).isZero();
+    }
+
+    @Test
+    @DisplayName("generationId 필터 — Repository에 그대로 전달")
+    void getRanking_withGenerationId() {
+      given(activityRepository.findRanking(any(), eq(13L), any())).willReturn(List.of());
+
+      List<RankingItemResponse> result =
+          activityService.getRanking(ContributionPeriodType.year, 13L, 10);
+
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("totalScore가 null인 row → 0 (null safe)")
+    void getRanking_nullTotalScoreHandled() {
+      List<RankingProjection> rows = List.of(new RankingProjection(1L, "홍길동", "url1", null, 0L));
+      given(activityRepository.findRanking(any(), any(), any())).willReturn(rows);
+
+      List<RankingItemResponse> result =
+          activityService.getRanking(ContributionPeriodType.all, null, 10);
+
+      assertThat(result.get(0).totalScore()).isZero();
     }
   }
 


### PR DESCRIPTION
 ※ 73번 PR(통합 이벤트 record 정정) 이후 구현입니다

### WHY

프로필 Activity 조회 API 3종 구현입니다

1. 멤버 활동 목록 조회 : 멤버 페이지에서 활동 내역 가져오기
2. 기여도 요약 : 기간별 점수 합산
3. 기여도 랭킹 : 기수별 활동 점수순 정렬

---

### WHAT

주요 결정 내용입니다

1. 활동 목록은 호출자에 따라 응답이 달라집니다.

활동을 두 종류로 봤습니다:
- 작성형 (글 작성, 답변, 발표 등) — 공개적 활동
- 반응형 (좋아요, 댓글, vote 등) — 개인적 활동

그래서 같은 endpoint(`/members/{memberId}/activities`)에서:
- 본인이 자기 페이지 보면 → 모든 활동
- 남이 그 페이지 보면 → 작성형만

토큰 들고 들어와서 viewer가 path memberId 본인이면 모두, 아니면 작성형만 응답합니다

2. 기여도 랭킹 정렬 기준

다음 순서로 정렬,
1. `totalScore` 내림차순
2. `activityCount` 내림차순 (활동량 많은 사람이 동률에서 위)
3. `member.id` 오름차순 (가입 순)

기수내 모든 멤버 정렬이라 활동 0건인 멤버도 포함합니다

---

### HOW

구현은 명세 그대로입니다 (`docs/profile/profile-api.md` 참고).
새로 결정한 부분:
- §6-1 분기 = Service에서 `viewerUserId`로 Member 조회 후 path memberId와 비교
- §6-3 랭킹 = JPQL의 LEFT JOIN + COALESCE + 정렬 키 3개

---