### PR TITLE
😭feat(profile): 팀 프로필 기능의 핵심 흐름(생성·참여·운영·탈퇴) 팀 관련 API 전체 개발

### DIFF
--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -996,7 +996,7 @@ GET /profile/contributions/ranking
 | [x] | `PATCH` | `/profile/teams/{teamId}/lead` | 팀장 양도 (팀장) | 시현 |
 | [ ] | `PUT` | `/profile/teams/{teamId}/members/{memberId}/roles` | 팀원 역할 수정 (팀장) | 시현 |
 | [x] | `DELETE` | `/profile/teams/{teamId}/members/{memberId}` | 팀원 강퇴 (팀장) | 시현 |
-| [ ] | `DELETE` | `/profile/teams/{teamId}/members/me` | 팀 탈퇴 | 시현 |
+| [x] | `DELETE` | `/profile/teams/{teamId}/members/me` | 팀 탈퇴 | 시현 |
 | [ ] | `GET` | `/profile/members/{memberId}/activities` | 멤버 활동 목록 | 근엽 |
 | [ ] | `GET` | `/profile/members/{memberId}/contributions` | 멤버 기여도 요약 | 근엽 |
 | [ ] | `GET` | `/profile/contributions/ranking` | 기여도 랭킹 | 근엽 |

--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -694,25 +694,7 @@ DELETE /profile/teams/{teamId}
 
 ---
 
-### 5-6. 초대 코드 조회 (팀장만)
-
-```
-GET /profile/teams/{teamId}/invite-code
-```
-
-> 팀장만 조회 가능. 팀원 초대 시 이 코드를 공유한다.
-
-**Response `200 OK`**
-```json
-{
-  "inviteCode": "A1B2C3",
-  "inviteCodeExpiresAt": "2025-05-10T10:00:00Z"
-}
-```
-
----
-
-### 5-7. 초대 코드 재생성 (팀장만)
+### 5-6. 초대 코드 재생성 (팀장만)
 
 ```
 POST /profile/teams/{teamId}/invite-code/regenerate
@@ -731,7 +713,7 @@ POST /profile/teams/{teamId}/invite-code/regenerate
 
 ---
 
-### 5-8. 초대 코드로 팀 가입
+### 5-7. 초대 코드로 팀 가입
 
 ```
 POST /profile/teams/join
@@ -764,7 +746,7 @@ POST /profile/teams/join
 
 ---
 
-### 5-9. 팀장 양도 (팀장만)
+### 5-8. 팀장 양도 (팀장만)
 
 ```
 PATCH /profile/teams/{teamId}/lead
@@ -792,7 +774,7 @@ PATCH /profile/teams/{teamId}/lead
 
 ---
 
-### 5-10. 팀원 역할 수정 (팀장만)
+### 5-9. 팀원 역할 수정 (팀장만)
 
 ```
 PUT /profile/teams/{teamId}/members/{memberId}/roles
@@ -817,6 +799,7 @@ PUT /profile/teams/{teamId}/members/{memberId}/roles
 ---
 
 ### 5-10. 팀원 강퇴 (팀장만)
+
 
 ```
 DELETE /profile/teams/{teamId}/members/{memberId}
@@ -1008,7 +991,6 @@ GET /profile/contributions/ranking
 | ✅   | `GET` | `/profile/teams/{teamId}` | 팀 상세 | 시현 |
 | [x] | `PATCH` | `/profile/teams/{teamId}` | 팀 정보 수정 (팀장) | 시현 |
 | [x] | `DELETE` | `/profile/teams/{teamId}` | 팀 삭제 (팀장) | 시현 |
-| [ ] | `GET` | `/profile/teams/{teamId}/invite-code` | 초대 코드 조회 (팀장) | 시현 |
 | [ ] | `POST` | `/profile/teams/{teamId}/invite-code/regenerate` | 초대 코드 재생성 (팀장) | 시현 |
 | [ ] | `POST` | `/profile/teams/join` | 초대 코드로 팀 가입 | 시현 |
 | [ ] | `PATCH` | `/profile/teams/{teamId}/lead` | 팀장 양도 (팀장) | 시현 |

--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -992,7 +992,7 @@ GET /profile/contributions/ranking
 | [x] | `PATCH` | `/profile/teams/{teamId}` | 팀 정보 수정 (팀장) | 시현 |
 | [x] | `DELETE` | `/profile/teams/{teamId}` | 팀 삭제 (팀장) | 시현 |
 | [x] | `POST` | `/profile/teams/{teamId}/invite-code/regenerate` | 초대 코드 재생성 (팀장) | 시현 |
-| [ ] | `POST` | `/profile/teams/join` | 초대 코드로 팀 가입 | 시현 |
+| [x] | `POST` | `/profile/teams/join` | 초대 코드로 팀 가입 | 시현 |
 | [ ] | `PATCH` | `/profile/teams/{teamId}/lead` | 팀장 양도 (팀장) | 시현 |
 | [ ] | `PUT` | `/profile/teams/{teamId}/members/{memberId}/roles` | 팀원 역할 수정 (팀장) | 시현 |
 | [ ] | `DELETE` | `/profile/teams/{teamId}/members/{memberId}` | 팀원 강퇴 (팀장) | 시현 |

--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -971,7 +971,7 @@ GET /profile/contributions/ranking
 |-----|--------|------|------|------|
 | [x] | `GET` | `/profile/members/me` | 내 프로필 조회 | 세인 |
 | [x] | `PATCH` | `/profile/members/me` | 내 프로필 수정 | 세인 |
-| [ ] | `GET` | `/profile/members/me/teams` | 내가 속한 팀 목록 | 시현 |
+| [x] | `GET` | `/profile/members/me/teams` | 내가 속한 팀 목록 | 시현 |
 | [x] | `GET` | `/profile/members` | 멤버 목록 | 세인 |
 | [x] | `GET` | `/profile/members/{memberId}` | 멤버 상세 | 세인 |
 | [x] | `GET` | `/profile/generations` | 기수 목록 | 세인 |

--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -993,7 +993,7 @@ GET /profile/contributions/ranking
 | [x] | `DELETE` | `/profile/teams/{teamId}` | 팀 삭제 (팀장) | 시현 |
 | [x] | `POST` | `/profile/teams/{teamId}/invite-code/regenerate` | 초대 코드 재생성 (팀장) | 시현 |
 | [x] | `POST` | `/profile/teams/join` | 초대 코드로 팀 가입 | 시현 |
-| [ ] | `PATCH` | `/profile/teams/{teamId}/lead` | 팀장 양도 (팀장) | 시현 |
+| [x] | `PATCH` | `/profile/teams/{teamId}/lead` | 팀장 양도 (팀장) | 시현 |
 | [ ] | `PUT` | `/profile/teams/{teamId}/members/{memberId}/roles` | 팀원 역할 수정 (팀장) | 시현 |
 | [ ] | `DELETE` | `/profile/teams/{teamId}/members/{memberId}` | 팀원 강퇴 (팀장) | 시현 |
 | [ ] | `DELETE` | `/profile/teams/{teamId}/members/me` | 팀 탈퇴 | 시현 |

--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -984,8 +984,8 @@ GET /profile/contributions/ranking
 
 ## 엔드포인트 요약
 
-| 구현 | 메서드 | 경로 | 설명 | 담당 |
-|---|--------|------|------|------|
+| 구현  | 메서드 | 경로 | 설명 | 담당 |
+|-----|--------|------|------|------|
 | [x] | `GET` | `/profile/members/me` | 내 프로필 조회 | 세인 |
 | [x] | `PATCH` | `/profile/members/me` | 내 프로필 수정 | 세인 |
 | [ ] | `GET` | `/profile/members/me/teams` | 내가 속한 팀 목록 | 시현 |
@@ -997,16 +997,16 @@ GET /profile/contributions/ranking
 | [x] | `PATCH` | `/profile/generations/{generationNumber}` | 기수 수정 (관리자) | 세인 |
 | [x] | `GET` | `/profile/generations/{generationNumber}/members` | 기수 멤버 목록 | 세인 |
 | [x] | `POST` | `/profile/generations/{generationNumber}/members` | 기수에 멤버 등록 (관리자) | 세인 |
-| ✅ | `GET` | `/profile/tech-stacks` | 기술 스택 목록 | 시현 |
+| ✅   | `GET` | `/profile/tech-stacks` | 기술 스택 목록 | 시현 |
 | [ ] | `POST` | `/profile/tech-stacks` | 기술 스택 등록 (관리자) | 시현 |
 | [ ] | `PATCH` | `/profile/tech-stacks/{techStackId}` | 기술 스택 수정 (관리자) | 시현 |
 | [ ] | `DELETE` | `/profile/tech-stacks/{techStackId}` | 기술 스택 삭제 (관리자) | 시현 |
 | [ ] | `GET` | `/profile/members/{memberId}/tech-stacks` | 멤버 기술 스택 조회 | 시현 |
 | [ ] | `PUT` | `/profile/members/me/tech-stacks` | 내 기술 스택 수정 | 시현 |
-| ✅ | `GET` | `/profile/teams` | 팀 목록 | 시현 |
-| ✅ | `POST` | `/profile/teams` | 팀 생성 | 시현 |
-| ✅ | `GET` | `/profile/teams/{teamId}` | 팀 상세 | 시현 |
-| [ ] | `PATCH` | `/profile/teams/{teamId}` | 팀 정보 수정 (팀장) | 시현 |
+| ✅   | `GET` | `/profile/teams` | 팀 목록 | 시현 |
+| ✅   | `POST` | `/profile/teams` | 팀 생성 | 시현 |
+| ✅   | `GET` | `/profile/teams/{teamId}` | 팀 상세 | 시현 |
+| [x] | `PATCH` | `/profile/teams/{teamId}` | 팀 정보 수정 (팀장) | 시현 |
 | [ ] | `DELETE` | `/profile/teams/{teamId}` | 팀 삭제 (팀장) | 시현 |
 | [ ] | `GET` | `/profile/teams/{teamId}/invite-code` | 초대 코드 조회 (팀장) | 시현 |
 | [ ] | `POST` | `/profile/teams/{teamId}/invite-code/regenerate` | 초대 코드 재생성 (팀장) | 시현 |

--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -774,13 +774,13 @@ PATCH /profile/teams/{teamId}/lead
 
 ---
 
-### 5-9. 팀원 역할 수정 (팀장만)
+### 5-9. 팀원 역할 수정 (팀장 또는 본인)
 
 ```
 PUT /profile/teams/{teamId}/members/{memberId}/roles
 ```
 
-> 팀장만 호출 가능. 기존 역할 목록을 전체 교체한다.
+> 팀장 또는 본인만 호출 가능. 기존 역할 목록을 전체 교체한다.
 
 **Request Body**
 ```json
