### PR TITLE
feat(QNA): Question·Vote 컨트롤러에 Swagger UI 어노테이션 추가

### DIFF
--- a/src/main/java/com/study/qna/presentation/QuestionController.java
+++ b/src/main/java/com/study/qna/presentation/QuestionController.java
@@ -9,6 +9,8 @@ import com.study.qna.application.dto.request.question.QuestionStatusUpdateReques
 import com.study.qna.application.dto.request.question.QuestionUpdateRequest;
 import com.study.qna.application.dto.response.question.QuestionDetailResponse;
 import com.study.qna.application.dto.response.question.QuestionSummaryResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Q&A 질문", description = "질문 CRUD 및 상태 관리 API")
 @RestController
 @RequestMapping("/api/v1/questions")
 @RequiredArgsConstructor
@@ -31,6 +34,7 @@ public class QuestionController {
 
   private final QuestionService questionService;
 
+  @Operation(summary = "질문 목록 조회", description = "키워드·상태·태그·기수 필터와 정렬·페이징으로 질문 목록을 조회합니다.")
   @GetMapping
   public ResponseEntity<List<QuestionSummaryResponse>> getQuestions(
       @RequestParam(required = false) String keyword,
@@ -45,11 +49,13 @@ public class QuestionController {
     return ResponseEntity.ok(questionService.getQuestions(condition));
   }
 
+  @Operation(summary = "질문 상세 조회", description = "질문 ID로 상세 정보를 조회합니다. 조회 시 조회수가 1 증가합니다.")
   @GetMapping("/{questionId}")
   public ResponseEntity<QuestionDetailResponse> getQuestion(@PathVariable Long questionId) {
     return ResponseEntity.ok(questionService.getQuestion(questionId));
   }
 
+  @Operation(summary = "질문 등록", description = "새 질문을 등록합니다. 태그 ID 목록을 함께 전달할 수 있습니다.")
   @PostMapping
   public ResponseEntity<QuestionDetailResponse> createQuestion(
       @CurrentUser CustomUserDetails user, @Valid @RequestBody QuestionCreateRequest request) {
@@ -57,6 +63,7 @@ public class QuestionController {
     return ResponseEntity.status(HttpStatus.CREATED).body(result);
   }
 
+  @Operation(summary = "질문 수정", description = "작성자만 제목·본문·태그를 수정할 수 있습니다. null 필드는 변경하지 않습니다.")
   @PatchMapping("/{questionId}")
   public ResponseEntity<QuestionDetailResponse> updateQuestion(
       @PathVariable Long questionId,
@@ -65,6 +72,7 @@ public class QuestionController {
     return ResponseEntity.ok(questionService.updateQuestion(questionId, request, user.userId()));
   }
 
+  @Operation(summary = "질문 상태 변경", description = "작성자만 상태를 변경할 수 있습니다. OPEN → RESOLVED → CLOSED 순으로 전이됩니다.")
   @PatchMapping("/{questionId}/status")
   public ResponseEntity<QuestionDetailResponse> closeQuestion(
       @PathVariable Long questionId,
@@ -73,6 +81,7 @@ public class QuestionController {
     return ResponseEntity.ok(questionService.closeQuestion(questionId, request, user.userId()));
   }
 
+  @Operation(summary = "질문 삭제", description = "작성자만 질문을 삭제할 수 있습니다.")
   @DeleteMapping("/{questionId}")
   public ResponseEntity<Void> deleteQuestion(
       @PathVariable Long questionId, @CurrentUser CustomUserDetails user) {

--- a/src/main/java/com/study/qna/presentation/VoteController.java
+++ b/src/main/java/com/study/qna/presentation/VoteController.java
@@ -5,6 +5,8 @@ import com.study.auth.infrastructure.security.CustomUserDetails;
 import com.study.qna.application.VoteService;
 import com.study.qna.application.dto.request.vote.VoteCreateRequest;
 import com.study.qna.application.dto.response.vote.MyVoteResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Q&A 투표", description = "답변 추천/비추천 투표 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
@@ -24,6 +27,7 @@ public class VoteController {
 
   private final VoteService voteService;
 
+  @Operation(summary = "투표 생성", description = "답변에 UPVOTE 또는 DOWNVOTE를 등록합니다. 본인 답변 투표 및 중복 투표는 불가합니다.")
   @PostMapping("/answers/{answerId}/votes")
   public ResponseEntity<Void> createVote(
       @PathVariable Long answerId,
@@ -33,6 +37,7 @@ public class VoteController {
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 
+  @Operation(summary = "투표 취소", description = "등록한 투표를 취소합니다. 투표가 없으면 404를 반환합니다.")
   @DeleteMapping("/answers/{answerId}/votes")
   public ResponseEntity<Void> cancelVote(
       @PathVariable Long answerId, @CurrentUser CustomUserDetails user) {
@@ -40,6 +45,7 @@ public class VoteController {
     return ResponseEntity.noContent().build();
   }
 
+  @Operation(summary = "내 투표 조회", description = "해당 답변에 대한 내 투표 타입을 조회합니다. 투표가 없으면 type이 null로 반환됩니다.")
   @GetMapping("/answers/{answerId}/votes/me")
   public ResponseEntity<MyVoteResponse> getMyVote(
       @PathVariable Long answerId, @CurrentUser CustomUserDetails user) {


### PR DESCRIPTION
## 개요

  Q&A 도메인의 Question·Vote 컨트롤러에 Swagger UI 어노테이션을 추가합니다.

  ---

  ## 변경 사항

  ### QuestionController

  | 어노테이션 | 적용 위치 | 내용 |
  |-----------|-----------|------|
  | `@Tag` | 클래스 | `name = "Q&A 질문"` |
  | `@Operation` | `GET /questions` | 질문 목록 조회 |
  | `@Operation` | `GET /questions/{id}` | 질문 상세 조회 |
  | `@Operation` | `POST /questions` | 질문 등록 |
  | `@Operation` | `PATCH /questions/{id}` | 질문 수정 |
  | `@Operation` | `PATCH /questions/{id}/status` | 질문 상태 변경 |
  | `@Operation` | `DELETE /questions/{id}` | 질문 삭제 |

  ### VoteController

  | 어노테이션 | 적용 위치 | 내용 |
  |-----------|-----------|------|
  | `@Tag` | 클래스 | `name = "Q&A 투표"` |
  | `@Operation` | `POST /answers/{id}/votes` | 투표 생성 |
  | `@Operation` | `DELETE /answers/{id}/votes` | 투표 취소 |
  | `@Operation` | `GET /answers/{id}/votes/me` | 내 투표 조회 |

  ---

  ## 확인 사항

  - `/swagger-ui/index.html` 접속 시 **Q&A 질문**, **Q&A 투표** 두 그룹으로 분리되어 표시됩니다.
  - 로직 변경 없음, 어노테이션 추가만 포함됩니다.