### PR TITLE
✨feat: 내 기술 스택 수정 API 구현 (PUT /members/me/tech-stacks)

### DIFF
--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -967,36 +967,36 @@ GET /profile/contributions/ranking
 
 ## 엔드포인트 요약
 
-| 구현 | 메서드 | 경로 | 설명 | 담당 |
-|---|--------|------|------|------|
-| [x] | `GET` | `/profile/members/me` | 내 프로필 조회 | 세인 |
-| [x] | `PATCH` | `/profile/members/me` | 내 프로필 수정 | 세인 |
-| ✅ | `GET` | `/profile/members/me/teams` | 내가 속한 팀 목록 | 시현 |
-| [x] | `GET` | `/profile/members` | 멤버 목록 | 세인 |
-| [x] | `GET` | `/profile/members/{memberId}` | 멤버 상세 | 세인 |
-| [x] | `GET` | `/profile/generations` | 기수 목록 | 세인 |
-| [x] | `POST` | `/profile/generations` | 기수 생성 (관리자) | 세인 |
+| 구현  | 메서드 | 경로 | 설명 | 담당 |
+|-----|--------|------|------|------|
+| ✅   | `GET` | `/profile/members/me` | 내 프로필 조회 | 세인 |
+| ✅   | `PATCH` | `/profile/members/me` | 내 프로필 수정 | 세인 |
+| ✅   | `GET` | `/profile/members/me/teams` | 내가 속한 팀 목록 | 시현 |
+| ✅   | `GET` | `/profile/members` | 멤버 목록 | 세인 |
+| ✅   | `GET` | `/profile/members/{memberId}` | 멤버 상세 | 세인 |
+| ✅   | `GET` | `/profile/generations` | 기수 목록 | 세인 |
+| ✅   | `POST` | `/profile/generations` | 기수 생성 (관리자) | 세인 |
 | [x] | `GET` | `/profile/generations/{generationNumber}` | 기수 상세 | 세인 |
-| [x] | `PATCH` | `/profile/generations/{generationNumber}` | 기수 수정 (관리자) | 세인 |
-| [x] | `GET` | `/profile/generations/{generationNumber}/members` | 기수 멤버 목록 | 세인 |
-| [x] | `POST` | `/profile/generations/{generationNumber}/members` | 기수에 멤버 등록 (관리자) | 세인 |
-| ✅ | `GET` | `/profile/tech-stacks` | 기술 스택 목록 | 시현 |
+| ✅   | `PATCH` | `/profile/generations/{generationNumber}` | 기수 수정 (관리자) | 세인 |
+| ✅   | `GET` | `/profile/generations/{generationNumber}/members` | 기수 멤버 목록 | 세인 |
+| ✅   | `POST` | `/profile/generations/{generationNumber}/members` | 기수에 멤버 등록 (관리자) | 세인 |
+| ✅   | `GET` | `/profile/tech-stacks` | 기술 스택 목록 | 시현 |
 | [ ] | `POST` | `/profile/tech-stacks` | 기술 스택 등록 (관리자) | 시현 |
 | [ ] | `PATCH` | `/profile/tech-stacks/{techStackId}` | 기술 스택 수정 (관리자) | 시현 |
 | [ ] | `DELETE` | `/profile/tech-stacks/{techStackId}` | 기술 스택 삭제 (관리자) | 시현 |
 | [ ] | `GET` | `/profile/members/{memberId}/tech-stacks` | 멤버 기술 스택 조회 | 시현 |
 | [ ] | `PUT` | `/profile/members/me/tech-stacks` | 내 기술 스택 수정 | 시현 |