@@ -994,7 +994,7 @@ GET /profile/contributions/ranking
 | [x] | `POST` | `/profile/teams/{teamId}/invite-code/regenerate` | 초대 코드 재생성 (팀장) | 시현 |
 | [x] | `POST` | `/profile/teams/join` | 초대 코드로 팀 가입 | 시현 |
 | [x] | `PATCH` | `/profile/teams/{teamId}/lead` | 팀장 양도 (팀장) | 시현 |
-| [x] | `PUT` | `/profile/teams/{teamId}/members/{memberId}/roles` | 팀원 역할 수정 (팀장) | 시현 |
+| [x] | `PUT` | `/profile/teams/{teamId}/members/{memberId}/roles` | 팀원 역할 수정 (팀장 또는 본인) | 시현 |
 | [x] | `DELETE` | `/profile/teams/{teamId}/members/{memberId}` | 팀원 강퇴 (팀장) | 시현 |
 | [x] | `DELETE` | `/profile/teams/{teamId}/members/me` | 팀 탈퇴 | 시현 |
 | [ ] | `GET` | `/profile/members/{memberId}/activities` | 멤버 활동 목록 | 근엽 |

--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -1007,7 +1007,7 @@ GET /profile/contributions/ranking
 | ✅   | `POST` | `/profile/teams` | 팀 생성 | 시현 |
 | ✅   | `GET` | `/profile/teams/{teamId}` | 팀 상세 | 시현 |
 | [x] | `PATCH` | `/profile/teams/{teamId}` | 팀 정보 수정 (팀장) | 시현 |
-| [ ] | `DELETE` | `/profile/teams/{teamId}` | 팀 삭제 (팀장) | 시현 |
+| [x] | `DELETE` | `/profile/teams/{teamId}` | 팀 삭제 (팀장) | 시현 |
 | [ ] | `GET` | `/profile/teams/{teamId}/invite-code` | 초대 코드 조회 (팀장) | 시현 |
 | [ ] | `POST` | `/profile/teams/{teamId}/invite-code/regenerate` | 초대 코드 재생성 (팀장) | 시현 |
 | [ ] | `POST` | `/profile/teams/join` | 초대 코드로 팀 가입 | 시현 |

--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -995,7 +995,7 @@ GET /profile/contributions/ranking
 | [x] | `POST` | `/profile/teams/join` | 초대 코드로 팀 가입 | 시현 |
 | [x] | `PATCH` | `/profile/teams/{teamId}/lead` | 팀장 양도 (팀장) | 시현 |
 | [ ] | `PUT` | `/profile/teams/{teamId}/members/{memberId}/roles` | 팀원 역할 수정 (팀장) | 시현 |
-| [ ] | `DELETE` | `/profile/teams/{teamId}/members/{memberId}` | 팀원 강퇴 (팀장) | 시현 |
+| [x] | `DELETE` | `/profile/teams/{teamId}/members/{memberId}` | 팀원 강퇴 (팀장) | 시현 |
 | [ ] | `DELETE` | `/profile/teams/{teamId}/members/me` | 팀 탈퇴 | 시현 |
 | [ ] | `GET` | `/profile/members/{memberId}/activities` | 멤버 활동 목록 | 근엽 |
 | [ ] | `GET` | `/profile/members/{memberId}/contributions` | 멤버 기여도 요약 | 근엽 |

--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -994,7 +994,7 @@ GET /profile/contributions/ranking
 | [x] | `POST` | `/profile/teams/{teamId}/invite-code/regenerate` | 초대 코드 재생성 (팀장) | 시현 |
 | [x] | `POST` | `/profile/teams/join` | 초대 코드로 팀 가입 | 시현 |
 | [x] | `PATCH` | `/profile/teams/{teamId}/lead` | 팀장 양도 (팀장) | 시현 |
-| [ ] | `PUT` | `/profile/teams/{teamId}/members/{memberId}/roles` | 팀원 역할 수정 (팀장) | 시현 |
+| [x] | `PUT` | `/profile/teams/{teamId}/members/{memberId}/roles` | 팀원 역할 수정 (팀장) | 시현 |
 | [x] | `DELETE` | `/profile/teams/{teamId}/members/{memberId}` | 팀원 강퇴 (팀장) | 시현 |
 | [x] | `DELETE` | `/profile/teams/{teamId}/members/me` | 팀 탈퇴 | 시현 |
 | [ ] | `GET` | `/profile/members/{memberId}/activities` | 멤버 활동 목록 | 근엽 |

--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -991,7 +991,7 @@ GET /profile/contributions/ranking
 | ✅   | `GET` | `/profile/teams/{teamId}` | 팀 상세 | 시현 |
 | [x] | `PATCH` | `/profile/teams/{teamId}` | 팀 정보 수정 (팀장) | 시현 |
 | [x] | `DELETE` | `/profile/teams/{teamId}` | 팀 삭제 (팀장) | 시현 |
-| [ ] | `POST` | `/profile/teams/{teamId}/invite-code/regenerate` | 초대 코드 재생성 (팀장) | 시현 |
+| [x] | `POST` | `/profile/teams/{teamId}/invite-code/regenerate` | 초대 코드 재생성 (팀장) | 시현 |
 | [ ] | `POST` | `/profile/teams/join` | 초대 코드로 팀 가입 | 시현 |
 | [ ] | `PATCH` | `/profile/teams/{teamId}/lead` | 팀장 양도 (팀장) | 시현 |
 | [ ] | `PUT` | `/profile/teams/{teamId}/members/{memberId}/roles` | 팀원 역할 수정 (팀장) | 시현 |

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -178,6 +178,33 @@ public class TeamService {
   }
 
   @Transactional
