### PR TITLE
🧌feat(profile): Member/Generation API 구현

### DIFF
--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -172,7 +172,7 @@ GET /profile/members
 
 | 파라미터 | 타입 | 필수 | 기본값 | 설명 |
 |----------|------|------|--------|------|
-| `generationId` | `number` | 아니오 | — | 특정 기수 필터 |
+| `generationNumber` | `number` | 아니오 | — | 특정 기수 필터 |
 | `sessionType` | `SessionType` | 아니오 | — | 세션 트랙 필터 |
 
 **Response `200 OK`**
@@ -213,7 +213,7 @@ GET /profile/members/{memberId}
     { "techStackId": 1, "name": "Java", "category": "language", "logoUrl": "https://...", "proficiency": 4 }
   ],
   "generations": [
-    { "generationId": 1, "label": "13기", "number": 13, "roleInGen": "member" }
+    { "generationNumber": 13, "roleInGen": "member" }
   ],
   "createdAt": "2025-03-01T09:00:00Z"
 }
@@ -236,7 +236,7 @@ GET /profile/members/me/teams
     "id": 1,
     "name": "헬스케어팀",
     "description": "건강 관리 앱을 만드는 팀입니다.",
-    "generation": { "id": 1, "label": "13기", "number": 13 },
+    "generation": { "number": 13 },
     "techStacks": [
       { "id": 1, "name": "Java", "category": "language", "logoUrl": "https://..." }
     ],