-| ✅ | `GET` | `/profile/teams` | 팀 목록 | 시현 |
-| ✅ | `POST` | `/profile/teams` | 팀 생성 | 시현 |
-| ✅ | `GET` | `/profile/teams/{teamId}` | 팀 상세 | 시현 |
-| ✅ | `PATCH` | `/profile/teams/{teamId}` | 팀 정보 수정 (팀장) | 시현 |
-| ✅ | `DELETE` | `/profile/teams/{teamId}` | 팀 삭제 (팀장) | 시현 |
-| ✅ | `POST` | `/profile/teams/{teamId}/invite-code/regenerate` | 초대 코드 재생성 (팀장) | 시현 |
-| ✅ | `POST` | `/profile/teams/join` | 초대 코드로 팀 가입 | 시현 |
-| ✅ | `PATCH` | `/profile/teams/{teamId}/lead` | 팀장 양도 (팀장) | 시현 |
-| ✅ | `PUT` | `/profile/teams/{teamId}/members/{memberId}/roles` | 팀원 역할 수정 (팀장 또는 본인) | 시현 |
-| ✅ | `DELETE` | `/profile/teams/{teamId}/members/{memberId}` | 팀원 강퇴 (팀장) | 시현 |
-| ✅ | `DELETE` | `/profile/teams/{teamId}/members/me` | 팀 탈퇴 | 시현 |
+| ✅   | `GET` | `/profile/teams` | 팀 목록 | 시현 |
+| ✅   | `POST` | `/profile/teams` | 팀 생성 | 시현 |
+| ✅   | `GET` | `/profile/teams/{teamId}` | 팀 상세 | 시현 |
+| ✅   | `PATCH` | `/profile/teams/{teamId}` | 팀 정보 수정 (팀장) | 시현 |
+| ✅   | `DELETE` | `/profile/teams/{teamId}` | 팀 삭제 (팀장) | 시현 |
+| ✅   | `POST` | `/profile/teams/{teamId}/invite-code/regenerate` | 초대 코드 재생성 (팀장) | 시현 |
+| ✅   | `POST` | `/profile/teams/join` | 초대 코드로 팀 가입 | 시현 |
+| ✅   | `PATCH` | `/profile/teams/{teamId}/lead` | 팀장 양도 (팀장) | 시현 |
+| ✅   | `PUT` | `/profile/teams/{teamId}/members/{memberId}/roles` | 팀원 역할 수정 (팀장 또는 본인) | 시현 |
+| ✅   | `DELETE` | `/profile/teams/{teamId}/members/{memberId}` | 팀원 강퇴 (팀장) | 시현 |
+| ✅   | `DELETE` | `/profile/teams/{teamId}/members/me` | 팀 탈퇴 | 시현 |
 | [ ] | `GET` | `/profile/members/{memberId}/activities` | 멤버 활동 목록 | 근엽 |
 | [ ] | `GET` | `/profile/members/{memberId}/contributions` | 멤버 기여도 요약 | 근엽 |
 | [ ] | `GET` | `/profile/contributions/ranking` | 기여도 랭킹 | 근엽 |

--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -967,11 +967,11 @@ GET /profile/contributions/ranking
 
 ## 엔드포인트 요약
 
-| 구현  | 메서드 | 경로 | 설명 | 담당 |
-|-----|--------|------|------|------|
+| 구현 | 메서드 | 경로 | 설명 | 담당 |
+|---|--------|------|------|------|
 | [x] | `GET` | `/profile/members/me` | 내 프로필 조회 | 세인 |
 | [x] | `PATCH` | `/profile/members/me` | 내 프로필 수정 | 세인 |
-| [x] | `GET` | `/profile/members/me/teams` | 내가 속한 팀 목록 | 시현 |
+| ✅ | `GET` | `/profile/members/me/teams` | 내가 속한 팀 목록 | 시현 |
 | [x] | `GET` | `/profile/members` | 멤버 목록 | 세인 |
 | [x] | `GET` | `/profile/members/{memberId}` | 멤버 상세 | 세인 |
 | [x] | `GET` | `/profile/generations` | 기수 목록 | 세인 |
@@ -980,23 +980,23 @@ GET /profile/contributions/ranking
 | [x] | `PATCH` | `/profile/generations/{generationNumber}` | 기수 수정 (관리자) | 세인 |
 | [x] | `GET` | `/profile/generations/{generationNumber}/members` | 기수 멤버 목록 | 세인 |
 | [x] | `POST` | `/profile/generations/{generationNumber}/members` | 기수에 멤버 등록 (관리자) | 세인 |
