### PR TITLE
refactor(qna): 질문 상태 전이 단순화 (OPEN/RESOLVED)

### DIFF
--- a/src/main/java/com/study/qna/application/AnswerService.java
+++ b/src/main/java/com/study/qna/application/AnswerService.java
@@ -50,7 +50,7 @@ public class AnswerService {
             .findById(questionId)
             .orElseThrow(() -> new QuestionNotFoundException(questionId));
 
-    if (question.getStatus() == QuestionStatus.CLOSED) {
+    if (question.getStatus() == QuestionStatus.RESOLVED) {
       throw new QuestionAlreadyClosedException(questionId);
     }
 
@@ -90,7 +90,7 @@ public class AnswerService {
       throw new ForbiddenQnaActionException();
     }
 
-    if (question.getStatus() == QuestionStatus.CLOSED) {
+    if (question.getStatus() == QuestionStatus.RESOLVED) {
       throw new QuestionAlreadyClosedException(question.getId());
     }
 

--- a/src/main/java/com/study/qna/application/QuestionService.java
+++ b/src/main/java/com/study/qna/application/QuestionService.java
@@ -90,7 +90,7 @@ public class QuestionService {
   }
 
   @Transactional
-  public QuestionDetailResponse closeQuestion(
+  public QuestionDetailResponse updateQuestionStatus(
       Long questionId, QuestionStatusUpdateRequest request, Long userId) {
     Question question =
         questionRepository
@@ -102,8 +102,8 @@ public class QuestionService {
     }
 
     QuestionStatus targetStatus = QuestionStatus.valueOf(request.status());
-    if (targetStatus == QuestionStatus.CLOSED) {
-      question.close();
+    if (targetStatus == QuestionStatus.RESOLVED) {
+      question.resolve();
     }
 
     return toDetailResponse(question);

--- a/src/main/java/com/study/qna/application/dto/request/question/QuestionStatusUpdateRequest.java
+++ b/src/main/java/com/study/qna/application/dto/request/question/QuestionStatusUpdateRequest.java
@@ -5,4 +5,4 @@ import jakarta.validation.constraints.Pattern;
 
 /** 질문 상태 변경 요청 DTO. */
 public record QuestionStatusUpdateRequest(
-    @NotBlank @Pattern(regexp = "CLOSED", message = "status는 CLOSED만 허용됩니다") String status) {}
+    @NotBlank @Pattern(regexp = "RESOLVED", message = "status는 RESOLVED만 허용됩니다") String status) {}

--- a/src/main/java/com/study/qna/domain/Question.java
+++ b/src/main/java/com/study/qna/domain/Question.java
@@ -100,20 +100,6 @@ public class Question {
     this.status = QuestionStatus.RESOLVED;
   }
 
-  public void close() {
-    if (!this.status.canTransitionTo(QuestionStatus.CLOSED)) {
-      throw new IllegalStateException("질문 상태를 CLOSED로 변경할 수 없습니다");
-    }
-    this.status = QuestionStatus.CLOSED;
-  }
-
-  public void reopen() {
-    if (this.status != QuestionStatus.CLOSED) {
-      throw new IllegalStateException("CLOSED 상태인 질문만 다시 OPEN으로 변경할 수 있습니다");
-    }
-    this.status = QuestionStatus.OPEN;
-  }
-
   public void addTag(Tag tag) {
     boolean exists =
         this.questionTags.stream()

--- a/src/main/java/com/study/qna/domain/QuestionStatus.java
+++ b/src/main/java/com/study/qna/domain/QuestionStatus.java
@@ -3,16 +3,9 @@ package com.study.qna.domain;
 /** 질문 상태 Enum과 상태 전이 규칙을 정의한다. */
 public enum QuestionStatus {
   OPEN,
-  RESOLVED,
-  CLOSED;
+  RESOLVED;
 
   public boolean canTransitionTo(QuestionStatus next) {
-    if (this == OPEN) {
-      return next == RESOLVED || next == CLOSED;
-    }
-    if (this == RESOLVED) {
-      return next == CLOSED;
-    }
-    return false;
+    return this == OPEN && next == RESOLVED;
   }
 }

--- a/src/main/java/com/study/qna/presentation/QuestionController.java
+++ b/src/main/java/com/study/qna/presentation/QuestionController.java
@@ -74,13 +74,14 @@ public class QuestionController {
 
   @Operation(
       summary = "질문 상태 변경",
-      description = "작성자만 상태를 변경할 수 있습니다. OPEN → RESOLVED → CLOSED 순으로 전이됩니다.")
+      description = "작성자만 상태를 변경할 수 있습니다. OPEN → RESOLVED 전이만 허용됩니다.")
   @PatchMapping("/{questionId}/status")
-  public ResponseEntity<QuestionDetailResponse> closeQuestion(
+  public ResponseEntity<QuestionDetailResponse> updateQuestionStatus(
       @PathVariable Long questionId,
       @CurrentUser CustomUserDetails user,
       @Valid @RequestBody QuestionStatusUpdateRequest request) {
-    return ResponseEntity.ok(questionService.closeQuestion(questionId, request, user.userId()));
+    return ResponseEntity.ok(
+        questionService.updateQuestionStatus(questionId, request, user.userId()));
   }
 
   @Operation(summary = "질문 삭제", description = "작성자만 질문을 삭제할 수 있습니다.")


### PR DESCRIPTION
## 변경 배경
  QnA 질문 상태 모델을 `OPEN - RESOLVED - CLOSED`에서 `OPEN - RESOLVED`로 단순화하기 위해,
  질문 상태 전이와 상태 변경 API/DTO를 정리함

  ## 변경 내용
  - `QuestionStatus`에서 `CLOSED` 제거
  - 상태 전이 규칙 변경
    - 기존: `OPEN -> RESOLVED -> CLOSED` (및 OPEN -> CLOSED)
    - 변경: `OPEN -> RESOLVED`만 허용
  - 질문 상태 변경 요청 DTO 검증값 변경
    - `status=CLOSED`만 허용 -> `status=RESOLVED`만 허용
  - 질문 상태 변경 서비스/컨트롤러 메서드명 정리
    - `closeQuestion` -> `updateQuestionStatus`
  - Swagger 설명 문구를 2상태 전이 정책으로 갱신
  - enum 변경으로 인한 컴파일 이슈 방지
    - `AnswerService`의 `QuestionStatus.CLOSED` 비교를 `RESOLVED`로 정리

  ## 영향 범위
  - QnA 질문 상태 변경 API (`PATCH /api/v1/questions/{questionId}/status`)
  - QnA 답변 작성/채택 시 질문 상태 체크 로직(RESOLVED 기준)

  ## 검증
  - `./gradlew.bat compileJava` 통과

  ## 비고
  - 이번 PR은 질문 상태 모델/상태 API 정리에 한정
  - 채택 취소/다중 채택 기능은 별도 PR에서 진행 예정