### PR TITLE
feat(qna): 질문 삭제 시 연관 데이터 cascade 삭제 구현

### DIFF
--- a/src/main/java/com/study/qna/application/AnswerService.java
+++ b/src/main/java/com/study/qna/application/AnswerService.java
@@ -108,6 +108,21 @@ public class AnswerService {
     return AnswerDetailResponse.from(answer, tempAuthor(answer.getUserId()));
   }
 
+  /**
+   * 질문 cascade 삭제 시 호출되는 답변 삭제.
+   *
+   * <p>TODO(answer 담당자): 아래 순서로 구현 필요
+   *
+   * <ol>
+   *   <li>해당 answer의 comment 목록 조회 → 삭제 + QnaCommentDeleted 이벤트 발행
+   *   <li>answer 삭제 + QnaAnswerDeleted 이벤트 발행
+   * </ol>
+   *
+   * <p>주의: answerCount 감산 불필요 — 질문 자체가 삭제되므로.
+   */
+  @Transactional
+  public void deleteAnswerCascade(Answer answer) {}
+
   @Transactional
   public void deleteAnswer(Long answerId, Long userId) {
     Answer answer =

--- a/src/main/java/com/study/qna/application/QuestionService.java
+++ b/src/main/java/com/study/qna/application/QuestionService.java
@@ -8,18 +8,23 @@ import com.study.qna.application.dto.response.common.MemberSummaryResponse;
 import com.study.qna.application.dto.response.question.QuestionDetailResponse;
 import com.study.qna.application.dto.response.question.QuestionSummaryResponse;
 import com.study.qna.application.dto.response.tag.TagResponse;
+import com.study.qna.domain.Answer;
 import com.study.qna.domain.Question;
 import com.study.qna.domain.QuestionStatus;
 import com.study.qna.domain.Tag;
 import com.study.qna.domain.exception.ForbiddenQnaActionException;
 import com.study.qna.domain.exception.QuestionNotFoundException;
 import com.study.qna.domain.exception.TagNotFoundException;
+import com.study.qna.infrastructure.AnswerRepository;
 import com.study.qna.infrastructure.QuestionRepository;
 import com.study.qna.infrastructure.TagRepository;
+import com.study.qna.infrastructure.VoteRepository;
+import com.study.shared.extevent.qna.QnaQuestionDeleted;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,7 +36,11 @@ public class QuestionService {
   private static final String TEMP_NICKNAME = "임시닉네임";
 
   private final QuestionRepository questionRepository;
+  private final AnswerRepository answerRepository;
+  private final VoteRepository voteRepository;
+  private final AnswerService answerService;
   private final TagRepository tagRepository;
+  private final ApplicationEventPublisher eventPublisher;
 
   public List<QuestionSummaryResponse> getQuestions(QuestionSearchCondition condition) {
     return questionRepository.searchQuestions(condition).stream()
@@ -120,7 +129,14 @@ public class QuestionService {
       throw new ForbiddenQnaActionException();
     }
 
+    List<Answer> answers = answerRepository.findByQuestionId(questionId);
+    for (Answer answer : answers) {
+      voteRepository.deleteAllByAnswer_Id(answer.getId());
+      answerService.deleteAnswerCascade(answer);
+    }
+
     questionRepository.delete(question);
+    eventPublisher.publishEvent(new QnaQuestionDeleted(userId, questionId));
   }
 
   private List<Tag> fetchAndValidateTags(List<Long> tagIds) {

--- a/src/main/java/com/study/qna/infrastructure/VoteRepository.java
+++ b/src/main/java/com/study/qna/infrastructure/VoteRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface VoteRepository extends JpaRepository<Vote, Long> {
 
   Optional<Vote> findByAnswer_IdAndUserId(Long answerId, Long userId);
+
+  void deleteAllByAnswer_Id(Long answerId);
 }


### PR DESCRIPTION
## 작업 내용

  질문 삭제 시 연관 데이터를 cascade로 정리하는 로직을 구현했습니다.

  ### 변경 파일
  - `QuestionService.deleteQuestion()`: cascade 흐름 추가
  - `VoteRepository`: `deleteAllByAnswer_Id()` 추가
  - `AnswerService`: `deleteAnswerCascade()` stub 추가

  ### deleteQuestion() 실행 흐름
  answer 목록 조회
    └─ 각 answer에 대해:
         1. voteRepository.deleteAllByAnswer_Id()   ← 이 PR에서 완료
         2. answerService.deleteAnswerCascade()      ← answer 담당자 구현 필요 (아래 참고)
  question 삭제
  QnaQuestionDeleted 이벤트 발행

  ---

  ## ⚠️ answer 담당자 작업 요청

  `AnswerService.deleteAnswerCascade(Answer answer)` stub을 채워주세요.

  **구현해야 할 내용:**
  1. 해당 answer의 comment 목록 조회 → 삭제 + `QnaCommentDeleted` 이벤트 발행
  2. answer 삭제 + `QnaAnswerDeleted` 이벤트 발행

  **주의사항:**
  - `answerCount` 감산 **불필요** (질문 자체가 삭제되므로)
  - `ApplicationEventPublisher` 주입 추가 필요
  - 기존 `deleteAnswer()`와 달리 권한 체크 없음 (question 삭제 시점에 이미 검증됨)

  **stub 위치:** `AnswerService.java` — `deleteAnswerCascade()` 메서드