+  public void kickMember(Long teamId, Long targetMemberId, Long userId) {
+    Member requestMember =
+        memberRepository
+            .findByUserId(userId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "멤버를 찾을 수 없습니다."));
+
+    teamRepository
+        .findById(teamId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다."));
+
+    teamMemberRepository
+        .findByTeamIdAndMemberIdAndIsLeadTrue(teamId, requestMember.getId())
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN, "팀장만 강퇴할 수 있습니다."));
+
+    if (requestMember.getId().equals(targetMemberId)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "팀장 본인은 강퇴할 수 없습니다.");
+    }
+
+    TeamMember target =
+        teamMemberRepository
+            .findByTeamIdAndMemberIdAndStatus(teamId, targetMemberId, TeamMemberStatus.accepted)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 팀에 존재하지 않는 멤버입니다."));
+
+    target.kick();
+  }
+
+  @Transactional
   public TeamLeadTransferResponse transferLead(Long teamId, TeamLeadTransferRequest req, Long userId) {
     Member currentLeaderMember =
         memberRepository

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -11,6 +11,8 @@ import com.study.profile.application.dto.TeamDto.TeamJoinRequest;
 import com.study.profile.application.dto.TeamDto.TeamJoinResponse;
 import com.study.profile.application.dto.TeamDto.TeamLeadTransferRequest;
 import com.study.profile.application.dto.TeamDto.TeamLeadTransferResponse;
+import com.study.profile.application.dto.TeamDto.TeamMemberRoleUpdateRequest;
+import com.study.profile.application.dto.TeamDto.TeamMemberRoleUpdateResponse;
 import com.study.profile.application.dto.TeamDto.TeamUpdateRequest;
 import com.study.profile.application.dto.TeamDto.TeamUpdateResponse;
 import com.study.profile.application.dto.TeamDto.TechStackSummary;
@@ -175,6 +177,33 @@ public class TeamService {
     teamMemberRepository.save(TeamMember.createByInviteCode(team, member));
 
     return new TeamJoinResponse(team.getId(), team.getName());
+  }
+
+  @Transactional
+  public TeamMemberRoleUpdateResponse updateMemberRoles(
+      Long teamId, Long targetMemberId, TeamMemberRoleUpdateRequest req, Long userId) {
+    Member requestMember =
+        memberRepository
+            .findByUserId(userId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "멤버를 찾을 수 없습니다."));
+
+    teamRepository
+        .findById(teamId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다."));
+
+    teamMemberRepository
+        .findByTeamIdAndMemberIdAndIsLeadTrue(teamId, requestMember.getId())
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN, "팀장만 역할을 수정할 수 있습니다."));
+
+    TeamMember target =
+        teamMemberRepository
+            .findByTeamIdAndMemberIdAndStatus(teamId, targetMemberId, TeamMemberStatus.accepted)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 팀에 존재하지 않는 멤버입니다."));
+
+    target.updateRoles(req.roles());
+
+    List<String> updatedRoles = target.getRoles().stream().map(r -> r.getRole().name()).toList();
+    return new TeamMemberRoleUpdateResponse(targetMemberId, updatedRoles);
   }
 
   @Transactional

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -147,6 +147,26 @@ public class TeamService {
     return new TeamUpdateResponse(team.getId(), team.getUpdatedAt());
   }
 
+  @Transactional
+  public void deleteTeam(Long teamId, Long userId) {
+    Member member =
+        memberRepository
+            .findByUserId(userId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "멤버를 찾을 수 없습니다."));
+
+    TeamProfile team =
+        teamRepository
+            .findById(teamId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다."));
+
+    if (!teamMemberRepository.existsByTeamIdAndMemberIdAndIsLeadTrue(teamId, member.getId())) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "팀장만 삭제할 수 있습니다.");
+    }
+
+    teamMemberRepository.deleteByTeamId(teamId);
+    teamRepository.delete(team);
+  }
+
   @Transactional(readOnly = true)
   public List<TeamListResponse> getTeams(Integer generationNumber) {
     List<TeamProfile> teams =

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -6,6 +6,8 @@ import com.study.profile.application.dto.TeamDto.TeamCreateResponse;
 import com.study.profile.application.dto.TeamDto.TeamDetailResponse;
 import com.study.profile.application.dto.TeamDto.TeamListResponse;
 import com.study.profile.application.dto.TeamDto.TeamMemberSummary;
+import com.study.profile.application.dto.TeamDto.TeamUpdateRequest;
+import com.study.profile.application.dto.TeamDto.TeamUpdateResponse;
 import com.study.profile.application.dto.TeamDto.TechStackSummary;
 import com.study.profile.domain.generation.Generation;
 import com.study.profile.domain.member.Member;
@@ -20,6 +22,8 @@ import com.study.profile.infrastructure.MemberRepository;
 import com.study.profile.infrastructure.TeamMemberRepository;
 import com.study.profile.infrastructure.TeamRepository;
 import com.study.profile.infrastructure.TechStackRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -33,6 +37,8 @@ import org.springframework.web.server.ResponseStatusException;
 @Service
 @RequiredArgsConstructor
 public class TeamService {
+
+  @PersistenceContext private EntityManager entityManager;
 
   private final TeamRepository teamRepository;
   private final TeamMemberRepository teamMemberRepository;
@@ -90,6 +96,55 @@ public class TeamService {
 
     return new TeamCreateResponse(
         team.getId(), team.getInviteCode(), team.getInviteCodeExpiresAt());
+  }
+
+  @Transactional
+  public TeamUpdateResponse updateTeam(Long teamId, TeamUpdateRequest req, Long userId) {
+    Member member =
+        memberRepository
+            .findByUserId(userId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "멤버를 찾을 수 없습니다."));
+
+    TeamProfile team =
+        teamRepository
+            .findById(teamId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다."));
+
+    if (!teamMemberRepository.existsByTeamIdAndMemberIdAndIsLeadTrue(teamId, member.getId())) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "팀장만 수정할 수 있습니다.");
+    }
+
+    Generation generation = team.getGeneration();
+    if (req.generationNumber() != null) {
+      generation =
+          generationRepository
+              .findById(req.generationNumber())
+              .orElseThrow(
+                  () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "기수를 찾을 수 없습니다."));
+    }
+
+    team.update(
+        generation,
+        req.name() != null ? req.name() : team.getName(),
+        req.description() != null ? req.description() : team.getDescription(),
+        req.projectUrl() != null ? req.projectUrl() : team.getProjectUrl(),
+        req.githubUrl() != null ? req.githubUrl() : team.getGithubUrl());
+
+    team.updateImages(req.imageUrls());
+
+    if (req.techStackIds() != null) {
+      List<TechStack> techStacks =
+          req.techStackIds().isEmpty()
+              ? List.of()
+              : techStackRepository.findAllById(req.techStackIds());
+      team.clearTechStacks();
+      entityManager.flush(); // DELETE 먼저 실행 후 INSERT — unique constraint 위반 방지
+      team.addTechStacks(techStacks);
+    }
+
+    teamRepository.saveAndFlush(team);
+
+    return new TeamUpdateResponse(team.getId(), team.getUpdatedAt());
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -9,6 +9,8 @@ import com.study.profile.application.dto.TeamDto.TeamMemberSummary;
 import com.study.profile.application.dto.TeamDto.InviteCodeResponse;
 import com.study.profile.application.dto.TeamDto.TeamJoinRequest;
 import com.study.profile.application.dto.TeamDto.TeamJoinResponse;
+import com.study.profile.application.dto.TeamDto.TeamLeadTransferRequest;
+import com.study.profile.application.dto.TeamDto.TeamLeadTransferResponse;
 import com.study.profile.application.dto.TeamDto.TeamUpdateRequest;
 import com.study.profile.application.dto.TeamDto.TeamUpdateResponse;
 import com.study.profile.application.dto.TeamDto.TechStackSummary;