-| ✅   | `GET` | `/profile/tech-stacks` | 기술 스택 목록 | 시현 |
+| ✅ | `GET` | `/profile/tech-stacks` | 기술 스택 목록 | 시현 |
 | [ ] | `POST` | `/profile/tech-stacks` | 기술 스택 등록 (관리자) | 시현 |
 | [ ] | `PATCH` | `/profile/tech-stacks/{techStackId}` | 기술 스택 수정 (관리자) | 시현 |
 | [ ] | `DELETE` | `/profile/tech-stacks/{techStackId}` | 기술 스택 삭제 (관리자) | 시현 |
 | [ ] | `GET` | `/profile/members/{memberId}/tech-stacks` | 멤버 기술 스택 조회 | 시현 |
 | [ ] | `PUT` | `/profile/members/me/tech-stacks` | 내 기술 스택 수정 | 시현 |
-| ✅   | `GET` | `/profile/teams` | 팀 목록 | 시현 |
-| ✅   | `POST` | `/profile/teams` | 팀 생성 | 시현 |
-| ✅   | `GET` | `/profile/teams/{teamId}` | 팀 상세 | 시현 |
-| [x] | `PATCH` | `/profile/teams/{teamId}` | 팀 정보 수정 (팀장) | 시현 |
-| [x] | `DELETE` | `/profile/teams/{teamId}` | 팀 삭제 (팀장) | 시현 |
-| [x] | `POST` | `/profile/teams/{teamId}/invite-code/regenerate` | 초대 코드 재생성 (팀장) | 시현 |
-| [x] | `POST` | `/profile/teams/join` | 초대 코드로 팀 가입 | 시현 |
-| [x] | `PATCH` | `/profile/teams/{teamId}/lead` | 팀장 양도 (팀장) | 시현 |
-| [x] | `PUT` | `/profile/teams/{teamId}/members/{memberId}/roles` | 팀원 역할 수정 (팀장 또는 본인) | 시현 |
-| [x] | `DELETE` | `/profile/teams/{teamId}/members/{memberId}` | 팀원 강퇴 (팀장) | 시현 |
-| [x] | `DELETE` | `/profile/teams/{teamId}/members/me` | 팀 탈퇴 | 시현 |
+| ✅ | `GET` | `/profile/teams` | 팀 목록 | 시현 |
+| ✅ | `POST` | `/profile/teams` | 팀 생성 | 시현 |
+| ✅ | `GET` | `/profile/teams/{teamId}` | 팀 상세 | 시현 |
+| ✅ | `PATCH` | `/profile/teams/{teamId}` | 팀 정보 수정 (팀장) | 시현 |
+| ✅ | `DELETE` | `/profile/teams/{teamId}` | 팀 삭제 (팀장) | 시현 |
+| ✅ | `POST` | `/profile/teams/{teamId}/invite-code/regenerate` | 초대 코드 재생성 (팀장) | 시현 |
+| ✅ | `POST` | `/profile/teams/join` | 초대 코드로 팀 가입 | 시현 |
+| ✅ | `PATCH` | `/profile/teams/{teamId}/lead` | 팀장 양도 (팀장) | 시현 |
+| ✅ | `PUT` | `/profile/teams/{teamId}/members/{memberId}/roles` | 팀원 역할 수정 (팀장 또는 본인) | 시현 |
+| ✅ | `DELETE` | `/profile/teams/{teamId}/members/{memberId}` | 팀원 강퇴 (팀장) | 시현 |
+| ✅ | `DELETE` | `/profile/teams/{teamId}/members/me` | 팀 탈퇴 | 시현 |
 | [ ] | `GET` | `/profile/members/{memberId}/activities` | 멤버 활동 목록 | 근엽 |
 | [ ] | `GET` | `/profile/members/{memberId}/contributions` | 멤버 기여도 요약 | 근엽 |
 | [ ] | `GET` | `/profile/contributions/ranking` | 기여도 랭킹 | 근엽 |

