### PR TITLE
Infra/deployment 소문자 변환 처리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,14 +39,16 @@ jobs:
               --output text | jq -r '.GHCR_TOKEN')
 
             echo $GHCR_TOKEN | docker login ghcr.io -u ${{ github.event.workflow_run.actor.login }} --password-stdin
-            docker pull ghcr.io/${{ github.repository }}:latest
+
+            IMAGE=$(echo "ghcr.io/${{ github.repository }}:latest" | tr '[:upper:]' '[:lower:]')
+            docker pull $IMAGE
 
             aws secretsmanager get-secret-value \
               --secret-id tech-blog-be \
               --query SecretString \
               --output text | jq -r 'to_entries|map("\(.key)=\(.value)")|.[]' > /home/ubuntu/.env
 
-            echo "GITHUB_REPOSITORY=${{ github.repository }}" >> /home/ubuntu/.env
+            echo "GITHUB_REPOSITORY=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')" >> /home/ubuntu/.env
 
             cd /home/ubuntu
             docker compose down

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,3 @@
-# ── Stage 1: Build ──────────────────────────────────────────────────────────
-# JDK + Gradle로 소스를 컴파일해 실행 가능한 JAR를 만드는 단계
-# 이 이미지 자체는 최종 결과물에 포함되지 않음
 FROM eclipse-temurin:21-jdk-alpine AS builder
 
 WORKDIR /workspace
@@ -16,9 +13,6 @@ COPY src src
 
 RUN ./gradlew bootJar --no-daemon -x test -q
 
-# ── Stage 2: Runtime ─────────────────────────────────────────────────────────
-# Stage 1에서 만든 JAR만 꺼내 JRE 위에서 실행하는 단계
-# JDK·Gradle·소스코드 없이 JAR + JRE만 남기므로 이미지 크기가 절반 이하로 줄어듦
 FROM eclipse-temurin:21-jre-alpine
 
 RUN addgroup -S app && adduser -S app -G app
@@ -27,8 +21,10 @@ WORKDIR /app
 
 COPY --from=builder /workspace/build/libs/*.jar app.jar
 
+RUN chown app:app app.jar
+
 USER app
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-jar", "app.jar"]


### PR DESCRIPTION
## Why
Docker 이미지 이름에 대문자가 포함된 경우(`likelion-khu-BE`) repository name must be lowercase 오류가 발생하여 EC2 배포가 실패했습니다.

## What
- `deploy.yml`에서 이미지 이름 및 `GITHUB_REPOSITORY` 소문자 변환 처리 추가

## How
- `tr '[:upper:]' '[:lower:]'`를 사용해 이미지 참조 시 소문자로 변환
- `IMAGE` 변수로 pull 경로 통일
- `.env`에 주입되는 `GITHUB_REPOSITORY` 값도 소문자로 변환하여 `docker-compose.yml`에서 올바르게 참조되도록 수정