@@ -173,6 +175,33 @@ public class TeamService {
     teamMemberRepository.save(TeamMember.createByInviteCode(team, member));
 
     return new TeamJoinResponse(team.getId(), team.getName());
+  }
+
+  @Transactional
+  public TeamLeadTransferResponse transferLead(Long teamId, TeamLeadTransferRequest req, Long userId) {
+    Member currentLeaderMember =
+        memberRepository
+            .findByUserId(userId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "멤버를 찾을 수 없습니다."));
+
+    teamRepository
+        .findById(teamId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다."));
+
+    TeamMember currentLeader =
+        teamMemberRepository
+            .findByTeamIdAndMemberIdAndIsLeadTrue(teamId, currentLeaderMember.getId())
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN, "팀장만 양도할 수 있습니다."));
+
+    TeamMember newLeader =
+        teamMemberRepository
+            .findByTeamIdAndMemberIdAndStatus(teamId, req.memberId(), TeamMemberStatus.accepted)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "대상 멤버가 해당 팀의 accepted 상태가 아닙니다."));
+
+    currentLeader.updateLead(false);
+    newLeader.updateLead(true);
+
+    return new TeamLeadTransferResponse(teamId, req.memberId());
   }
 
   @Transactional

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -465,7 +465,10 @@ public class TeamService {
 
     String thumbUrl = team.getImages().isEmpty() ? null : team.getImages().get(0).getImageUrl();
 
-    int memberCount = team.getMembers().size();
+    int memberCount =
+        (int) team.getMembers().stream()
+            .filter(m -> m.getStatus() == TeamMemberStatus.accepted)
+            .count();
 
     return new TeamListResponse(
         team.getId(),

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -13,6 +13,7 @@ import com.study.profile.application.dto.TeamDto.TeamLeadTransferRequest;
 import com.study.profile.application.dto.TeamDto.TeamLeadTransferResponse;
 import com.study.profile.application.dto.TeamDto.TeamMemberRoleUpdateRequest;
 import com.study.profile.application.dto.TeamDto.TeamMemberRoleUpdateResponse;
+import com.study.profile.application.dto.TeamDto.MyTeamResponse;
 import com.study.profile.application.dto.TeamDto.TeamUpdateRequest;
 import com.study.profile.application.dto.TeamDto.TeamUpdateResponse;
 import com.study.profile.application.dto.TeamDto.TechStackSummary;
@@ -403,6 +404,48 @@ public class TeamService {
         isTeamMember ? team.getInviteCode() : null,
         isTeamMember ? team.getInviteCodeExpiresAt() : null,
         team.getUpdatedAt());
+  }
+
+  @Transactional(readOnly = true)
+  public List<MyTeamResponse> getMyTeams(Long userId) {
+    Member member =
+        memberRepository
+            .findByUserId(userId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "멤버를 찾을 수 없습니다."));
+
+    List<TeamMember> myTeamMembers =
+        teamMemberRepository.findByMemberIdAndStatus(member.getId(), TeamMemberStatus.accepted);
+
+    return myTeamMembers.stream()
+        .map(
+            tm -> {
+              TeamProfile team = tm.getTeam();
+              GenerationSummary generation =
+                  team.getGeneration() != null
+                      ? new GenerationSummary(team.getGeneration().getNumber())
+                      : null;
+              List<TechStackSummary> techStacks =
+                  team.getTechStacks().stream()
+                      .map(TeamTechStack::getTechStack)
+                      .map(
+                          ts ->
+                              new TechStackSummary(
+                                  ts.getId(), ts.getName(), ts.getCategory().name(), ts.getLogoUrl()))
+                      .toList();
+              List<String> roles = tm.getRoles().stream().map(r -> r.getRole().name()).toList();
+              String thumbUrl =
+                  team.getImages().isEmpty() ? null : team.getImages().get(0).getImageUrl();
+              return new MyTeamResponse(
+                  team.getId(),
+                  team.getName(),
+                  team.getDescription(),
+                  generation,
+                  techStacks,
+                  tm.isLead(),
+                  roles,
+                  thumbUrl);
+            })
+        .toList();
   }
 
   private TeamListResponse toListResponse(TeamProfile team) {

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -178,6 +178,29 @@ public class TeamService {
   }
 
   @Transactional
+  public void leaveTeam(Long teamId, Long userId) {
+    Member member =
+        memberRepository
+            .findByUserId(userId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "멤버를 찾을 수 없습니다."));
+
+    teamRepository
+        .findById(teamId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다."));
+
+    TeamMember teamMember =
+        teamMemberRepository
+            .findByTeamIdAndMemberIdAndStatus(teamId, member.getId(), TeamMemberStatus.accepted)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 팀에 속해 있지 않습니다."));
+
+    if (teamMember.isLead()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "팀장은 탈퇴할 수 없습니다. 팀을 해산하려면 팀 삭제를 이용해주세요.");
+    }
+
+    teamMember.leave();
+  }
+
+  @Transactional
   public void kickMember(Long teamId, Long targetMemberId, Long userId) {
     Member requestMember =
         memberRepository

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -191,9 +191,12 @@ public class TeamService {
         .findById(teamId)
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다."));
 
-    teamMemberRepository
-        .findByTeamIdAndMemberIdAndIsLeadTrue(teamId, requestMember.getId())
-        .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN, "팀장만 역할을 수정할 수 있습니다."));
+    boolean isLead = teamMemberRepository.existsByTeamIdAndMemberIdAndIsLeadTrue(teamId, requestMember.getId());
+    boolean isSelf = requestMember.getId().equals(targetMemberId);
+
+    if (!isLead && !isSelf) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "팀장 또는 본인만 역할을 수정할 수 있습니다.");
+    }
 
     TeamMember target =
         teamMemberRepository

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -6,6 +6,7 @@ import com.study.profile.application.dto.TeamDto.TeamCreateResponse;
 import com.study.profile.application.dto.TeamDto.TeamDetailResponse;
 import com.study.profile.application.dto.TeamDto.TeamListResponse;
 import com.study.profile.application.dto.TeamDto.TeamMemberSummary;
+import com.study.profile.application.dto.TeamDto.InviteCodeResponse;
 import com.study.profile.application.dto.TeamDto.TeamUpdateRequest;
 import com.study.profile.application.dto.TeamDto.TeamUpdateResponse;
 import com.study.profile.application.dto.TeamDto.TechStackSummary;
@@ -145,6 +146,28 @@ public class TeamService {
     teamRepository.saveAndFlush(team);
 
     return new TeamUpdateResponse(team.getId(), team.getUpdatedAt());
+  }
+
+  @Transactional
+  public InviteCodeResponse regenerateInviteCode(Long teamId, Long userId) {
+    Member member =
+        memberRepository
+            .findByUserId(userId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "멤버를 찾을 수 없습니다."));
+
+    TeamProfile team =
+        teamRepository
+            .findById(teamId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다."));
+
+    if (!teamMemberRepository.existsByTeamIdAndMemberIdAndIsLeadTrue(teamId, member.getId())) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "팀장만 초대 코드를 재생성할 수 있습니다.");
+    }
+
+    String newCode = UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase();
+    team.regenerateInviteCode(newCode);
+
+    return new InviteCodeResponse(team.getInviteCode(), team.getInviteCodeExpiresAt());
   }
 
   @Transactional

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -34,6 +34,7 @@ import jakarta.persistence.PersistenceContext;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -170,8 +171,15 @@ public class TeamService {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "만료된 초대 코드입니다.");
     }
 