--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -985,7 +985,7 @@ GET /profile/contributions/ranking
 | [ ] | `PATCH` | `/profile/tech-stacks/{techStackId}` | 기술 스택 수정 (관리자) | 시현 |
 | [ ] | `DELETE` | `/profile/tech-stacks/{techStackId}` | 기술 스택 삭제 (관리자) | 시현 |
 | [ ] | `GET` | `/profile/members/{memberId}/tech-stacks` | 멤버 기술 스택 조회 | 시현 |
-| [ ] | `PUT` | `/profile/members/me/tech-stacks` | 내 기술 스택 수정 | 시현 |
+| ✅   | `PUT` | `/profile/members/me/tech-stacks` | 내 기술 스택 수정 | 시현 |
 | ✅   | `GET` | `/profile/teams` | 팀 목록 | 시현 |
 | ✅   | `POST` | `/profile/teams` | 팀 생성 | 시현 |
 | ✅   | `GET` | `/profile/teams/{teamId}` | 팀 상세 | 시현 |

--- a/src/main/java/com/study/profile/application/MemberService.java
+++ b/src/main/java/com/study/profile/application/MemberService.java
@@ -6,32 +6,50 @@ import com.study.profile.application.dto.MemberCreateRequest;
 import com.study.profile.application.dto.MemberDto;
 import com.study.profile.application.dto.MemberGenerationDto;
 import com.study.profile.application.dto.MemberSummaryDto;
+import com.study.profile.application.dto.MemberTechStackUpdateRequest;
 import com.study.profile.application.dto.MemberUpdateRequest;
 import com.study.profile.application.dto.MemberUpdateResponse;
+import com.study.profile.application.dto.TechStackItemDto;
 import com.study.profile.domain.member.Member;
 import com.study.profile.domain.member.SessionType;
+import com.study.profile.domain.techstack.MemberTechStack;
+import com.study.profile.domain.techstack.TechStack;
 import com.study.profile.infrastructure.MemberGenerationRepository;
 import com.study.profile.infrastructure.MemberRepository;
+import com.study.profile.infrastructure.MemberTechStackRepository;
+import com.study.profile.infrastructure.TechStackRepository;
+import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.PersistenceContext;
 import java.util.List;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @Transactional(readOnly = true)
 public class MemberService {
 
+  @PersistenceContext private EntityManager entityManager;
+
   private final MemberRepository memberRepository;
   private final MemberGenerationRepository memberGenerationRepository;
   private final UserRepository userRepository;
+  private final TechStackRepository techStackRepository;
+  private final MemberTechStackRepository memberTechStackRepository;
 
   public MemberService(
       MemberRepository memberRepository,
       MemberGenerationRepository memberGenerationRepository,
-      UserRepository userRepository) {
+      UserRepository userRepository,
+      TechStackRepository techStackRepository,
+      MemberTechStackRepository memberTechStackRepository) {
     this.memberRepository = memberRepository;
     this.memberGenerationRepository = memberGenerationRepository;
     this.userRepository = userRepository;
+    this.techStackRepository = techStackRepository;
+    this.memberTechStackRepository = memberTechStackRepository;
   }
 
   public Member getMemberToUserId(Long userId) {
@@ -113,6 +131,31 @@ public class MemberService {
               : memberRepository.findAllSorted();
     }
     return members.stream().map(MemberSummaryDto::from).toList();
+  }
+
+  @Transactional
+  public List<TechStackItemDto> updateMyTechStacks(
+      Long userId, List<MemberTechStackUpdateRequest> req) {
+    Member member =
+        memberRepository
+            .findByUserId(userId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "멤버를 찾을 수 없습니다."));
+
+    member.getTechStacks().clear();
+    entityManager.flush(); // DELETE 먼저 실행 — unique constraint 위반 방지
+
+    for (MemberTechStackUpdateRequest item : req) {
+      TechStack techStack =
+          techStackRepository
+              .findById(item.techStackId())
+              .orElseThrow(
+                  () ->
+                      new ResponseStatusException(
+                          HttpStatus.NOT_FOUND, "기술 스택을 찾을 수 없습니다. id: " + item.techStackId()));
+      member.getTechStacks().add(MemberTechStack.create(member, techStack, item.proficiency()));
+    }
+
+    return member.getTechStacks().stream().map(TechStackItemDto::from).toList();
   }
 
   @Transactional

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -135,9 +135,9 @@ public class TeamService {
     team.update(
         generation,
         req.name() != null ? req.name() : team.getName(),
-        req.description() != null ? req.description() : team.getDescription(),
-        req.projectUrl() != null ? req.projectUrl() : team.getProjectUrl(),
-        req.githubUrl() != null ? req.githubUrl() : team.getGithubUrl());
+        req.description() == null ? team.getDescription() : (req.description().isBlank() ? null : req.description()),
+        req.projectUrl() == null ? team.getProjectUrl() : (req.projectUrl().isBlank() ? null : req.projectUrl()),
+        req.githubUrl() == null ? team.getGithubUrl() : (req.githubUrl().isBlank() ? null : req.githubUrl()));
 
     team.updateImages(req.imageUrls());
 