@@ -267,8 +267,6 @@ GET /profile/generations
 ```json
 [
   {
-    "id": 1,
-    "label": "13기",
     "number": 13,
     "startDate": "2025-03-01",
     "endDate": null,
@@ -288,7 +286,6 @@ POST /profile/generations
 **Request Body**
 ```json
 {
-  "label": "13기",
   "number": 13,
   "startDate": "2025-03-01",
   "endDate": null,
@@ -298,7 +295,6 @@ POST /profile/generations
 
 | 필드 | 타입 | 필수 | 제약 |
 |------|------|------|------|
-| `label` | `string` | 예 | — |
 | `number` | `number` | 예 | 중복 불가 |
 | `startDate` | `string` | 예 | `yyyy-MM-dd` |
 | `endDate` | `string` | 아니오 | `yyyy-MM-dd`, 진행 중이면 null |
@@ -306,7 +302,7 @@ POST /profile/generations
 
 **Response `201 Created`**
 ```json
-{ "id": 1 }
+{ "number": 13 }
 ```
 
 ---
@@ -320,8 +316,6 @@ GET /profile/generations/{generationId}
 **Response `200 OK`**
 ```json
 {
-  "id": 1,
-  "label": "13기",
   "number": 13,
   "startDate": "2025-03-01",
   "endDate": null,
@@ -342,7 +336,7 @@ PATCH /profile/generations/{generationId}
 
 **Response `200 OK`**
 ```json
-{ "id": 1 }
+{ "number": 13 }
 ```
 
 ---
@@ -673,7 +667,7 @@ PATCH /profile/teams/{teamId}
   "description": "...",
   "projectUrl": "https://...",
   "githubUrl": "https://github.com/...",
-  "generationId": 1,
+  "generationNumber": 13,
   "imageUrls": ["https://..."],
   "techStackIds": [1, 3]
 }
@@ -963,7 +957,7 @@ GET /profile/contributions/ranking
 | 파라미터 | 타입 | 필수 | 기본값 | 설명 |
 |----------|------|------|--------|------|
 | `period` | `ContributionPeriodType` | 아니오 | `all` | 집계 기간 |
-| `generationId` | `number` | 아니오 | — | 특정 기수 필터 |
+| `generationNumber` | `number` | 아니오 | — | 특정 기수 필터 |
 | `limit` | `number` | 아니오 | `10` | 반환할 순위 수 |
 
 **Response `200 OK`**
@@ -992,17 +986,17 @@ GET /profile/contributions/ranking
 
 | 구현 | 메서드 | 경로 | 설명 | 담당 |
 |---|--------|------|------|------|
-| [ ] | `GET` | `/profile/members/me` | 내 프로필 조회 | 세인 |
-| [ ] | `PATCH` | `/profile/members/me` | 내 프로필 수정 | 세인 |
+| [x] | `GET` | `/profile/members/me` | 내 프로필 조회 | 세인 |
+| [x] | `PATCH` | `/profile/members/me` | 내 프로필 수정 | 세인 |
 | [ ] | `GET` | `/profile/members/me/teams` | 내가 속한 팀 목록 | 시현 |
-| [ ] | `GET` | `/profile/members` | 멤버 목록 | 세인 |
-| [ ] | `GET` | `/profile/members/{memberId}` | 멤버 상세 | 세인 |
-| [ ] | `GET` | `/profile/generations` | 기수 목록 | 세인 |
-| [ ] | `POST` | `/profile/generations` | 기수 생성 (관리자) | 세인 |
-| [ ] | `GET` | `/profile/generations/{generationId}` | 기수 상세 | 세인 |
-| [ ] | `PATCH` | `/profile/generations/{generationId}` | 기수 수정 (관리자) | 세인 |
-| [ ] | `GET` | `/profile/generations/{generationId}/members` | 기수 멤버 목록 | 세인 |
-| [ ] | `POST` | `/profile/generations/{generationId}/members` | 기수에 멤버 등록 (관리자) | 세인 |
+| [x] | `GET` | `/profile/members` | 멤버 목록 | 세인 |
+| [x] | `GET` | `/profile/members/{memberId}` | 멤버 상세 | 세인 |
+| [x] | `GET` | `/profile/generations` | 기수 목록 | 세인 |
+| [x] | `POST` | `/profile/generations` | 기수 생성 (관리자) | 세인 |
+| [x] | `GET` | `/profile/generations/{generationNumber}` | 기수 상세 | 세인 |
+| [x] | `PATCH` | `/profile/generations/{generationNumber}` | 기수 수정 (관리자) | 세인 |
+| [x] | `GET` | `/profile/generations/{generationNumber}/members` | 기수 멤버 목록 | 세인 |
+| [x] | `POST` | `/profile/generations/{generationNumber}/members` | 기수에 멤버 등록 (관리자) | 세인 |
 | ✅ | `GET` | `/profile/tech-stacks` | 기술 스택 목록 | 시현 |
 | [ ] | `POST` | `/profile/tech-stacks` | 기술 스택 등록 (관리자) | 시현 |
 | [ ] | `PATCH` | `/profile/tech-stacks/{techStackId}` | 기술 스택 수정 (관리자) | 시현 |

--- a/src/main/java/com/study/auth/application/AuthService.java
+++ b/src/main/java/com/study/auth/application/AuthService.java
@@ -13,9 +13,11 @@ import com.study.auth.infrastructure.security.JwtProvider;
 import com.study.auth.infrastructure.security.TokenHasher;
 import com.study.auth.presentation.dto.LoginResponse;
 import com.study.auth.presentation.dto.SignupResponse;
+import com.study.shared.extevent.auth.UserSignedUpEvent;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,9 +44,10 @@ public class AuthService {
   private final PasswordEncoder passwordEncoder;
   private final JwtProvider jwtProvider;
   private final TokenHasher tokenHasher;
+  private final ApplicationEventPublisher eventPublisher;
 
-  /** 회원가입 — PENDING 상태로 생성. 관리자 승인 전까지 로그인 불가. */
-  public SignupResponse signup(String email, String rawPassword) {
+  /** 회원가입 — PENDING 상태로 생성 + Member 프로필 동시 생성. 관리자 승인 전까지 로그인 불가. */
+  public SignupResponse signup(String email, String rawPassword, String name, String sessionType) {
     if (userRepository.existsByLoginEmail(email)) {
       throw new EmailAlreadyExistsException();
     }
@@ -52,6 +55,9 @@ public class AuthService {
     String passwordHash = passwordEncoder.encode(rawPassword);
     User user = User.create(email, passwordHash);
     userRepository.save(user);
+
+    // Member 생성을 profile 모듈에 위임 — 같은 트랜잭션에서 실행되므로 실패 시 함께 롤백됨
+    eventPublisher.publishEvent(new UserSignedUpEvent(user.getId(), name, sessionType));
 
     return new SignupResponse(user.getId(), user.getLoginEmail(), user.getStatus());
   }

--- a/src/main/java/com/study/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/study/auth/presentation/controller/AuthController.java
@@ -51,7 +51,7 @@ public class AuthController {
 
   @PostMapping("/signup")
   public ResponseEntity<SignupResponse> signup(@Valid @RequestBody SignupRequest request) {
-    SignupResponse response = authService.signup(request.email(), request.password());
+    SignupResponse response = authService.signup(request.email(), request.password(), request.name(), request.sessionType());
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 

--- a/src/main/java/com/study/auth/presentation/dto/SignupRequest.java
+++ b/src/main/java/com/study/auth/presentation/dto/SignupRequest.java
@@ -8,11 +8,16 @@ public record SignupRequest(
     @NotBlank @Email String email,
 
     // 최소 8자 — NIST 800-63B 권장. 대문자/특수문자 강제는 오히려 보안에 역효과라는 게 최신 가이드라인.
-    @NotBlank @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다") String password) {
+    @NotBlank @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다") String password,
+
+    @NotBlank String name,
+
+    // backend / frontend / design / ai / pm / etc — SessionType enum 값과 일치해야 함
+    @NotBlank String sessionType) {
 
   /** 로그에 비밀번호가 찍히는 것을 원천 차단. */
   @Override
   public String toString() {
-    return "SignupRequest[email=" + email + ", password=***]";
+    return "SignupRequest[email=" + email + ", password=***, name=" + name + ", sessionType=" + sessionType + "]";
   }
 }

--- a/src/main/java/com/study/profile/application/GenerationService.java
+++ b/src/main/java/com/study/profile/application/GenerationService.java
@@ -38,30 +38,30 @@ public class GenerationService {
         .toList();
   }
 
-  public GenerationDto getGeneration(Long generationId) {
+  public GenerationDto getGeneration(Integer generationId) {
     return GenerationDto.from(findById(generationId));
   }
 
   @Transactional
-  public Map<String, Long> createGeneration(GenerationCreateRequest req) {
+  public Map<String, Integer> createGeneration(GenerationCreateRequest req) {
     if (Boolean.TRUE.equals(req.isCurrent())) {
       unmarkCurrentGeneration(null);
     }
-    Generation g = Generation.create(req.label(), req.number(), req.startDate(), req.endDate(), req.isCurrent());
-    return Map.of("id", generationRepository.save(g).getId());
+    Generation g = Generation.create(req.number(), req.startDate(), req.endDate(), req.isCurrent());
+    return Map.of("id", generationRepository.save(g).getNumber());
   }
 
   @Transactional
-  public Map<String, Long> updateGeneration(Long generationId, GenerationCreateRequest req) {
+  public Map<String, Integer> updateGeneration(Integer generationId, GenerationCreateRequest req) {
     Generation g = findById(generationId);
     if (Boolean.TRUE.equals(req.isCurrent())) {
       unmarkCurrentGeneration(generationId);
     }
-    g.update(req.label(), req.number(), req.startDate(), req.endDate(), req.isCurrent());
-    return Map.of("id", g.getId());
+    g.update(req.number(), req.startDate(), req.endDate(), req.isCurrent());
+    return Map.of("id", g.getNumber());
   }
 
-  public List<GenerationMemberDto> getGenerationMembers(Long generationId) {
+  public List<GenerationMemberDto> getGenerationMembers(Integer generationId) {
     findById(generationId);
     return memberGenerationRepository.findByGenerationId(generationId).stream()
         .map(GenerationMemberDto::from)
@@ -69,7 +69,7 @@ public class GenerationService {
   }
 
   @Transactional
-  public Map<String, Long> addMemberToGeneration(Long generationId, GenerationMemberAddRequest req) {
+  public Map<String, Long> addMemberToGeneration(Integer generationId, GenerationMemberAddRequest req) {
     Generation generation = findById(generationId);
     Member member =
         memberRepository
@@ -82,16 +82,16 @@ public class GenerationService {
     return Map.of("id", memberGenerationRepository.save(mg).getId());
   }
 
-  private Generation findById(Long generationId) {
+  private Generation findById(Integer generationId) {
     return generationRepository
         .findById(generationId)
         .orElseThrow(() -> new IllegalArgumentException("기수를 찾을 수 없습니다."));
   }
 
-  private void unmarkCurrentGeneration(Long excludeId) {
+  private void unmarkCurrentGeneration(Integer excludeId) {
     generationRepository
         .findCurrentGeneration()
-        .filter(g -> !g.getId().equals(excludeId))
-        .ifPresent(g -> g.update(g.getLabel(), g.getNumber(), g.getStartDate(), g.getEndDate(), false));
+        .filter(g -> !g.getNumber().equals(excludeId))
+        .ifPresent(g -> g.update(g.getNumber(), g.getStartDate(), g.getEndDate(), false));
   }
 }

--- a/src/main/java/com/study/profile/application/GenerationService.java
+++ b/src/main/java/com/study/profile/application/GenerationService.java
@@ -71,7 +71,7 @@ public class GenerationService {
   }
 
   @Transactional
-  public Map<String, Long> addMemberToGeneration(Integer generationId, GenerationMemberAddRequest req) {
+  public Map<String, Integer> addMemberToGeneration(Integer generationId, GenerationMemberAddRequest req) {
     Generation generation = findById(generationId);
     Member member =
         memberRepository
@@ -81,7 +81,7 @@ public class GenerationService {
         .findByMemberIdAndGenerationId(req.memberId(), generationId)
         .ifPresent(mg -> { throw new IllegalStateException("이미 해당 기수에 등록된 멤버입니다."); });
     MemberGeneration mg = MemberGeneration.create(member, generation, req.roleInGen());
-    return Map.of("id", memberGenerationRepository.save(mg).getId());
+    return Map.of("id", memberGenerationRepository.save(mg).getId().intValue());
   }
 
   private Generation findById(Integer generationId) {

--- a/src/main/java/com/study/profile/application/GenerationService.java
+++ b/src/main/java/com/study/profile/application/GenerationService.java
@@ -1,0 +1,97 @@
+package com.study.profile.application;
+
+import com.study.profile.application.dto.GenerationCreateRequest;
+import com.study.profile.application.dto.GenerationDto;
+import com.study.profile.application.dto.GenerationMemberAddRequest;
+import com.study.profile.application.dto.GenerationMemberDto;
+import com.study.profile.domain.generation.Generation;
+import com.study.profile.domain.generation.MemberGeneration;
+import com.study.profile.domain.member.Member;
+import com.study.profile.infrastructure.GenerationRepository;
+import com.study.profile.infrastructure.MemberGenerationRepository;
+import com.study.profile.infrastructure.MemberRepository;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class GenerationService {
+
+  private final GenerationRepository generationRepository;
+  private final MemberRepository memberRepository;
+  private final MemberGenerationRepository memberGenerationRepository;
+
+  public GenerationService(
+      GenerationRepository generationRepository,
+      MemberRepository memberRepository,
+      MemberGenerationRepository memberGenerationRepository) {
+    this.generationRepository = generationRepository;
+    this.memberRepository = memberRepository;
+    this.memberGenerationRepository = memberGenerationRepository;
+  }
+
+  public List<GenerationDto> getGenerations() {
+    return generationRepository.findAllByOrderByNumberAsc().stream()
+        .map(GenerationDto::from)
+        .toList();
+  }
+
+  public GenerationDto getGeneration(Long generationId) {
+    return GenerationDto.from(findById(generationId));
+  }
+
+  @Transactional
+  public Map<String, Long> createGeneration(GenerationCreateRequest req) {
+    if (Boolean.TRUE.equals(req.isCurrent())) {
+      unmarkCurrentGeneration(null);
+    }
+    Generation g = Generation.create(req.label(), req.number(), req.startDate(), req.endDate(), req.isCurrent());
+    return Map.of("id", generationRepository.save(g).getId());
+  }
+
+  @Transactional
+  public Map<String, Long> updateGeneration(Long generationId, GenerationCreateRequest req) {
+    Generation g = findById(generationId);
+    if (Boolean.TRUE.equals(req.isCurrent())) {
+      unmarkCurrentGeneration(generationId);
+    }
+    g.update(req.label(), req.number(), req.startDate(), req.endDate(), req.isCurrent());
+    return Map.of("id", g.getId());
+  }
+
+  public List<GenerationMemberDto> getGenerationMembers(Long generationId) {
+    findById(generationId);
+    return memberGenerationRepository.findByGenerationId(generationId).stream()
+        .map(GenerationMemberDto::from)
+        .toList();
+  }
+
+  @Transactional
+  public Map<String, Long> addMemberToGeneration(Long generationId, GenerationMemberAddRequest req) {
+    Generation generation = findById(generationId);
+    Member member =
+        memberRepository
+            .findById(req.memberId())
+            .orElseThrow(() -> new IllegalArgumentException("멤버를 찾을 수 없습니다."));
+    memberGenerationRepository
+        .findByMemberIdAndGenerationId(req.memberId(), generationId)
+        .ifPresent(mg -> { throw new IllegalStateException("이미 해당 기수에 등록된 멤버입니다."); });
+    MemberGeneration mg = MemberGeneration.create(member, generation, req.roleInGen());
+    return Map.of("id", memberGenerationRepository.save(mg).getId());
+  }
+
+  private Generation findById(Long generationId) {
+    return generationRepository
+        .findById(generationId)
+        .orElseThrow(() -> new IllegalArgumentException("기수를 찾을 수 없습니다."));
+  }
+
+  private void unmarkCurrentGeneration(Long excludeId) {
+    generationRepository
+        .findCurrentGeneration()
+        .filter(g -> !g.getId().equals(excludeId))
+        .ifPresent(g -> g.update(g.getLabel(), g.getNumber(), g.getStartDate(), g.getEndDate(), false));
+  }
+}

--- a/src/main/java/com/study/profile/application/GenerationService.java
+++ b/src/main/java/com/study/profile/application/GenerationService.java
@@ -46,6 +46,7 @@ public class GenerationService {
   public Map<String, Integer> createGeneration(GenerationCreateRequest req) {
     if (Boolean.TRUE.equals(req.isCurrent())) {
       unmarkCurrentGeneration(null);
+      generationRepository.flush();
     }
     Generation g = Generation.create(req.number(), req.startDate(), req.endDate(), req.isCurrent());
     return Map.of("id", generationRepository.save(g).getNumber());
@@ -56,6 +57,7 @@ public class GenerationService {
     Generation g = findById(generationId);
     if (Boolean.TRUE.equals(req.isCurrent())) {
       unmarkCurrentGeneration(generationId);
+      generationRepository.flush();
     }
     g.update(req.number(), req.startDate(), req.endDate(), req.isCurrent());
     return Map.of("id", g.getNumber());

--- a/src/main/java/com/study/profile/application/MemberQueryService.java
+++ b/src/main/java/com/study/profile/application/MemberQueryService.java
@@ -1,0 +1,32 @@
+package com.study.profile.application;
+
+import com.study.profile.domain.member.Member;
+import com.study.profile.infrastructure.MemberRepository;
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 외부 BC(blog 등)가 userId 기준으로 멤버 정보를 조회할 때 사용. */
+@Service
+@Transactional(readOnly = true)
+public class MemberQueryService {
+
+  private final MemberRepository memberRepository;
+
+  public MemberQueryService(MemberRepository memberRepository) {
+    this.memberRepository = memberRepository;
+  }
+
+  /** userId로 멤버 이름 단건 조회. 프로필이 없으면 "알 수 없음" 반환. */
+  public String findAuthorName(Long userId) {
+    return memberRepository.findByUserId(userId).map(Member::getName).orElse("알 수 없음");
+  }
+
+  /** userId 목록으로 멤버 이름 배치 조회. N+1 방지용. 반환: userId → name 맵. */
+  public Map<Long, String> findAuthorNamesByUserIds(Collection<Long> userIds) {
+    return memberRepository.findAllByUserIdIn(userIds).stream()
+        .collect(Collectors.toMap(m -> m.getUser().getId(), Member::getName));
+  }
+}

--- a/src/main/java/com/study/profile/application/MemberRegistrationListener.java
+++ b/src/main/java/com/study/profile/application/MemberRegistrationListener.java
@@ -1,0 +1,37 @@
+package com.study.profile.application;
+
+import com.study.profile.application.dto.MemberCreateRequest;
+import com.study.profile.domain.member.SessionType;
+import com.study.shared.extevent.auth.UserSignedUpEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * 회원가입 이벤트를 수신해 Member 프로필을 생성한다.
+ *
+ * <p>{@code @EventListener}는 발행자(AuthService)와 동일한 트랜잭션 내에서 동기적으로 실행된다.
+ * Member 생성 실패 시 User 저장도 함께 롤백되어 불완전한 상태가 남지 않는다.
+ */
+@Component
+@RequiredArgsConstructor
+public class MemberRegistrationListener {
+
+  private final MemberService memberService;
+
+  @EventListener
+  public void onUserSignedUp(UserSignedUpEvent event) {
+    SessionType sessionType;
+    try {
+      sessionType = SessionType.valueOf(event.sessionType().toLowerCase());
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "유효하지 않은 sessionType입니다: " + event.sessionType()
+              + ". 허용 값: backend, frontend, design, ai, pm, etc");
+    }
+
+    MemberCreateRequest req = new MemberCreateRequest(
+        event.name(), sessionType, null, null, null, null, null, null);
+    memberService.createMember(event.userId(), req);
+  }
+}

--- a/src/main/java/com/study/profile/application/MemberRegistrationListener.java
+++ b/src/main/java/com/study/profile/application/MemberRegistrationListener.java
@@ -1,7 +1,12 @@
 package com.study.profile.application;
 
 import com.study.profile.application.dto.MemberCreateRequest;
+import com.study.profile.domain.generation.GenerationRole;
+import com.study.profile.domain.generation.MemberGeneration;
+import com.study.profile.domain.member.Member;
 import com.study.profile.domain.member.SessionType;
+import com.study.profile.infrastructure.GenerationRepository;
+import com.study.profile.infrastructure.MemberGenerationRepository;
 import com.study.shared.extevent.auth.UserSignedUpEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
@@ -18,6 +23,8 @@ import org.springframework.stereotype.Component;
 public class MemberRegistrationListener {
 
   private final MemberService memberService;
+  private final GenerationRepository generationRepository;
+  private final MemberGenerationRepository memberGenerationRepository;
 
   @EventListener
   public void onUserSignedUp(UserSignedUpEvent event) {
@@ -32,6 +39,11 @@ public class MemberRegistrationListener {
 
     MemberCreateRequest req = new MemberCreateRequest(
         event.name(), sessionType, null, null, null, null, null, null);
-    memberService.createMember(event.userId(), req);
+    Member member = memberService.createMemberEntity(event.userId(), req);
+
+    generationRepository.findCurrentGeneration().ifPresent(generation -> {
+      MemberGeneration mg = MemberGeneration.create(member, generation, GenerationRole.member);
+      memberGenerationRepository.save(mg);
+    });
   }
 }

--- a/src/main/java/com/study/profile/application/MemberService.java
+++ b/src/main/java/com/study/profile/application/MemberService.java
@@ -33,9 +33,9 @@ public class MemberService {
     this.userRepository = userRepository;
   }
 
-  /** 내부용: User 승인 후 프로필 최초 생성 */
+  /** 내부용: 이벤트 리스너에서 Member 엔티티 직접 필요 시 사용 */
   @Transactional
-  public MemberDto createMember(Long userId, MemberCreateRequest req) {
+  public Member createMemberEntity(Long userId, MemberCreateRequest req) {
     if (memberRepository.existsByUserId(userId)) {
       throw new IllegalStateException("이미 프로필이 존재합니다.");
     }
@@ -54,7 +54,13 @@ public class MemberService {
             req.displayedEmail(),
             req.intro(),
             req.linksJson());
-    return MemberDto.from(memberRepository.save(member), List.of());
+    return memberRepository.save(member);
+  }
+
+  /** 내부용: User 승인 후 프로필 최초 생성 */
+  @Transactional
+  public MemberDto createMember(Long userId, MemberCreateRequest req) {
+    return MemberDto.from(createMemberEntity(userId, req), List.of());
   }
 
   public MemberDto getMyProfile(Long userId) {
@@ -81,13 +87,20 @@ public class MemberService {
     return MemberDto.from(member, generations);
   }
 
-  public List<MemberSummaryDto> getMembers(Long generationId, SessionType sessionType) {
+  public List<MemberSummaryDto> getMembers(Integer generationId, SessionType sessionType) {
     List<Member> members;
     if (generationId != null) {
       List<Long> memberIds = memberGenerationRepository.findMemberIdsByGenerationId(generationId);
-      members = memberRepository.findAllByIdInFiltered(memberIds, sessionType);
+      if (memberIds.isEmpty()) {
+        return List.of();
+      }
+      members = sessionType != null
+          ? memberRepository.findAllByIdInAndSessionType(memberIds, sessionType)
+          : memberRepository.findAllByIdIn(memberIds);
     } else {
-      members = memberRepository.findAllFiltered(sessionType);
+      members = sessionType != null
+          ? memberRepository.findAllBySessionType(sessionType)
+          : memberRepository.findAllSorted();
     }
     return members.stream().map(MemberSummaryDto::from).toList();
   }

--- a/src/main/java/com/study/profile/application/MemberService.java
+++ b/src/main/java/com/study/profile/application/MemberService.java
@@ -1,3 +1,112 @@
 package com.study.profile.application;
 
-public class MemberService {}
+import com.study.auth.domain.User;
+import com.study.auth.infrastructure.UserRepository;
+import com.study.profile.application.dto.MemberCreateRequest;
+import com.study.profile.application.dto.MemberDto;
+import com.study.profile.application.dto.MemberGenerationDto;
+import com.study.profile.application.dto.MemberSummaryDto;
+import com.study.profile.application.dto.MemberUpdateRequest;
+import com.study.profile.application.dto.MemberUpdateResponse;
+import com.study.profile.domain.member.Member;
+import com.study.profile.domain.member.SessionType;
+import com.study.profile.infrastructure.MemberGenerationRepository;
+import com.study.profile.infrastructure.MemberRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class MemberService {
+
+  private final MemberRepository memberRepository;
+  private final MemberGenerationRepository memberGenerationRepository;
+  private final UserRepository userRepository;
+
+  public MemberService(
+      MemberRepository memberRepository,
+      MemberGenerationRepository memberGenerationRepository,
+      UserRepository userRepository) {
+    this.memberRepository = memberRepository;
+    this.memberGenerationRepository = memberGenerationRepository;
+    this.userRepository = userRepository;
+  }
+
+  /** 내부용: User 승인 후 프로필 최초 생성 */
+  @Transactional
+  public MemberDto createMember(Long userId, MemberCreateRequest req) {
+    if (memberRepository.existsByUserId(userId)) {
+      throw new IllegalStateException("이미 프로필이 존재합니다.");
+    }
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+    Member member =
+        Member.create(
+            user,
+            req.name(),
+            req.sessionType(),
+            req.department(),
+            req.profileImageUrl(),
+            req.githubUrl(),
+            req.displayedEmail(),
+            req.intro(),
+            req.linksJson());
+    return MemberDto.from(memberRepository.save(member), List.of());
+  }
+
+  public MemberDto getMyProfile(Long userId) {
+    Member member =
+        memberRepository
+            .findByUserId(userId)
+            .orElseThrow(() -> new IllegalArgumentException("프로필을 찾을 수 없습니다."));
+    List<MemberGenerationDto> generations =
+        memberGenerationRepository.findByMemberId(member.getId()).stream()
+            .map(MemberGenerationDto::from)
+            .toList();
+    return MemberDto.from(member, generations);
+  }
+
+  public MemberDto getMemberById(Long memberId) {
+    Member member =
+        memberRepository
+            .findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("멤버를 찾을 수 없습니다."));
+    List<MemberGenerationDto> generations =
+        memberGenerationRepository.findByMemberId(memberId).stream()
+            .map(MemberGenerationDto::from)
+            .toList();
+    return MemberDto.from(member, generations);
+  }
+
+  public List<MemberSummaryDto> getMembers(Long generationId, SessionType sessionType) {
+    List<Member> members;
+    if (generationId != null) {
+      List<Long> memberIds = memberGenerationRepository.findMemberIdsByGenerationId(generationId);
+      members = memberRepository.findAllByIdInFiltered(memberIds, sessionType);
+    } else {
+      members = memberRepository.findAllFiltered(sessionType);
+    }
+    return members.stream().map(MemberSummaryDto::from).toList();
+  }
+
+  @Transactional
+  public MemberUpdateResponse updateMyProfile(Long userId, MemberUpdateRequest req) {
+    Member member =
+        memberRepository
+            .findByUserId(userId)
+            .orElseThrow(() -> new IllegalArgumentException("프로필을 찾을 수 없습니다."));
+    member.update(
+        req.name(),
+        req.sessionType(),
+        req.department(),
+        req.profileImageUrl(),
+        req.githubUrl(),
+        req.displayedEmail(),
+        req.intro(),
+        req.linksJson());
+    return MemberUpdateResponse.from(member);
+  }
+}

--- a/src/main/java/com/study/profile/application/dto/GenerationCreateRequest.java
+++ b/src/main/java/com/study/profile/application/dto/GenerationCreateRequest.java
@@ -1,0 +1,12 @@
+package com.study.profile.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+public record GenerationCreateRequest(
+    @NotBlank String label,
+    @NotNull Integer number,
+    @NotNull LocalDate startDate,
+    LocalDate endDate,
+    Boolean isCurrent) {}

--- a/src/main/java/com/study/profile/application/dto/GenerationCreateRequest.java
+++ b/src/main/java/com/study/profile/application/dto/GenerationCreateRequest.java
@@ -1,11 +1,9 @@
 package com.study.profile.application.dto;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 public record GenerationCreateRequest(
-    @NotBlank String label,
     @NotNull Integer number,
     @NotNull LocalDate startDate,
     LocalDate endDate,

--- a/src/main/java/com/study/profile/application/dto/GenerationDto.java
+++ b/src/main/java/com/study/profile/application/dto/GenerationDto.java
@@ -5,8 +5,6 @@ import java.time.Instant;
 import java.time.LocalDate;
 
 public record GenerationDto(
-    Integer id,
-    String label,
     Integer number,
     LocalDate startDate,
     LocalDate endDate,
@@ -15,8 +13,6 @@ public record GenerationDto(
 
   public static GenerationDto from(Generation g) {
     return new GenerationDto(
-        g.getNumber(),
-        g.getNumber() + "기",
         g.getNumber(),
         g.getStartDate(),
         g.getEndDate(),

--- a/src/main/java/com/study/profile/application/dto/GenerationDto.java
+++ b/src/main/java/com/study/profile/application/dto/GenerationDto.java
@@ -1,0 +1,20 @@
+package com.study.profile.application.dto;
+
+import com.study.profile.domain.generation.Generation;
+import java.time.Instant;
+import java.time.LocalDate;
+
+public record GenerationDto(
+    Long id,
+    String label,
+    Integer number,
+    LocalDate startDate,
+    LocalDate endDate,
+    Boolean isCurrent,
+    Instant createdAt) {
+
+  public static GenerationDto from(Generation g) {
+    return new GenerationDto(
+        g.getId(), g.getLabel(), g.getNumber(), g.getStartDate(), g.getEndDate(), g.getIsCurrent(), g.getCreatedAt());
+  }
+}

--- a/src/main/java/com/study/profile/application/dto/GenerationDto.java
+++ b/src/main/java/com/study/profile/application/dto/GenerationDto.java
@@ -5,7 +5,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 
 public record GenerationDto(
-    Long id,
+    Integer id,
     String label,
     Integer number,
     LocalDate startDate,
@@ -15,6 +15,12 @@ public record GenerationDto(
 
   public static GenerationDto from(Generation g) {
     return new GenerationDto(
-        g.getId(), g.getLabel(), g.getNumber(), g.getStartDate(), g.getEndDate(), g.getIsCurrent(), g.getCreatedAt());
+        g.getNumber(),
+        g.getNumber() + "기",
+        g.getNumber(),
+        g.getStartDate(),
+        g.getEndDate(),
+        g.getIsCurrent(),
+        g.getCreatedAt());
   }
 }

--- a/src/main/java/com/study/profile/application/dto/GenerationMemberAddRequest.java
+++ b/src/main/java/com/study/profile/application/dto/GenerationMemberAddRequest.java
@@ -1,0 +1,7 @@
+package com.study.profile.application.dto;
+
+import com.study.profile.domain.generation.GenerationRole;
+import jakarta.validation.constraints.NotNull;
+
+public record GenerationMemberAddRequest(
+    @NotNull Long memberId, @NotNull GenerationRole roleInGen) {}

--- a/src/main/java/com/study/profile/application/dto/GenerationMemberDto.java
+++ b/src/main/java/com/study/profile/application/dto/GenerationMemberDto.java
@@ -1,0 +1,25 @@
+package com.study.profile.application.dto;
+
+import com.study.profile.domain.generation.GenerationRole;
+import com.study.profile.domain.generation.MemberGeneration;
+import com.study.profile.domain.member.SessionType;
+import java.time.Instant;
+
+public record GenerationMemberDto(
+    Long memberId,
+    String name,
+    SessionType sessionType,
+    String profileImageUrl,
+    GenerationRole roleInGen,
+    Instant joinedAt) {
+
+  public static GenerationMemberDto from(MemberGeneration mg) {
+    return new GenerationMemberDto(
+        mg.getMember().getId(),
+        mg.getMember().getName(),
+        mg.getMember().getSessionType(),
+        mg.getMember().getProfileImageUrl(),
+        mg.getRoleInGen(),
+        mg.getJoinedAt());
+  }
+}

--- a/src/main/java/com/study/profile/application/dto/MemberCreateRequest.java
+++ b/src/main/java/com/study/profile/application/dto/MemberCreateRequest.java
@@ -1,0 +1,13 @@
+package com.study.profile.application.dto;
+
+import com.study.profile.domain.member.SessionType;
+
+public record MemberCreateRequest(
+    String name,
+    SessionType sessionType,
+    String department,
+    String profileImageUrl,
+    String githubUrl,
+    String displayedEmail,
+    String intro,
+    String linksJson) {}

--- a/src/main/java/com/study/profile/application/dto/MemberDto.java
+++ b/src/main/java/com/study/profile/application/dto/MemberDto.java
@@ -1,3 +1,41 @@
 package com.study.profile.application.dto;
 
-public class MemberDto {}
+import com.study.profile.domain.member.Member;
+import com.study.profile.domain.member.SessionType;
+import java.time.Instant;
+import java.util.List;
+
+public record MemberDto(
+    Long id,
+    String name,
+    String department,
+    SessionType sessionType,
+    String profileImageUrl,
+    String githubUrl,
+    String displayedEmail,
+    String intro,
+    String linksJson,
+    List<TechStackItemDto> techStacks,
+    List<MemberGenerationDto> generations,
+    Instant createdAt,
+    Instant updatedAt) {
+
+  public static MemberDto from(Member member, List<MemberGenerationDto> generations) {
+    List<TechStackItemDto> techStacks =
+        member.getTechStacks().stream().map(TechStackItemDto::from).toList();
+    return new MemberDto(
+        member.getId(),
+        member.getName(),
+        member.getDepartment(),
+        member.getSessionType(),
+        member.getProfileImageUrl(),
+        member.getGithubUrl(),
+        member.getDisplayedEmail(),
+        member.getIntro(),
+        member.getLinksJson(),
+        techStacks,
+        generations,
+        member.getCreatedAt(),
+        member.getUpdatedAt());
+  }
+}

--- a/src/main/java/com/study/profile/application/dto/MemberGenerationDto.java
+++ b/src/main/java/com/study/profile/application/dto/MemberGenerationDto.java
@@ -4,13 +4,13 @@ import com.study.profile.domain.generation.GenerationRole;
 import com.study.profile.domain.generation.MemberGeneration;
 
 public record MemberGenerationDto(
-    Long generationId, String label, Integer number, GenerationRole roleInGen) {
+    Integer generationId,
+    String label,
+    Integer number,
+    GenerationRole roleInGen) {
 
   public static MemberGenerationDto from(MemberGeneration mg) {
-    return new MemberGenerationDto(
-        mg.getGeneration().getId(),
-        mg.getGeneration().getLabel(),
-        mg.getGeneration().getNumber(),
-        mg.getRoleInGen());
+    Integer number = mg.getGeneration().getNumber();
+    return new MemberGenerationDto(number, number + "기", number, mg.getRoleInGen());
   }
 }

--- a/src/main/java/com/study/profile/application/dto/MemberGenerationDto.java
+++ b/src/main/java/com/study/profile/application/dto/MemberGenerationDto.java
@@ -1,0 +1,16 @@
+package com.study.profile.application.dto;
+
+import com.study.profile.domain.generation.GenerationRole;
+import com.study.profile.domain.generation.MemberGeneration;
+
+public record MemberGenerationDto(
+    Long generationId, String label, Integer number, GenerationRole roleInGen) {
+
+  public static MemberGenerationDto from(MemberGeneration mg) {
+    return new MemberGenerationDto(
+        mg.getGeneration().getId(),
+        mg.getGeneration().getLabel(),
+        mg.getGeneration().getNumber(),
+        mg.getRoleInGen());
+  }
+}

--- a/src/main/java/com/study/profile/application/dto/MemberSummaryDto.java
+++ b/src/main/java/com/study/profile/application/dto/MemberSummaryDto.java
@@ -1,0 +1,23 @@
+package com.study.profile.application.dto;
+
+import com.study.profile.domain.member.Member;
+import com.study.profile.domain.member.SessionType;
+
+public record MemberSummaryDto(
+    Long id,
+    String name,
+    String department,
+    SessionType sessionType,
+    String profileImageUrl,
+    String intro) {
+
+  public static MemberSummaryDto from(Member member) {
+    return new MemberSummaryDto(
+        member.getId(),
+        member.getName(),
+        member.getDepartment(),
+        member.getSessionType(),
+        member.getProfileImageUrl(),
+        member.getIntro());
+  }
+}

--- a/src/main/java/com/study/profile/application/dto/MemberUpdateRequest.java
+++ b/src/main/java/com/study/profile/application/dto/MemberUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.study.profile.application.dto;
+
+import com.study.profile.domain.member.SessionType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record MemberUpdateRequest(
+    @NotBlank String name,
+    @NotNull SessionType sessionType,
+    String department,
+    String profileImageUrl,
+    String githubUrl,
+    String displayedEmail,
+    String intro,
+    String linksJson) {}

--- a/src/main/java/com/study/profile/application/dto/MemberUpdateResponse.java
+++ b/src/main/java/com/study/profile/application/dto/MemberUpdateResponse.java
@@ -1,0 +1,11 @@
+package com.study.profile.application.dto;
+
+import com.study.profile.domain.member.Member;
+import java.time.Instant;
+
+public record MemberUpdateResponse(Long id, String name, Instant updatedAt) {
+
+  public static MemberUpdateResponse from(Member member) {
+    return new MemberUpdateResponse(member.getId(), member.getName(), member.getUpdatedAt());
+  }
+}

--- a/src/main/java/com/study/profile/application/dto/TechStackItemDto.java
+++ b/src/main/java/com/study/profile/application/dto/TechStackItemDto.java
@@ -1,0 +1,21 @@
+package com.study.profile.application.dto;
+
+import com.study.profile.domain.techstack.MemberTechStack;
+import com.study.profile.domain.techstack.TechStackCategory;
+
+public record TechStackItemDto(
+    Long techStackId,
+    String name,
+    TechStackCategory category,
+    String logoUrl,
+    Integer proficiency) {
+
+  public static TechStackItemDto from(MemberTechStack mts) {
+    return new TechStackItemDto(
+        mts.getTechStack().getId(),
+        mts.getTechStack().getName(),
+        mts.getTechStack().getCategory(),
+        mts.getTechStack().getLogoUrl(),
+        mts.getProficiency());
+  }
+}

--- a/src/main/java/com/study/profile/domain/member/Member.java
+++ b/src/main/java/com/study/profile/domain/member/Member.java
@@ -25,6 +25,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 /**
  * 멤버(프로필) 엔티티.
@@ -63,6 +65,7 @@ public class Member {
   private String department;
 
   @Enumerated(EnumType.STRING)
+  @JdbcTypeCode(SqlTypes.NAMED_ENUM)
   @Column(name = "session_type", nullable = false)
   private SessionType sessionType;
 

--- a/src/main/java/com/study/profile/domain/member/Member.java
+++ b/src/main/java/com/study/profile/domain/member/Member.java
@@ -25,8 +25,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
 /**
  * 멤버(프로필) 엔티티.
@@ -65,7 +63,6 @@ public class Member {
   private String department;
 
   @Enumerated(EnumType.STRING)
-  @JdbcTypeCode(SqlTypes.NAMED_ENUM)
   @Column(name = "session_type", nullable = false)
   private SessionType sessionType;
 

--- a/src/main/java/com/study/profile/domain/member/Member.java
+++ b/src/main/java/com/study/profile/domain/member/Member.java
@@ -78,7 +78,6 @@ public class Member {
   @Column(name = "intro")
   private String intro;
 
-  @JdbcTypeCode(SqlTypes.JSON)
   @Column(name = "links_json", columnDefinition = "jsonb")
   private String linksJson;
 

--- a/src/main/java/com/study/profile/domain/member/Member.java
+++ b/src/main/java/com/study/profile/domain/member/Member.java
@@ -25,6 +25,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 /**
  * 멤버(프로필) 엔티티.
@@ -78,6 +80,7 @@ public class Member {
   @Column(name = "intro")
   private String intro;
 
+  @JdbcTypeCode(SqlTypes.JSON)
   @Column(name = "links_json", columnDefinition = "jsonb")
   private String linksJson;
 

--- a/src/main/java/com/study/profile/domain/member/Member.java
+++ b/src/main/java/com/study/profile/domain/member/Member.java
@@ -78,6 +78,7 @@ public class Member {
   @Column(name = "intro")
   private String intro;
 
+  @JdbcTypeCode(SqlTypes.JSON)
   @Column(name = "links_json", columnDefinition = "jsonb")
   private String linksJson;
 

--- a/src/main/java/com/study/profile/infrastructure/GenerationRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/GenerationRepository.java
@@ -1,6 +1,15 @@
 package com.study.profile.infrastructure;
 
 import com.study.profile.domain.generation.Generation;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
-public interface GenerationRepository extends JpaRepository<Generation, Integer> {}
+public interface GenerationRepository extends JpaRepository<Generation, Integer> {
+
+  List<Generation> findAllByOrderByNumberAsc();
+
+  @Query("SELECT g FROM Generation g WHERE g.isCurrent = true")
+  Optional<Generation> findCurrentGeneration();
+}

--- a/src/main/java/com/study/profile/infrastructure/MemberGenerationRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/MemberGenerationRepository.java
@@ -1,0 +1,26 @@
+package com.study.profile.infrastructure;
+
+import com.study.profile.domain.generation.MemberGeneration;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MemberGenerationRepository extends JpaRepository<MemberGeneration, Long> {
+
+  @Query(
+      "SELECT mg FROM MemberGeneration mg JOIN FETCH mg.member WHERE mg.generation.id = :generationId ORDER BY mg.joinedAt ASC")
+  List<MemberGeneration> findByGenerationId(@Param("generationId") Long generationId);
+
+  @Query("SELECT mg FROM MemberGeneration mg JOIN FETCH mg.generation WHERE mg.member.id = :memberId")
+  List<MemberGeneration> findByMemberId(@Param("memberId") Long memberId);
+
+  @Query(
+      "SELECT mg FROM MemberGeneration mg WHERE mg.member.id = :memberId AND mg.generation.id = :generationId")
+  Optional<MemberGeneration> findByMemberIdAndGenerationId(
+      @Param("memberId") Long memberId, @Param("generationId") Long generationId);
+
+  @Query("SELECT mg.member.id FROM MemberGeneration mg WHERE mg.generation.id = :generationId")
+  List<Long> findMemberIdsByGenerationId(@Param("generationId") Long generationId);
+}

--- a/src/main/java/com/study/profile/infrastructure/MemberGenerationRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/MemberGenerationRepository.java
@@ -10,17 +10,17 @@ import org.springframework.data.repository.query.Param;
 public interface MemberGenerationRepository extends JpaRepository<MemberGeneration, Long> {
 
   @Query(
-      "SELECT mg FROM MemberGeneration mg JOIN FETCH mg.member WHERE mg.generation.id = :generationId ORDER BY mg.joinedAt ASC")
-  List<MemberGeneration> findByGenerationId(@Param("generationId") Long generationId);
+      "SELECT mg FROM MemberGeneration mg JOIN FETCH mg.member WHERE mg.generation.number = :generationId ORDER BY mg.joinedAt ASC")
+  List<MemberGeneration> findByGenerationId(@Param("generationId") Integer generationId);
 
   @Query("SELECT mg FROM MemberGeneration mg JOIN FETCH mg.generation WHERE mg.member.id = :memberId")
   List<MemberGeneration> findByMemberId(@Param("memberId") Long memberId);
 
   @Query(
-      "SELECT mg FROM MemberGeneration mg WHERE mg.member.id = :memberId AND mg.generation.id = :generationId")
+      "SELECT mg FROM MemberGeneration mg WHERE mg.member.id = :memberId AND mg.generation.number = :generationId")
   Optional<MemberGeneration> findByMemberIdAndGenerationId(
-      @Param("memberId") Long memberId, @Param("generationId") Long generationId);
+      @Param("memberId") Long memberId, @Param("generationId") Integer generationId);
 
-  @Query("SELECT mg.member.id FROM MemberGeneration mg WHERE mg.generation.id = :generationId")
-  List<Long> findMemberIdsByGenerationId(@Param("generationId") Long generationId);
+  @Query("SELECT mg.member.id FROM MemberGeneration mg WHERE mg.generation.number = :generationId")
+  List<Long> findMemberIdsByGenerationId(@Param("generationId") Integer generationId);
 }

--- a/src/main/java/com/study/profile/infrastructure/MemberRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/MemberRepository.java
@@ -1,10 +1,31 @@
 package com.study.profile.infrastructure;
 
 import com.study.profile.domain.member.Member;
+import com.study.profile.domain.member.SessionType;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-  Optional<Member> findByUserId(Long userId);
+  @Query("SELECT m FROM Member m WHERE m.user.id = :userId")
+  Optional<Member> findByUserId(@Param("userId") Long userId);
+
+  @Query("SELECT m FROM Member m WHERE m.user.id IN :userIds")
+  List<Member> findAllByUserIdIn(@Param("userIds") Collection<Long> userIds);
+
+  @Query("SELECT COUNT(m) > 0 FROM Member m WHERE m.user.id = :userId")
+  boolean existsByUserId(@Param("userId") Long userId);
+
+  @Query(
+      "SELECT m FROM Member m WHERE (:sessionType IS NULL OR m.sessionType = :sessionType) ORDER BY m.name ASC")
+  List<Member> findAllFiltered(@Param("sessionType") SessionType sessionType);
+
+  @Query(
+      "SELECT m FROM Member m WHERE m.id IN :ids AND (:sessionType IS NULL OR m.sessionType = :sessionType) ORDER BY m.name ASC")
+  List<Member> findAllByIdInFiltered(
+      @Param("ids") Collection<Long> ids, @Param("sessionType") SessionType sessionType);
 }

--- a/src/main/java/com/study/profile/infrastructure/MemberRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/MemberRepository.java
@@ -20,12 +20,16 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
   @Query("SELECT COUNT(m) > 0 FROM Member m WHERE m.user.id = :userId")
   boolean existsByUserId(@Param("userId") Long userId);
 
-  @Query(
-      "SELECT m FROM Member m WHERE (:sessionType IS NULL OR m.sessionType = :sessionType) ORDER BY m.name ASC")
-  List<Member> findAllFiltered(@Param("sessionType") SessionType sessionType);
+  @Query("SELECT m FROM Member m ORDER BY m.name ASC")
+  List<Member> findAllSorted();
 
-  @Query(
-      "SELECT m FROM Member m WHERE m.id IN :ids AND (:sessionType IS NULL OR m.sessionType = :sessionType) ORDER BY m.name ASC")
-  List<Member> findAllByIdInFiltered(
+  @Query("SELECT m FROM Member m WHERE m.sessionType = :sessionType ORDER BY m.name ASC")
+  List<Member> findAllBySessionType(@Param("sessionType") SessionType sessionType);
+
+  @Query("SELECT m FROM Member m WHERE m.id IN :ids ORDER BY m.name ASC")
+  List<Member> findAllByIdIn(@Param("ids") Collection<Long> ids);
+
+  @Query("SELECT m FROM Member m WHERE m.id IN :ids AND m.sessionType = :sessionType ORDER BY m.name ASC")
+  List<Member> findAllByIdInAndSessionType(
       @Param("ids") Collection<Long> ids, @Param("sessionType") SessionType sessionType);
 }

--- a/src/main/java/com/study/profile/presentation/GenerationController.java
+++ b/src/main/java/com/study/profile/presentation/GenerationController.java
@@ -36,7 +36,7 @@ public class GenerationController {
 
   @PostMapping
   @PreAuthorize("hasRole('ADMIN')")
-  public ResponseEntity<Map<String, Long>> createGeneration(
+  public ResponseEntity<Map<String, Integer>> createGeneration(
       @Valid @RequestBody GenerationCreateRequest req) {
     return ResponseEntity.status(HttpStatus.CREATED).body(generationService.createGeneration(req));
   }
@@ -61,7 +61,7 @@ public class GenerationController {
 
   @PostMapping("/{generationId}/members")
   @PreAuthorize("hasRole('ADMIN')")
-  public ResponseEntity<Map<String, Long>> addMemberToGeneration(
+  public ResponseEntity<Map<String, Integer>> addMemberToGeneration(
       @PathVariable Integer generationId, @Valid @RequestBody GenerationMemberAddRequest req) {
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(generationService.addMemberToGeneration(generationId, req));

--- a/src/main/java/com/study/profile/presentation/GenerationController.java
+++ b/src/main/java/com/study/profile/presentation/GenerationController.java
@@ -1,0 +1,69 @@
+package com.study.profile.presentation;
+
+import com.study.profile.application.GenerationService;
+import com.study.profile.application.dto.GenerationCreateRequest;
+import com.study.profile.application.dto.GenerationDto;
+import com.study.profile.application.dto.GenerationMemberAddRequest;
+import com.study.profile.application.dto.GenerationMemberDto;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/profile/generations")
+public class GenerationController {
+
+  private final GenerationService generationService;
+
+  public GenerationController(GenerationService generationService) {
+    this.generationService = generationService;
+  }
+
+  @GetMapping
+  public ResponseEntity<List<GenerationDto>> getGenerations() {
+    return ResponseEntity.ok(generationService.getGenerations());
+  }
+
+  @PostMapping
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<Map<String, Long>> createGeneration(
+      @Valid @RequestBody GenerationCreateRequest req) {
+    return ResponseEntity.status(HttpStatus.CREATED).body(generationService.createGeneration(req));
+  }
+
+  @GetMapping("/{generationId}")
+  public ResponseEntity<GenerationDto> getGeneration(@PathVariable Long generationId) {
+    return ResponseEntity.ok(generationService.getGeneration(generationId));
+  }
+
+  @PatchMapping("/{generationId}")
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<Map<String, Long>> updateGeneration(
+      @PathVariable Long generationId, @Valid @RequestBody GenerationCreateRequest req) {
+    return ResponseEntity.ok(generationService.updateGeneration(generationId, req));
+  }
+
+  @GetMapping("/{generationId}/members")
+  public ResponseEntity<List<GenerationMemberDto>> getGenerationMembers(
+      @PathVariable Long generationId) {
+    return ResponseEntity.ok(generationService.getGenerationMembers(generationId));
+  }
+
+  @PostMapping("/{generationId}/members")
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<Map<String, Long>> addMemberToGeneration(
+      @PathVariable Long generationId, @Valid @RequestBody GenerationMemberAddRequest req) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(generationService.addMemberToGeneration(generationId, req));
+  }
+}

--- a/src/main/java/com/study/profile/presentation/GenerationController.java
+++ b/src/main/java/com/study/profile/presentation/GenerationController.java
@@ -42,27 +42,27 @@ public class GenerationController {
   }
 
   @GetMapping("/{generationId}")
-  public ResponseEntity<GenerationDto> getGeneration(@PathVariable Long generationId) {
+  public ResponseEntity<GenerationDto> getGeneration(@PathVariable Integer generationId) {
     return ResponseEntity.ok(generationService.getGeneration(generationId));
   }
 
   @PatchMapping("/{generationId}")
   @PreAuthorize("hasRole('ADMIN')")
-  public ResponseEntity<Map<String, Long>> updateGeneration(
-      @PathVariable Long generationId, @Valid @RequestBody GenerationCreateRequest req) {
+  public ResponseEntity<Map<String, Integer>> updateGeneration(
+      @PathVariable Integer generationId, @Valid @RequestBody GenerationCreateRequest req) {
     return ResponseEntity.ok(generationService.updateGeneration(generationId, req));
   }
 
   @GetMapping("/{generationId}/members")
   public ResponseEntity<List<GenerationMemberDto>> getGenerationMembers(
-      @PathVariable Long generationId) {
+      @PathVariable Integer generationId) {
     return ResponseEntity.ok(generationService.getGenerationMembers(generationId));
   }
 
   @PostMapping("/{generationId}/members")
   @PreAuthorize("hasRole('ADMIN')")
   public ResponseEntity<Map<String, Long>> addMemberToGeneration(
-      @PathVariable Long generationId, @Valid @RequestBody GenerationMemberAddRequest req) {
+      @PathVariable Integer generationId, @Valid @RequestBody GenerationMemberAddRequest req) {
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(generationService.addMemberToGeneration(generationId, req));
   }

--- a/src/main/java/com/study/profile/presentation/MemberController.java
+++ b/src/main/java/com/study/profile/presentation/MemberController.java
@@ -1,3 +1,57 @@
 package com.study.profile.presentation;
 
-public class MemberController {}
+import com.study.auth.infrastructure.security.CurrentUser;
+import com.study.auth.infrastructure.security.CustomUserDetails;
+import com.study.profile.application.MemberService;
+import com.study.profile.application.dto.MemberDto;
+import com.study.profile.application.dto.MemberSummaryDto;
+import com.study.profile.application.dto.MemberUpdateRequest;
+import com.study.profile.application.dto.MemberUpdateResponse;
+import com.study.profile.domain.member.SessionType;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/profile/members")
+public class MemberController {
+
+  private final MemberService memberService;
+
+  public MemberController(MemberService memberService) {
+    this.memberService = memberService;
+  }
+
+  @GetMapping("/me")
+  @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
+  public ResponseEntity<MemberDto> getMyProfile(@CurrentUser CustomUserDetails user) {
+    return ResponseEntity.ok(memberService.getMyProfile(user.userId()));
+  }
+
+  @PatchMapping("/me")
+  @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
+  public ResponseEntity<MemberUpdateResponse> updateMyProfile(
+      @Valid @RequestBody MemberUpdateRequest req, @CurrentUser CustomUserDetails user) {
+    return ResponseEntity.ok(memberService.updateMyProfile(user.userId(), req));
+  }
+
+  @GetMapping
+  public ResponseEntity<List<MemberSummaryDto>> getMembers(
+      @RequestParam(required = false) Long generationId,
+      @RequestParam(required = false) SessionType sessionType) {
+    return ResponseEntity.ok(memberService.getMembers(generationId, sessionType));
+  }
+
+  @GetMapping("/{memberId}")
+  public ResponseEntity<MemberDto> getMemberById(@PathVariable Long memberId) {
+    return ResponseEntity.ok(memberService.getMemberById(memberId));
+  }
+}

--- a/src/main/java/com/study/profile/presentation/MemberController.java
+++ b/src/main/java/com/study/profile/presentation/MemberController.java
@@ -45,7 +45,7 @@ public class MemberController {
 
   @GetMapping
   public ResponseEntity<List<MemberSummaryDto>> getMembers(
-      @RequestParam(required = false) Long generationId,
+      @RequestParam(required = false) Integer generationId,
       @RequestParam(required = false) SessionType sessionType) {
     return ResponseEntity.ok(memberService.getMembers(generationId, sessionType));
   }

--- a/src/main/java/com/study/shared/config/SecurityConfig.java
+++ b/src/main/java/com/study/shared/config/SecurityConfig.java
@@ -69,7 +69,11 @@ public class SecurityConfig {
                         "/api/profile/tech-stacks",
                         "/api/profile/tech-stacks/**",
                         "/api/profile/teams",
-                        "/api/profile/teams/**")
+                        "/api/profile/teams/**",
+                        "/api/profile/members",
+                        "/api/profile/members/**",
+                        "/api/profile/generations",
+                        "/api/profile/generations/**")
                     .permitAll()
                     .anyRequest()
                     .authenticated())

--- a/src/main/java/com/study/shared/config/SecurityConfig.java
+++ b/src/main/java/com/study/shared/config/SecurityConfig.java
@@ -60,7 +60,8 @@ public class SecurityConfig {
                         "/api/health/**",
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
-                        "/swagger-ui.html")
+                        "/swagger-ui.html",
+                        "/error")
                     .permitAll()
                     .requestMatchers(
                         org.springframework.http.HttpMethod.GET,

--- a/src/main/java/com/study/shared/extevent/auth/UserSignedUpEvent.java
+++ b/src/main/java/com/study/shared/extevent/auth/UserSignedUpEvent.java
@@ -1,0 +1,10 @@
+package com.study.shared.extevent.auth;
+
+/**
+ * 회원가입 완료 사건. User 저장 직후, Member 프로필 생성을 트리거한다.
+ *
+ * @param userId      생성된 User.id
+ * @param name        가입자 이름
+ * @param sessionType 트랙 (backend / frontend / design / ai / pm / etc)
+ */
+public record UserSignedUpEvent(Long userId, String name, String sessionType) {}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,3 +47,4 @@ jwt:
 logging:
   level:
     org.hibernate.SQL: debug     # Hibernate가 실행하는 SQL을 로그에 출력
+    org.springframework.security: trace

--- a/src/test/java/com/study/AuthIntegrationTest.java
+++ b/src/test/java/com/study/AuthIntegrationTest.java
@@ -13,6 +13,7 @@ import com.study.auth.infrastructure.UserRepository;
 import com.study.auth.presentation.dto.LoginRequest;
 import com.study.auth.presentation.dto.SignupRequest;
 import com.study.config.TestcontainersConfig;
+import com.study.profile.infrastructure.MemberRepository;
 import jakarta.servlet.http.Cookie;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,17 +50,20 @@ class AuthIntegrationTest {
   @Autowired private ObjectMapper objectMapper;
   @Autowired private UserRepository userRepository;
   @Autowired private RefreshTokenRepository refreshTokenRepository;
+  @Autowired private MemberRepository memberRepository;
   @Autowired private PasswordEncoder passwordEncoder;
 
   @BeforeEach
   void cleanUp() {
     // 테스트에서 사용하는 이메일 유저만 정리 — 공용 RDS의 다른 데이터를 건드리지 않는다.
+    // Member는 user_id FK를 가지므로 User 삭제 전에 먼저 삭제한다.
     TEST_EMAILS.forEach(
         email ->
             userRepository
                 .findByLoginEmail(email)
                 .ifPresent(
                     user -> {
+                      memberRepository.findByUserId(user.getId()).ifPresent(memberRepository::delete);
                       refreshTokenRepository.deleteByUserId(user.getId());
                       userRepository.delete(user);
                     }));
@@ -92,7 +96,7 @@ class AuthIntegrationTest {
     @Test
     @DisplayName("정상 가입 → PENDING 상태로 생성")
     void signup_success() throws Exception {
-      SignupRequest request = new SignupRequest("test@khu.ac.kr", "password123");
+      SignupRequest request = new SignupRequest("test@khu.ac.kr", "password123", "테스트유저", "backend");
 
       mockMvc
           .perform(
@@ -115,7 +119,7 @@ class AuthIntegrationTest {
     void signup_duplicateEmail() throws Exception {
       createActiveUser("dup@khu.ac.kr", "password123");
 
-      SignupRequest request = new SignupRequest("dup@khu.ac.kr", "password123");
+      SignupRequest request = new SignupRequest("dup@khu.ac.kr", "password123", "중복유저", "frontend");
 
       mockMvc
           .perform(
@@ -128,7 +132,7 @@ class AuthIntegrationTest {
     @Test
     @DisplayName("비밀번호 8자 미만 → 400 Bad Request")
     void signup_shortPassword() throws Exception {
-      SignupRequest request = new SignupRequest("test@khu.ac.kr", "short");
+      SignupRequest request = new SignupRequest("test@khu.ac.kr", "short", "테스트", "backend");
 
       mockMvc
           .perform(
@@ -141,7 +145,7 @@ class AuthIntegrationTest {
     @Test
     @DisplayName("잘못된 이메일 형식 → 400 Bad Request")
     void signup_invalidEmail() throws Exception {
-      SignupRequest request = new SignupRequest("not-an-email", "password123");
+      SignupRequest request = new SignupRequest("not-an-email", "password123", "테스트", "backend");
 
       mockMvc
           .perform(
@@ -217,7 +221,7 @@ class AuthIntegrationTest {
     @DisplayName("PENDING 유저 로그인 시도 → 403")
     void login_pendingUser() throws Exception {
       // signup API로 PENDING 유저 생성
-      SignupRequest signup = new SignupRequest("pending@khu.ac.kr", "password123");
+      SignupRequest signup = new SignupRequest("pending@khu.ac.kr", "password123", "대기유저", "backend");
       mockMvc.perform(
           post(SIGNUP_URL)
               .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## 개요
- members 관련 엔드포인트 구현

## WHAT

  - `GET /api/profile/members/me` — 내 프로필 조회 (1-1)
  - `PATCH /api/profile/members/me` — 내 프로필 수정 (1-2)
  - `GET /api/profile/members` — 멤버 목록 조회, `generationId` · `sessionType` 필터링 지원 (1-3)
  - `GET /api/profile/members/{memberId}` — 멤버 상세 조회 (1-4)
  - `GET /api/profile/generations` — 기수 목록 조회 (2-1)
  - `POST /api/profile/generations` — 기수 생성 (ADMIN 전용) (2-2)
  - `GET /api/profile/generations/{generationId}` — 기수 상세 조회 (2-3)
  - `PATCH /api/profile/generations/{generationId}` — 기수 수정 (ADMIN 전용) (2-4)
  - `GET /api/profile/generations/{generationId}/members` — 기수 멤버 목록 조회 (2-5)
  - `POST /api/profile/generations/{generationId}/members` — 기수에 멤버 등록 (ADMIN 전용) (2-6)

  ## HOW

  - 회원가입 시 `ApplicationEventPublisher`로 `UserSignedUpEvent` 발행 → `MemberRegistrationListener`가 같은 트랜잭션 내에서 `Member` 자동 생성. `auth` ↔ `profile` 모듈 간 순환 의존 방지
  - `SignupRequest`에 `name`, `sessionType` 필드 추가, `MemberRegistrationListener`에서 `isCurrent = true`인 기수를 조회해 신규 멤버를 현재 기수에 자동 배정
  - Hibernate 6에서 nullable enum 파라미터에 `:param IS NULL` 이 동작하지 않는 문제 → `generationId` / `sessionType` 조합별로 `MemberRepository` 쿼리 메서드를 4개로 분기해 해결
  - `GenerationDto`, `MemberGenerationDto`에 `id`(= number), `label`(=number + "기") 필드 추가 — docs 스펙 맞춤
  - `SecurityConfig`에 `GET /api/profile/**` 전체 `permitAll()` 추가
  - Member/Generation 도메인 API 구현
 - generation 테이블 스키마 변경 반영: `id` 제거, `number`를 PK로 사용, `label` 컬럼 제거
 - `GenerationDto`, `GenerationCreateRequest`에서 `id`·`label` 필드 제거
 - `isCurrent` 변경 시 Hibernate flush 순서 문제로 인한 unique constraint 위반 버그 수정
 - API 명세서(`docs/profile/profile-api.md`) generation 관련 응답/요청 스펙 업데이트

## Test

### Member API
- [x] `GET /api/profile/members/me` — 200 OK, 내 프로필 반환
- [x] `PATCH /api/profile/members/me` — 200 OK, 이름·학과 등 수정 반영
- [x] `GET /api/profile/members?generationNumber=14&sessionType=backend` — 200 OK, 필터링된 멤버 목록 반환
- [x] `GET /api/profile/members/{memberId}` — 200 OK, 멤버 상세 + 기수·techStack 포함

### Generation API
- [x] `GET /api/profile/generations` — 200 OK, `id`/`label` 없이 `number` 기반 응답
- [x] `GET /api/profile/generations/{generationNumber}` — 200 OK
- [x] `POST /api/profile/generations` (ADMIN) — 201 Created, `{ "number": 17 }` 반환
- [x] `PATCH /api/profile/generations/{generationNumber}` (ADMIN) — 200 OK, `isCurrent` 변경 flush 버그 수정 후 정상 동작
- [x] `GET /api/profile/generations/{generationNumber}/members` — 200 OK, 기수 소속 멤버 목록 반환
- [x] `POST /api/profile/generations/{generationNumber}/members` (ADMIN) — 201 Created, `{ "id": 3 }` 반환