-    if (teamMemberRepository.existsByTeamIdAndMemberId(team.getId(), member.getId())) {
-      throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 가입된 팀입니다.");
+    Optional<TeamMember> existing = teamMemberRepository.findByTeamIdAndMemberId(team.getId(), member.getId());
+
+    if (existing.isPresent()) {
+      TeamMember teamMember = existing.get();
+      if (teamMember.getStatus() == TeamMemberStatus.accepted) {
+        throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 가입된 팀입니다.");
+      }
+      teamMember.rejoin();
+      return new TeamJoinResponse(team.getId(), team.getName());
     }
 
     teamMemberRepository.save(TeamMember.createByInviteCode(team, member));

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -7,6 +7,8 @@ import com.study.profile.application.dto.TeamDto.TeamDetailResponse;
 import com.study.profile.application.dto.TeamDto.TeamListResponse;
 import com.study.profile.application.dto.TeamDto.TeamMemberSummary;
 import com.study.profile.application.dto.TeamDto.InviteCodeResponse;
+import com.study.profile.application.dto.TeamDto.TeamJoinRequest;
+import com.study.profile.application.dto.TeamDto.TeamJoinResponse;
 import com.study.profile.application.dto.TeamDto.TeamUpdateRequest;
 import com.study.profile.application.dto.TeamDto.TeamUpdateResponse;
 import com.study.profile.application.dto.TeamDto.TechStackSummary;
@@ -146,6 +148,31 @@ public class TeamService {
     teamRepository.saveAndFlush(team);
 
     return new TeamUpdateResponse(team.getId(), team.getUpdatedAt());
+  }
+
+  @Transactional
+  public TeamJoinResponse joinTeam(TeamJoinRequest req, Long userId) {
+    Member member =
+        memberRepository
+            .findByUserId(userId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "멤버를 찾을 수 없습니다."));
+
+    TeamProfile team =
+        teamRepository
+            .findByInviteCode(req.inviteCode())
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "유효하지 않은 초대 코드입니다."));
+
+    if (team.getInviteCodeExpiresAt().isBefore(Instant.now())) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "만료된 초대 코드입니다.");
+    }
+
+    if (teamMemberRepository.existsByTeamIdAndMemberId(team.getId(), member.getId())) {
+      throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 가입된 팀입니다.");
+    }
+
+    teamMemberRepository.save(TeamMember.createByInviteCode(team, member));
+
+    return new TeamJoinResponse(team.getId(), team.getName());
   }
 
   @Transactional