--- a/src/main/java/com/study/profile/application/dto/MemberTechStackUpdateRequest.java
+++ b/src/main/java/com/study/profile/application/dto/MemberTechStackUpdateRequest.java
@@ -1,0 +1,3 @@
+package com.study.profile.application.dto;
+
+public record MemberTechStackUpdateRequest(Long techStackId, Integer proficiency) {}

--- a/src/main/java/com/study/profile/infrastructure/MemberTechStackRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/MemberTechStackRepository.java
@@ -1,0 +1,9 @@
+package com.study.profile.infrastructure;
+
+import com.study.profile.domain.techstack.MemberTechStack;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberTechStackRepository extends JpaRepository<MemberTechStack, Long> {
+
+  void deleteByMemberId(Long memberId);
+}

--- a/src/main/java/com/study/profile/presentation/MemberController.java
+++ b/src/main/java/com/study/profile/presentation/MemberController.java
@@ -6,8 +6,10 @@ import com.study.profile.application.MemberService;
 import com.study.profile.application.TeamService;
 import com.study.profile.application.dto.MemberDto;
 import com.study.profile.application.dto.MemberSummaryDto;
+import com.study.profile.application.dto.MemberTechStackUpdateRequest;
 import com.study.profile.application.dto.MemberUpdateRequest;
 import com.study.profile.application.dto.MemberUpdateResponse;
+import com.study.profile.application.dto.TechStackItemDto;
 import com.study.profile.application.dto.TeamDto.MyTeamResponse;
 import com.study.profile.domain.member.SessionType;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,6 +22,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -46,6 +49,14 @@ public class MemberController {
   @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
   public ResponseEntity<List<MyTeamResponse>> getMyTeams(@CurrentUser CustomUserDetails user) {
     return ResponseEntity.ok(teamService.getMyTeams(user.userId()));
+  }
+
+  @Operation(summary = "내 기술 스택 수정", description = "기존 목록을 전체 교체합니다. 빈 배열 []이면 전체 삭제.")
+  @PutMapping("/me/tech-stacks")
+  @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
+  public ResponseEntity<List<TechStackItemDto>> updateMyTechStacks(
+      @RequestBody List<MemberTechStackUpdateRequest> req, @CurrentUser CustomUserDetails user) {
+    return ResponseEntity.ok(memberService.updateMyTechStacks(user.userId(), req));
   }
 
   @PatchMapping("/me")


### PR DESCRIPTION
## 변경 내용                            
                                                                                                                                                                                                               
  - `PUT /profile/members/me/tech-stacks` — 내 기술 스택 수정 API 구현                                                                                                                                         
    - 기존 목록 전체 교체, 빈 배열 `[]` 전송 시 전체 삭제
  - 팀 수정 시 선택 필드(`description`, `projectUrl`, `githubUrl`) 빈 문자열 `""`로 초기화 가능하도록 수정                                                                                                     
  - 팀 목록 `memberCount` 버그 수정 — `accepted` 상태 멤버만 집계                                                                                                                                              
  - API 명세 업데이트 (5-9 권한 설명, memberCount 기준)
  