### PR TITLE
feat: QnA 댓글 수정/삭제 API 구현 및
   comment_count 원자적 갱신 적용

### DIFF
--- a/src/main/java/com/study/qna/application/CommentService.java
+++ b/src/main/java/com/study/qna/application/CommentService.java
@@ -1,11 +1,14 @@
 package com.study.qna.application;
 
 import com.study.qna.application.dto.request.comment.CommentCreateRequest;
+import com.study.qna.application.dto.request.comment.CommentUpdateRequest;
 import com.study.qna.application.dto.response.comment.CommentResponse;
 import com.study.qna.application.dto.response.common.MemberSummaryResponse;
 import com.study.qna.domain.Answer;
 import com.study.qna.domain.Comment;
 import com.study.qna.domain.exception.AnswerNotFoundException;
+import com.study.qna.domain.exception.CommentNotFoundException;
+import com.study.qna.domain.exception.ForbiddenQnaActionException;
 import com.study.qna.infrastructure.AnswerRepository;
 import com.study.qna.infrastructure.CommentRepository;
 import java.util.List;
@@ -41,10 +44,43 @@ public class CommentService {
             .orElseThrow(() -> new AnswerNotFoundException(answerId));
 
     Comment comment = Comment.createForAnswer(userId, answer, request.content());
-    answer.incrementCommentCount();
+    answerRepository.incrementCommentCount(answerId);
     Comment saved = commentRepository.save(comment);
     MemberSummaryResponse author =
         MemberSummaryResponse.of(saved.getUserId(), String.valueOf(saved.getUserId()), 0);
     return CommentResponse.of(saved, author);
+  }
+
+  @Transactional
+  public CommentResponse updateComment(Long commentId, CommentUpdateRequest request, Long userId) {
+    Comment comment =
+        commentRepository
+            .findById(commentId)
+            .orElseThrow(() -> new CommentNotFoundException(commentId));
+
+    if (!comment.isAuthor(userId)) {
+      throw new ForbiddenQnaActionException();
+    }
+
+    comment.update(request.content());
+    MemberSummaryResponse author =
+        MemberSummaryResponse.of(comment.getUserId(), String.valueOf(comment.getUserId()), 0);
+    return CommentResponse.of(comment, author);
+  }
+
+  @Transactional
+  public void deleteComment(Long commentId, Long userId) {
+    Comment comment =
+        commentRepository
+            .findById(commentId)
+            .orElseThrow(() -> new CommentNotFoundException(commentId));
+
+    if (!comment.isAuthor(userId)) {
+      throw new ForbiddenQnaActionException();
+    }
+
+    Long answerId = comment.getAnswer().getId();
+    commentRepository.delete(comment);
+    answerRepository.decrementCommentCount(answerId);
   }
 }

--- a/src/main/java/com/study/qna/presentation/CommentController.java
+++ b/src/main/java/com/study/qna/presentation/CommentController.java
@@ -4,13 +4,16 @@ import com.study.auth.infrastructure.security.CurrentUser;
 import com.study.auth.infrastructure.security.CustomUserDetails;
 import com.study.qna.application.CommentService;
 import com.study.qna.application.dto.request.comment.CommentCreateRequest;
+import com.study.qna.application.dto.request.comment.CommentUpdateRequest;
 import com.study.qna.application.dto.response.comment.CommentResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,22 +22,38 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController("qnaCommentController")
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/answers/{answerId}/comments")
+@RequestMapping("/api/v1")
 public class CommentController {
 
   private final CommentService commentService;
 
-  @GetMapping
+  @GetMapping("/answers/{answerId}/comments")
   public ResponseEntity<List<CommentResponse>> getComments(@PathVariable Long answerId) {
     return ResponseEntity.ok(commentService.getComments(answerId));
   }
 
-  @PostMapping
+  @PostMapping("/answers/{answerId}/comments")
   public ResponseEntity<CommentResponse> createComment(
       @PathVariable Long answerId,
       @RequestBody @Valid CommentCreateRequest request,
       @CurrentUser CustomUserDetails user) {
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(commentService.createComment(answerId, request, user.userId()));
+  }
+
+  @PatchMapping("/comments/{commentId}")
+  public ResponseEntity<CommentResponse> updateComment(
+      @PathVariable Long commentId,
+      @Valid @RequestBody CommentUpdateRequest request,
+      @CurrentUser CustomUserDetails user) {
+    return ResponseEntity.ok(commentService.updateComment(commentId, request, user.userId()));
+  }
+
+  @DeleteMapping("/comments/{commentId}")
+  public ResponseEntity<Void> deleteComment(
+      @PathVariable Long commentId,
+      @CurrentUser CustomUserDetails user) {
+    commentService.deleteComment(commentId, user.userId());
+    return ResponseEntity.noContent().build();
   }
 }


### PR DESCRIPTION
## 변경사항
  - 댓글 수정 API 구현 (PATCH /api/v1/comments/{commentId})
  - 댓글 삭제 API 구현 (DELETE /api/v1/comments/{commentId})
  - 댓글 등록 시 comment_count 원자적 갱신으로 교체