--- a/src/main/java/com/study/profile/application/dto/TeamDto.java
+++ b/src/main/java/com/study/profile/application/dto/TeamDto.java
@@ -27,6 +27,8 @@ public class TeamDto {
 
   public record TeamUpdateResponse(Long id, Instant updatedAt) {}
 
+  public record InviteCodeResponse(String inviteCode, Instant inviteCodeExpiresAt) {}
+
   public record GenerationSummary(Integer number) {}
 
   public record TechStackSummary(Long id, String name, String category, String logoUrl) {}

--- a/src/main/java/com/study/profile/application/dto/TeamDto.java
+++ b/src/main/java/com/study/profile/application/dto/TeamDto.java
@@ -16,6 +16,17 @@ public class TeamDto {
 
   public record TeamCreateResponse(Long id, String inviteCode, Instant inviteCodeExpiresAt) {}
 
+  public record TeamUpdateRequest(
+      String name,
+      String description,
+      String projectUrl,
+      String githubUrl,
+      Integer generationNumber,
+      List<String> imageUrls,
+      List<Long> techStackIds) {}
+
+  public record TeamUpdateResponse(Long id, Instant updatedAt) {}
+
   public record GenerationSummary(Integer number) {}
 
   public record TechStackSummary(Long id, String name, String category, String logoUrl) {}

--- a/src/main/java/com/study/profile/application/dto/TeamDto.java
+++ b/src/main/java/com/study/profile/application/dto/TeamDto.java
@@ -37,6 +37,10 @@ public class TeamDto {
 
   public record TeamLeadTransferResponse(Long teamId, Long newLeadMemberId) {}
 
+  public record TeamMemberRoleUpdateRequest(List<com.study.profile.domain.team.RoleInTeam> roles) {}
+
+  public record TeamMemberRoleUpdateResponse(Long memberId, List<String> roles) {}
+
   public record GenerationSummary(Integer number) {}
 
   public record TechStackSummary(Long id, String name, String category, String logoUrl) {}

--- a/src/main/java/com/study/profile/application/dto/TeamDto.java
+++ b/src/main/java/com/study/profile/application/dto/TeamDto.java
@@ -62,6 +62,16 @@ public class TeamDto {
       boolean isLead,
       List<String> roles) {}
 
+  public record MyTeamResponse(
+      Long id,
+      String name,
+      String description,
+      GenerationSummary generation,
+      List<TechStackSummary> techStacks,
+      boolean isLead,
+      List<String> roles,
+      String thumbUrl) {}
+
   public record TeamDetailResponse(
       Long id,
       String name,

--- a/src/main/java/com/study/profile/application/dto/TeamDto.java
+++ b/src/main/java/com/study/profile/application/dto/TeamDto.java
@@ -33,6 +33,10 @@ public class TeamDto {
 
   public record TeamJoinResponse(Long teamId, String teamName) {}
 
+  public record TeamLeadTransferRequest(Long memberId) {}
+
+  public record TeamLeadTransferResponse(Long teamId, Long newLeadMemberId) {}
+
   public record GenerationSummary(Integer number) {}
 
   public record TechStackSummary(Long id, String name, String category, String logoUrl) {}

--- a/src/main/java/com/study/profile/application/dto/TeamDto.java
+++ b/src/main/java/com/study/profile/application/dto/TeamDto.java
@@ -29,6 +29,10 @@ public class TeamDto {
 
   public record InviteCodeResponse(String inviteCode, Instant inviteCodeExpiresAt) {}
 
+  public record TeamJoinRequest(String inviteCode) {}
+
+  public record TeamJoinResponse(Long teamId, String teamName) {}
+
   public record GenerationSummary(Integer number) {}
 
   public record TechStackSummary(Long id, String name, String category, String logoUrl) {}

--- a/src/main/java/com/study/profile/domain/team/TeamMember.java
+++ b/src/main/java/com/study/profile/domain/team/TeamMember.java
@@ -109,6 +109,11 @@ public class TeamMember {
     this.status = TeamMemberStatus.left;
   }
 
+  public void rejoin() {
+    this.status = TeamMemberStatus.accepted;
+    this.isLead = false;
+  }
+
   public void updateRoles(List<RoleInTeam> newRoles) {
     this.roles.clear();
     newRoles.stream().distinct().forEach(role -> this.roles.add(TeamMemberRole.create(this, role)));

--- a/src/main/java/com/study/profile/domain/team/TeamMember.java
+++ b/src/main/java/com/study/profile/domain/team/TeamMember.java
@@ -105,6 +105,10 @@ public class TeamMember {
     this.status = TeamMemberStatus.kicked;
   }
 
+  public void leave() {
+    this.status = TeamMemberStatus.left;
+  }
+
   public static TeamMember createByInviteCode(TeamProfile team, Member member) {
     TeamMember teamMember = new TeamMember();
     teamMember.team = team;

--- a/src/main/java/com/study/profile/domain/team/TeamMember.java
+++ b/src/main/java/com/study/profile/domain/team/TeamMember.java
@@ -97,6 +97,15 @@ public class TeamMember {
     this.roles.add(TeamMemberRole.create(this, role));
   }
 
+  public static TeamMember createByInviteCode(TeamProfile team, Member member) {
+    TeamMember teamMember = new TeamMember();
+    teamMember.team = team;
+    teamMember.member = member;
+    teamMember.isLead = false;
+    teamMember.status = TeamMemberStatus.accepted;
+    return teamMember;
+  }
+
   /** DB 저장 직전에 JPA가 자동으로 현재 시각을 createdAt에 넣어준다. */
   @PrePersist
   void prePersist() {

--- a/src/main/java/com/study/profile/domain/team/TeamMember.java
+++ b/src/main/java/com/study/profile/domain/team/TeamMember.java
@@ -97,6 +97,10 @@ public class TeamMember {
     this.roles.add(TeamMemberRole.create(this, role));
   }
 
+  public void updateLead(boolean isLead) {
+    this.isLead = isLead;
+  }
+
   public static TeamMember createByInviteCode(TeamProfile team, Member member) {
     TeamMember teamMember = new TeamMember();
     teamMember.team = team;

--- a/src/main/java/com/study/profile/domain/team/TeamMember.java
+++ b/src/main/java/com/study/profile/domain/team/TeamMember.java
@@ -109,6 +109,11 @@ public class TeamMember {
     this.status = TeamMemberStatus.left;
   }
 
+  public void updateRoles(List<RoleInTeam> newRoles) {
+    this.roles.clear();
+    newRoles.stream().distinct().forEach(role -> this.roles.add(TeamMemberRole.create(this, role)));
+  }
+
   public static TeamMember createByInviteCode(TeamProfile team, Member member) {
     TeamMember teamMember = new TeamMember();
     teamMember.team = team;

--- a/src/main/java/com/study/profile/domain/team/TeamMember.java
+++ b/src/main/java/com/study/profile/domain/team/TeamMember.java
@@ -101,6 +101,10 @@ public class TeamMember {
     this.isLead = isLead;
   }
 
+  public void kick() {
+    this.status = TeamMemberStatus.kicked;
+  }
+
   public static TeamMember createByInviteCode(TeamProfile team, Member member) {
     TeamMember teamMember = new TeamMember();
     teamMember.team = team;

--- a/src/main/java/com/study/profile/domain/team/TeamProfile.java
+++ b/src/main/java/com/study/profile/domain/team/TeamProfile.java
@@ -105,16 +105,21 @@ public class TeamProfile {
 
   /** 팀의 사용 기술 스택을 업데이트하는 메서드 */
   public void updateTechStacks(List<TechStack> newStacks) {
-    // 1. null이면 아무것도 하지 않고 기존 스택 유지 (방어 로직)
     if (newStacks == null) {
       return;
     }
-
-    // 2. 기존 스택 비우기
     this.techStacks.clear();
-
-    // 3. 중복을 제거(.distinct())하고 리스트에 추가
     newStacks.stream()
+        .distinct()
+        .forEach(stack -> this.techStacks.add(TeamTechStack.create(this, stack)));
+  }
+
+  public void clearTechStacks() {
+    this.techStacks.clear();
+  }
+
+  public void addTechStacks(List<TechStack> stacks) {
+    stacks.stream()
         .distinct()
         .forEach(stack -> this.techStacks.add(TeamTechStack.create(this, stack)));
   }

--- a/src/main/java/com/study/profile/infrastructure/TeamMemberRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/TeamMemberRepository.java
@@ -12,4 +12,6 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
   boolean existsByTeamIdAndMemberIdAndIsLeadTrue(Long teamId, Long memberId);
 
   void deleteByTeamId(Long teamId);
+
+  boolean existsByTeamIdAndMemberId(Long teamId, Long memberId);
 }

--- a/src/main/java/com/study/profile/infrastructure/TeamMemberRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/TeamMemberRepository.java
@@ -3,6 +3,7 @@ package com.study.profile.infrastructure;
 import com.study.profile.domain.team.TeamMember;
 import com.study.profile.domain.team.TeamMemberStatus;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
@@ -14,4 +15,10 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
   void deleteByTeamId(Long teamId);
 
   boolean existsByTeamIdAndMemberId(Long teamId, Long memberId);
+
+  Optional<TeamMember> findByTeamIdAndMemberIdAndIsLeadTrue(Long teamId, Long memberId);
+
+  Optional<TeamMember> findByTeamIdAndMemberId(Long teamId, Long memberId);
+
+  Optional<TeamMember> findByTeamIdAndMemberIdAndStatus(Long teamId, Long memberId, TeamMemberStatus status);
 }

--- a/src/main/java/com/study/profile/infrastructure/TeamMemberRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/TeamMemberRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
 
   List<TeamMember> findByTeamIdAndStatus(Long teamId, TeamMemberStatus status);
+
+  boolean existsByTeamIdAndMemberIdAndIsLeadTrue(Long teamId, Long memberId);
 }

--- a/src/main/java/com/study/profile/infrastructure/TeamMemberRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/TeamMemberRepository.java
@@ -20,5 +20,7 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
 
   Optional<TeamMember> findByTeamIdAndMemberId(Long teamId, Long memberId);
 
+  List<TeamMember> findByMemberIdAndStatus(Long memberId, TeamMemberStatus status);
+
   Optional<TeamMember> findByTeamIdAndMemberIdAndStatus(Long teamId, Long memberId, TeamMemberStatus status);
 }

--- a/src/main/java/com/study/profile/infrastructure/TeamMemberRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/TeamMemberRepository.java
@@ -10,4 +10,6 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
   List<TeamMember> findByTeamIdAndStatus(Long teamId, TeamMemberStatus status);
 
   boolean existsByTeamIdAndMemberIdAndIsLeadTrue(Long teamId, Long memberId);
+
+  void deleteByTeamId(Long teamId);
 }

--- a/src/main/java/com/study/profile/presentation/MemberController.java
+++ b/src/main/java/com/study/profile/presentation/MemberController.java
@@ -3,13 +3,18 @@ package com.study.profile.presentation;
 import com.study.auth.infrastructure.security.CurrentUser;
 import com.study.auth.infrastructure.security.CustomUserDetails;
 import com.study.profile.application.MemberService;
+import com.study.profile.application.TeamService;
 import com.study.profile.application.dto.MemberDto;
 import com.study.profile.application.dto.MemberSummaryDto;
 import com.study.profile.application.dto.MemberUpdateRequest;
 import com.study.profile.application.dto.MemberUpdateResponse;
+import com.study.profile.application.dto.TeamDto.MyTeamResponse;
 import com.study.profile.domain.member.SessionType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,20 +25,27 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "멤버 프로필", description = "멤버 조회·수정 API")
 @RestController
 @RequestMapping("/api/profile/members")
+@RequiredArgsConstructor
 public class MemberController {
 
   private final MemberService memberService;
+  private final TeamService teamService;
 
-  public MemberController(MemberService memberService) {
-    this.memberService = memberService;
-  }
-
+  @Operation(summary = "내 프로필 조회")
   @GetMapping("/me")
   @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
   public ResponseEntity<MemberDto> getMyProfile(@CurrentUser CustomUserDetails user) {
     return ResponseEntity.ok(memberService.getMyProfile(user.userId()));
+  }
+
+  @Operation(summary = "내가 속한 팀 목록 조회", description = "로그인한 멤버가 accepted 상태로 참여 중인 팀 목록을 반환합니다.")
+  @GetMapping("/me/teams")
+  @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
+  public ResponseEntity<List<MyTeamResponse>> getMyTeams(@CurrentUser CustomUserDetails user) {
+    return ResponseEntity.ok(teamService.getMyTeams(user.userId()));
   }
 
   @PatchMapping("/me")

--- a/src/main/java/com/study/profile/presentation/TeamController.java
+++ b/src/main/java/com/study/profile/presentation/TeamController.java
@@ -71,6 +71,17 @@ public class TeamController {
     return ResponseEntity.ok(teamService.joinTeam(req, user.userId()));
   }
 
+  @Operation(summary = "팀원 강퇴", description = "팀장만 호출 가능. 강퇴된 팀원의 status는 kicked로 변경됩니다. 팀장 본인은 강퇴할 수 없습니다.")
+  @DeleteMapping("/{teamId}/members/{memberId}")
+  @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
+  public ResponseEntity<Void> kickMember(
+      @PathVariable Long teamId,
+      @PathVariable Long memberId,
+      @CurrentUser CustomUserDetails user) {
+    teamService.kickMember(teamId, memberId, user.userId());
+    return ResponseEntity.noContent().build();
+  }
+
   @Operation(summary = "팀장 양도", description = "팀장만 호출 가능. 기존 팀장의 isLead는 false, 새 팀장의 isLead는 true로 변경됩니다. 대상 멤버는 accepted 상태여야 합니다.")
   @PatchMapping("/{teamId}/lead")
   @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")

--- a/src/main/java/com/study/profile/presentation/TeamController.java
+++ b/src/main/java/com/study/profile/presentation/TeamController.java
@@ -10,6 +10,8 @@ import com.study.profile.application.dto.TeamDto.TeamListResponse;
 import com.study.profile.application.dto.TeamDto.InviteCodeResponse;
 import com.study.profile.application.dto.TeamDto.TeamJoinRequest;
 import com.study.profile.application.dto.TeamDto.TeamJoinResponse;
+import com.study.profile.application.dto.TeamDto.TeamLeadTransferRequest;
+import com.study.profile.application.dto.TeamDto.TeamLeadTransferResponse;
 import com.study.profile.application.dto.TeamDto.TeamUpdateRequest;
 import com.study.profile.application.dto.TeamDto.TeamUpdateResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -67,6 +69,16 @@ public class TeamController {
   public ResponseEntity<TeamJoinResponse> joinTeam(
       @RequestBody TeamJoinRequest req, @CurrentUser CustomUserDetails user) {
     return ResponseEntity.ok(teamService.joinTeam(req, user.userId()));
+  }
+
+  @Operation(summary = "팀장 양도", description = "팀장만 호출 가능. 기존 팀장의 isLead는 false, 새 팀장의 isLead는 true로 변경됩니다. 대상 멤버는 accepted 상태여야 합니다.")
+  @PatchMapping("/{teamId}/lead")
+  @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
+  public ResponseEntity<TeamLeadTransferResponse> transferLead(
+      @PathVariable Long teamId,
+      @RequestBody TeamLeadTransferRequest req,
+      @CurrentUser CustomUserDetails user) {
+    return ResponseEntity.ok(teamService.transferLead(teamId, req, user.userId()));
   }
 
   @Operation(summary = "초대 코드 재생성", description = "팀장만 초대 코드를 재생성할 수 있습니다. 기존 코드는 즉시 무효화되고 만료 시각은 현재 시각 + 3일로 갱신됩니다.")

--- a/src/main/java/com/study/profile/presentation/TeamController.java
+++ b/src/main/java/com/study/profile/presentation/TeamController.java
@@ -83,7 +83,7 @@ public class TeamController {
     return ResponseEntity.noContent().build();
   }
 
-  @Operation(summary = "팀원 역할 수정", description = "팀장만 호출 가능. 기존 역할 목록을 전체 교체합니다. 빈 배열이면 전체 삭제.")
+  @Operation(summary = "팀원 역할 수정", description = "팀장 또는 본인만 호출 가능. 기존 역할 목록을 전체 교체합니다. 빈 배열이면 전체 삭제.")
   @PutMapping("/{teamId}/members/{memberId}/roles")
   @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
   public ResponseEntity<TeamMemberRoleUpdateResponse> updateMemberRoles(

--- a/src/main/java/com/study/profile/presentation/TeamController.java
+++ b/src/main/java/com/study/profile/presentation/TeamController.java
@@ -71,6 +71,15 @@ public class TeamController {
     return ResponseEntity.ok(teamService.joinTeam(req, user.userId()));
   }
 
+  @Operation(summary = "팀 탈퇴", description = "팀원이 팀을 탈퇴합니다. 탈퇴 시 status는 left로 변경됩니다. 팀장은 탈퇴 불가 — 팀 해산은 팀 삭제를 이용하세요.")
+  @DeleteMapping("/{teamId}/members/me")
+  @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
+  public ResponseEntity<Void> leaveTeam(
+      @PathVariable Long teamId, @CurrentUser CustomUserDetails user) {
+    teamService.leaveTeam(teamId, user.userId());
+    return ResponseEntity.noContent().build();
+  }
+
   @Operation(summary = "팀원 강퇴", description = "팀장만 호출 가능. 강퇴된 팀원의 status는 kicked로 변경됩니다. 팀장 본인은 강퇴할 수 없습니다.")
   @DeleteMapping("/{teamId}/members/{memberId}")
   @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")

--- a/src/main/java/com/study/profile/presentation/TeamController.java
+++ b/src/main/java/com/study/profile/presentation/TeamController.java
@@ -8,6 +8,8 @@ import com.study.profile.application.dto.TeamDto.TeamCreateResponse;
 import com.study.profile.application.dto.TeamDto.TeamDetailResponse;
 import com.study.profile.application.dto.TeamDto.TeamListResponse;
 import com.study.profile.application.dto.TeamDto.InviteCodeResponse;
+import com.study.profile.application.dto.TeamDto.TeamJoinRequest;
+import com.study.profile.application.dto.TeamDto.TeamJoinResponse;
 import com.study.profile.application.dto.TeamDto.TeamUpdateRequest;
 import com.study.profile.application.dto.TeamDto.TeamUpdateResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -57,6 +59,14 @@ public class TeamController {
       @RequestBody TeamCreateRequest req, @CurrentUser CustomUserDetails user) {
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(teamService.createTeam(req, user.userId()));
+  }
+
+  @Operation(summary = "초대 코드로 팀 가입", description = "초대 코드를 입력해 팀에 가입합니다. 가입 즉시 status = accepted로 확정됩니다.")
+  @PostMapping("/join")
+  @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
+  public ResponseEntity<TeamJoinResponse> joinTeam(
+      @RequestBody TeamJoinRequest req, @CurrentUser CustomUserDetails user) {
+    return ResponseEntity.ok(teamService.joinTeam(req, user.userId()));
   }
 
   @Operation(summary = "초대 코드 재생성", description = "팀장만 초대 코드를 재생성할 수 있습니다. 기존 코드는 즉시 무효화되고 만료 시각은 현재 시각 + 3일로 갱신됩니다.")

--- a/src/main/java/com/study/profile/presentation/TeamController.java
+++ b/src/main/java/com/study/profile/presentation/TeamController.java
@@ -12,6 +12,8 @@ import com.study.profile.application.dto.TeamDto.TeamJoinRequest;
 import com.study.profile.application.dto.TeamDto.TeamJoinResponse;
 import com.study.profile.application.dto.TeamDto.TeamLeadTransferRequest;
 import com.study.profile.application.dto.TeamDto.TeamLeadTransferResponse;
+import com.study.profile.application.dto.TeamDto.TeamMemberRoleUpdateRequest;
+import com.study.profile.application.dto.TeamDto.TeamMemberRoleUpdateResponse;
 import com.study.profile.application.dto.TeamDto.TeamUpdateRequest;
 import com.study.profile.application.dto.TeamDto.TeamUpdateResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,6 +24,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -78,6 +81,17 @@ public class TeamController {
       @PathVariable Long teamId, @CurrentUser CustomUserDetails user) {
     teamService.leaveTeam(teamId, user.userId());
     return ResponseEntity.noContent().build();
+  }
+
+  @Operation(summary = "팀원 역할 수정", description = "팀장만 호출 가능. 기존 역할 목록을 전체 교체합니다. 빈 배열이면 전체 삭제.")
+  @PutMapping("/{teamId}/members/{memberId}/roles")
+  @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
+  public ResponseEntity<TeamMemberRoleUpdateResponse> updateMemberRoles(
+      @PathVariable Long teamId,
+      @PathVariable Long memberId,
+      @RequestBody TeamMemberRoleUpdateRequest req,
+      @CurrentUser CustomUserDetails user) {
+    return ResponseEntity.ok(teamService.updateMemberRoles(teamId, memberId, req, user.userId()));
   }
 
   @Operation(summary = "팀원 강퇴", description = "팀장만 호출 가능. 강퇴된 팀원의 status는 kicked로 변경됩니다. 팀장 본인은 강퇴할 수 없습니다.")

--- a/src/main/java/com/study/profile/presentation/TeamController.java
+++ b/src/main/java/com/study/profile/presentation/TeamController.java
@@ -7,6 +7,7 @@ import com.study.profile.application.dto.TeamDto.TeamCreateRequest;
 import com.study.profile.application.dto.TeamDto.TeamCreateResponse;
 import com.study.profile.application.dto.TeamDto.TeamDetailResponse;
 import com.study.profile.application.dto.TeamDto.TeamListResponse;
+import com.study.profile.application.dto.TeamDto.InviteCodeResponse;
 import com.study.profile.application.dto.TeamDto.TeamUpdateRequest;
 import com.study.profile.application.dto.TeamDto.TeamUpdateResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -56,6 +57,14 @@ public class TeamController {
       @RequestBody TeamCreateRequest req, @CurrentUser CustomUserDetails user) {
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(teamService.createTeam(req, user.userId()));
+  }
+
+  @Operation(summary = "초대 코드 재생성", description = "팀장만 초대 코드를 재생성할 수 있습니다. 기존 코드는 즉시 무효화되고 만료 시각은 현재 시각 + 3일로 갱신됩니다.")
+  @PostMapping("/{teamId}/invite-code/regenerate")
+  @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
+  public ResponseEntity<InviteCodeResponse> regenerateInviteCode(
+      @PathVariable Long teamId, @CurrentUser CustomUserDetails user) {
+    return ResponseEntity.ok(teamService.regenerateInviteCode(teamId, user.userId()));
   }
 
   @Operation(summary = "팀 삭제", description = "팀장만 팀을 삭제할 수 있습니다. 팀원·이미지·기술스택 모두 함께 삭제됩니다.")

--- a/src/main/java/com/study/profile/presentation/TeamController.java
+++ b/src/main/java/com/study/profile/presentation/TeamController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -55,6 +56,15 @@ public class TeamController {
       @RequestBody TeamCreateRequest req, @CurrentUser CustomUserDetails user) {
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(teamService.createTeam(req, user.userId()));
+  }
+
+  @Operation(summary = "팀 삭제", description = "팀장만 팀을 삭제할 수 있습니다. 팀원·이미지·기술스택 모두 함께 삭제됩니다.")
+  @DeleteMapping("/{teamId}")
+  @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
+  public ResponseEntity<Void> deleteTeam(
+      @PathVariable Long teamId, @CurrentUser CustomUserDetails user) {
+    teamService.deleteTeam(teamId, user.userId());
+    return ResponseEntity.noContent().build();
   }
 
   @Operation(summary = "팀 정보 수정", description = "팀장만 팀 이름·설명·기술스택·이미지 등을 수정할 수 있습니다. null 필드는 변경하지 않습니다.")

--- a/src/main/java/com/study/profile/presentation/TeamController.java
+++ b/src/main/java/com/study/profile/presentation/TeamController.java
@@ -7,12 +7,17 @@ import com.study.profile.application.dto.TeamDto.TeamCreateRequest;
 import com.study.profile.application.dto.TeamDto.TeamCreateResponse;
 import com.study.profile.application.dto.TeamDto.TeamDetailResponse;
 import com.study.profile.application.dto.TeamDto.TeamListResponse;
+import com.study.profile.application.dto.TeamDto.TeamUpdateRequest;
+import com.study.profile.application.dto.TeamDto.TeamUpdateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "팀 프로필", description = "팀 생성·조회·수정 API")
 @RestController
 @RequestMapping("/api/profile/teams")
 @RequiredArgsConstructor
@@ -27,12 +33,14 @@ public class TeamController {
 
   private final TeamService teamService;
 
+  @Operation(summary = "팀 목록 조회", description = "기수 번호로 필터링하여 팀 목록을 조회합니다. 기수 미입력 시 전체 조회.")
   @GetMapping
   public ResponseEntity<List<TeamListResponse>> getTeams(
       @RequestParam(required = false) Integer generationNumber) {
     return ResponseEntity.ok(teamService.getTeams(generationNumber));
   }
 
+  @Operation(summary = "팀 상세 조회", description = "팀 ID로 팀 상세 정보를 조회합니다. 비로그인 상태로도 조회 가능합니다.")
   @GetMapping("/{teamId}")
   public ResponseEntity<TeamDetailResponse> getTeamDetail(
       @PathVariable Long teamId, @CurrentUser CustomUserDetails user) {
@@ -40,11 +48,22 @@ public class TeamController {
     return ResponseEntity.ok(teamService.getTeamDetail(teamId, userId));
   }
 
+  @Operation(summary = "팀 생성", description = "새 팀을 생성합니다. 생성한 유저가 팀장으로 자동 등록되며 초대코드가 발급됩니다.")
   @PostMapping
   @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
   public ResponseEntity<TeamCreateResponse> createTeam(
       @RequestBody TeamCreateRequest req, @CurrentUser CustomUserDetails user) {
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(teamService.createTeam(req, user.userId()));
+  }
+
+  @Operation(summary = "팀 정보 수정", description = "팀장만 팀 이름·설명·기술스택·이미지 등을 수정할 수 있습니다. null 필드는 변경하지 않습니다.")
+  @PatchMapping("/{teamId}")
+  @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
+  public ResponseEntity<TeamUpdateResponse> updateTeam(
+      @PathVariable Long teamId,
+      @RequestBody TeamUpdateRequest req,
+      @CurrentUser CustomUserDetails user) {
+    return ResponseEntity.ok(teamService.updateTeam(teamId, req, user.userId()));
   }
 }


### PR DESCRIPTION
## WHAT                                                                                                                                                                                                      
  ### 신규 엔드포인트 (11개)              
  | 메서드 | 경로 | 설명 |                                                                                                                                                                                     
  |--------|------|------|                                                                                                                                                                                     
  | `PATCH` | `/profile/teams/{teamId}` | 팀 정보 수정 (팀장만) |                                                                                                                                              
  | `DELETE` | `/profile/teams/{teamId}` | 팀 삭제 (팀장만) |                                                                                                                                                  
  | `POST` | `/profile/teams/{teamId}/invite-code/regenerate` | 초대 코드 재생성 (팀장만) |                                                                                                                    
  | `POST` | `/profile/teams/join` | 초대 코드로 팀 가입 |                                                                                                                                                     
  | `PATCH` | `/profile/teams/{teamId}/lead` | 팀장 양도 (팀장만) |                                                                                                                                            
  | `PUT` | `/profile/teams/{teamId}/members/{memberId}/roles` | 팀원 역할 수정 (팀장 또는 본인) |                                                                                                             
  | `DELETE` | `/profile/teams/{teamId}/members/{memberId}` | 팀원 강퇴 (팀장만) |                                                                                                                             
  | `DELETE` | `/profile/teams/{teamId}/members/me` | 팀 탈퇴 |                                                                                                                                                
  | `GET` | `/profile/members/me/teams` | 내가 속한 팀 목록 조회 |                                                                                                                                             
                                                                                                                                                                                                               
  ### 버그 수정                                                                                                                                                                                                
  - **팀 기술스택 수정 시 409 에러**: `clearTechStacks()` → `entityManager.flush()` → `addTechStacks()` 순서로 분리해 Hibernate flush 순서 문제(INSERT before DELETE) 해결                                     
  - **초대 코드 가입 후 팀 상세에 멤버 미노출**: `TeamMember.create()`가 `isLead=false`일 때 `status=pending`으로 설정하던 문제 → `createByInviteCode()` 팩토리 메서드 추가로 `status=accepted` 직접 지정      
  - **탈퇴/강퇴된 멤버 재가입 불가**: `existsByTeamIdAndMemberId`로 막던 로직을 `findByTeamIdAndMemberId` + status 체크로 변경, `rejoin()` 메서드 추가                                                         
  - **팀 목록 memberCount에 탈퇴·강퇴 멤버 포함**: `team.getMembers().size()` → `accepted` 상태 필터링으로 수정                                                                                                
                                                                                                                                                                                                               
  ---                                                                                                                                                                                                          
                                                                                                                                                                                                               
  ## HOW                                                                                                                                                                                                       
  - 팀장 권한 검사: `existsByTeamIdAndMemberIdAndIsLeadTrue()` / `findByTeamIdAndMemberIdAndIsLeadTrue()`                                                                                                      
  - 역할 수정 자기 자신 허용: `requestMember.getId().equals(targetMemberId)` 로 본인 여부 판단                                                                                                                 
  - 초대 코드: UUID 앞 8자리 대문자, 만료 시각은 생성/재생성 기준 +3일
  - 팀 삭제: `deleteByTeamId()` 후 `teamRepository.delete()` — cascade로 image·techStack·memberRole 연쇄 삭제

## TEST
> 다 완료!!! 에러 핸들러 관련 부분은 의논 필요