### PR TITLE
feat: 세션 CRUD API 구현 (1-1 ~ 1-5)

### DIFF
--- a/src/main/java/com/study/sessionboard/application/session/SessionService.java
+++ b/src/main/java/com/study/sessionboard/application/session/SessionService.java
@@ -1,0 +1,131 @@
+package com.study.sessionboard.application.session;
+
+import com.study.profile.domain.generation.Generation;
+import com.study.profile.domain.member.Member;
+import com.study.profile.infrastructure.GenerationRepository;
+import com.study.profile.infrastructure.MemberRepository;
+import com.study.sessionboard.application.session.exception.SessionNotFoundException;
+import com.study.sessionboard.domain.session.Session;
+import com.study.sessionboard.domain.session.SessionSpeaker;
+import com.study.sessionboard.domain.session.SessionStatus;
+import com.study.sessionboard.infrastructure.session.ResourceRepository;
+import com.study.sessionboard.infrastructure.session.RetroRepository;
+import com.study.sessionboard.infrastructure.session.SessionNoteRepository;
+import com.study.sessionboard.infrastructure.session.SessionRepository;
+import com.study.sessionboard.infrastructure.session.SessionSpeakerRepository;
+import com.study.sessionboard.presentation.dto.session.SessionCreateRequest;
+import com.study.sessionboard.presentation.dto.session.SessionResponse;
+import com.study.sessionboard.presentation.dto.session.SessionUpdateRequest;
+import java.time.OffsetDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SessionService {
+
+  private final SessionRepository sessionRepository;
+  private final SessionSpeakerRepository sessionSpeakerRepository;
+  private final SessionNoteRepository sessionNoteRepository;
+  private final ResourceRepository resourceRepository;
+  private final RetroRepository retroRepository;
+  private final GenerationRepository generationRepository;
+  private final MemberRepository memberRepository;
+
+  public List<SessionResponse> getSessions(Integer generationNumber, SessionStatus status) {
+    List<Session> sessions =
+        (status == null)
+            ? sessionRepository.findAllByGenerationNumber(generationNumber)
+            : sessionRepository.findAllByGenerationNumberAndStatus(generationNumber, status);
+
+    return sessions.stream().map(this::toResponse).toList();
+  }
+
+  public SessionResponse getSession(Long sessionId) {
+    Session session =
+        sessionRepository
+            .findById(sessionId)
+            .orElseThrow(() -> new SessionNotFoundException(sessionId));
+    return toResponse(session);
+  }
+
+  @Transactional
+  public Long createSession(Integer generationNumber, SessionCreateRequest request) {
+    Generation generation =
+        generationRepository
+            .findById(generationNumber)
+            .orElseThrow(() -> new IllegalArgumentException("해당 기수를 찾을 수 없습니다."));
+
+    Session session =
+        Session.create(
+            generation,
+            request.weekLabel(),
+            request.title(),
+            request.status(),
+            request.startedAt());
+
+    Session savedSession = sessionRepository.save(session);
+
+    if (request.speakerIds() != null && !request.speakerIds().isEmpty()) {
+      List<Member> speakers = memberRepository.findAllById(request.speakerIds());
+
+      if (speakers.size() != request.speakerIds().size()) {
+        throw new IllegalArgumentException("존재하지 않는 스피커 ID가 포함되어 있습니다.");
+      }
+
+      speakers.forEach(
+          member -> {
+            savedSession.addSpeaker(SessionSpeaker.of(savedSession, member));
+          });
+    }
+
+    return savedSession.getId();
+  }
+
+  @Transactional
+  public OffsetDateTime updateSession(Long sessionId, SessionUpdateRequest request) {
+    Session session =
+        sessionRepository
+            .findById(sessionId)
+            .orElseThrow(() -> new SessionNotFoundException(sessionId));
+
+    session.update(request.weekLabel(), request.title(), request.status(), request.startedAt());
+
+    if (request.speakerIds() != null) {
+      session.getSpeakers().clear();
+      List<Member> speakers = memberRepository.findAllById(request.speakerIds());
+
+      if (speakers.size() != request.speakerIds().size()) {
+        throw new IllegalArgumentException("존재하지 않는 스피커 ID가 포함되어 있습니다.");
+      }
+
+      speakers.forEach(
+          member -> {
+            session.addSpeaker(SessionSpeaker.of(session, member));
+          });
+    }
+
+    return OffsetDateTime.now(); // Updated at is not in the entity, using current time for response
+  }
+
+  @Transactional
+  public void deleteSession(Long sessionId) {
+    Session session =
+        sessionRepository
+            .findById(sessionId)
+            .orElseThrow(() -> new SessionNotFoundException(sessionId));
+    sessionRepository.delete(session);
+  }
+
+  private SessionResponse toResponse(Session session) {
+    List<SessionSpeaker> speakers = sessionSpeakerRepository.findAllBySession(session);
+    Double averageRating = retroRepository.getAverageRatingBySession(session);
+    long noteCount = sessionNoteRepository.countBySession(session);
+    long resourceCount = resourceRepository.countBySession(session);
+
+    return SessionResponse.of(session, speakers, averageRating, noteCount, resourceCount);
+  }
+}

--- a/src/main/java/com/study/sessionboard/application/session/exception/SessionNotFoundException.java
+++ b/src/main/java/com/study/sessionboard/application/session/exception/SessionNotFoundException.java
@@ -1,0 +1,12 @@
+package com.study.sessionboard.application.session.exception;
+
+public class SessionNotFoundException extends RuntimeException {
+
+  public SessionNotFoundException() {
+    super("해당 세션을 찾을 수 없습니다.");
+  }
+
+  public SessionNotFoundException(Long sessionId) {
+    super("해당 세션을 찾을 수 없습니다. ID: " + sessionId);
+  }
+}

--- a/src/main/java/com/study/sessionboard/domain/session/Session.java
+++ b/src/main/java/com/study/sessionboard/domain/session/Session.java
@@ -1,6 +1,7 @@
 package com.study.sessionboard.domain.session;
 
 import com.study.profile.domain.generation.Generation;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -11,8 +12,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -44,10 +48,33 @@ public class Session {
   @Column(name = "started_at")
   private OffsetDateTime startedAt;
 
-  public static Session of(Generation generation, String title) {
+  @OneToMany(mappedBy = "session", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<SessionSpeaker> speakers = new ArrayList<>();
+
+  public void addSpeaker(SessionSpeaker speaker) {
+    this.speakers.add(speaker);
+  }
+
+  public static Session create(
+      Generation generation,
+      String weekLabel,
+      String title,
+      SessionStatus status,
+      OffsetDateTime startedAt) {
     Session session = new Session();
     session.generation = generation;
+    session.weekLabel = weekLabel;
     session.title = title;
+    session.status = status != null ? status : SessionStatus.SCHEDULED;
+    session.startedAt = startedAt;
     return session;
+  }
+
+  public void update(
+      String weekLabel, String title, SessionStatus status, OffsetDateTime startedAt) {
+    if (weekLabel != null) this.weekLabel = weekLabel;
+    if (title != null) this.title = title;
+    if (status != null) this.status = status;
+    if (startedAt != null) this.startedAt = startedAt;
   }
 }

--- a/src/main/java/com/study/sessionboard/infrastructure/session/ResourceRepository.java
+++ b/src/main/java/com/study/sessionboard/infrastructure/session/ResourceRepository.java
@@ -1,0 +1,9 @@
+package com.study.sessionboard.infrastructure.session;
+
+import com.study.sessionboard.domain.session.Resource;
+import com.study.sessionboard.domain.session.Session;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ResourceRepository extends JpaRepository<Resource, Long> {
+  long countBySession(Session session);
+}

--- a/src/main/java/com/study/sessionboard/infrastructure/session/RetroRepository.java
+++ b/src/main/java/com/study/sessionboard/infrastructure/session/RetroRepository.java
@@ -1,0 +1,12 @@
+package com.study.sessionboard.infrastructure.session;
+
+import com.study.sessionboard.domain.session.Retro;
+import com.study.sessionboard.domain.session.Session;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface RetroRepository extends JpaRepository<Retro, Long> {
+  @Query("SELECT AVG(r.rating) FROM Retro r WHERE r.session = :session")
+  Double getAverageRatingBySession(@Param("session") Session session);
+}

--- a/src/main/java/com/study/sessionboard/infrastructure/session/SessionNoteRepository.java
+++ b/src/main/java/com/study/sessionboard/infrastructure/session/SessionNoteRepository.java
@@ -1,0 +1,9 @@
+package com.study.sessionboard.infrastructure.session;
+
+import com.study.sessionboard.domain.session.Session;
+import com.study.sessionboard.domain.session.SessionNote;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SessionNoteRepository extends JpaRepository<SessionNote, Long> {
+  long countBySession(Session session);
+}

--- a/src/main/java/com/study/sessionboard/infrastructure/session/SessionRepository.java
+++ b/src/main/java/com/study/sessionboard/infrastructure/session/SessionRepository.java
@@ -1,0 +1,12 @@
+package com.study.sessionboard.infrastructure.session;
+
+import com.study.sessionboard.domain.session.Session;
+import com.study.sessionboard.domain.session.SessionStatus;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SessionRepository extends JpaRepository<Session, Long> {
+  List<Session> findAllByGenerationNumber(Integer generationNumber);
+
+  List<Session> findAllByGenerationNumberAndStatus(Integer generationNumber, SessionStatus status);
+}

--- a/src/main/java/com/study/sessionboard/infrastructure/session/SessionSpeakerRepository.java
+++ b/src/main/java/com/study/sessionboard/infrastructure/session/SessionSpeakerRepository.java
@@ -1,0 +1,12 @@
+package com.study.sessionboard.infrastructure.session;
+
+import com.study.sessionboard.domain.session.Session;
+import com.study.sessionboard.domain.session.SessionSpeaker;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SessionSpeakerRepository extends JpaRepository<SessionSpeaker, Long> {
+  List<SessionSpeaker> findAllBySession(Session session);
+
+  void deleteAllBySession(Session session);
+}

--- a/src/main/java/com/study/sessionboard/presentation/dto/session/SessionCreateRequest.java
+++ b/src/main/java/com/study/sessionboard/presentation/dto/session/SessionCreateRequest.java
@@ -1,0 +1,12 @@
+package com.study.sessionboard.presentation.dto.session;
+
+import com.study.sessionboard.domain.session.SessionStatus;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record SessionCreateRequest(
+    String weekLabel,
+    String title,
+    SessionStatus status,
+    OffsetDateTime startedAt,
+    List<Long> speakerIds) {}

--- a/src/main/java/com/study/sessionboard/presentation/dto/session/SessionCreateResponse.java
+++ b/src/main/java/com/study/sessionboard/presentation/dto/session/SessionCreateResponse.java
@@ -1,0 +1,3 @@
+package com.study.sessionboard.presentation.dto.session;
+
+public record SessionCreateResponse(Long id) {}

--- a/src/main/java/com/study/sessionboard/presentation/dto/session/SessionListResponse.java
+++ b/src/main/java/com/study/sessionboard/presentation/dto/session/SessionListResponse.java
@@ -1,0 +1,5 @@
+package com.study.sessionboard.presentation.dto.session;
+
+import java.util.List;
+
+public record SessionListResponse(List<SessionResponse> sessions) {}

--- a/src/main/java/com/study/sessionboard/presentation/dto/session/SessionResponse.java
+++ b/src/main/java/com/study/sessionboard/presentation/dto/session/SessionResponse.java
@@ -1,0 +1,44 @@
+package com.study.sessionboard.presentation.dto.session;
+
+import com.study.sessionboard.domain.session.Session;
+import com.study.sessionboard.domain.session.SessionSpeaker;
+import com.study.sessionboard.domain.session.SessionStatus;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record SessionResponse(
+    Long id,
+    String weekLabel,
+    String title,
+    SessionStatus status,
+    OffsetDateTime startedAt,
+    List<SpeakerResponse> speakers,
+    double rating,
+    long noteCount,
+    long resourceCount) {
+
+  public record SpeakerResponse(Long id, String name, String role) {}
+
+  public static SessionResponse of(
+      Session session,
+      List<SessionSpeaker> speakers,
+      Double averageRating,
+      long noteCount,
+      long resourceCount) {
+    return new SessionResponse(
+        session.getId(),
+        session.getWeekLabel(),
+        session.getTitle(),
+        session.getStatus(),
+        session.getStartedAt(),
+        speakers.stream()
+            .map(
+                s ->
+                    new SpeakerResponse(
+                        s.getMember().getId(), s.getMember().getName(), s.getRole()))
+            .toList(),
+        averageRating != null ? Math.round(averageRating * 10) / 10.0 : 0.0,
+        noteCount,
+        resourceCount);
+  }
+}

--- a/src/main/java/com/study/sessionboard/presentation/dto/session/SessionUpdateRequest.java
+++ b/src/main/java/com/study/sessionboard/presentation/dto/session/SessionUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.study.sessionboard.presentation.dto.session;
+
+import com.study.sessionboard.domain.session.SessionStatus;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record SessionUpdateRequest(
+    String weekLabel,
+    String title,
+    SessionStatus status,
+    OffsetDateTime startedAt,
+    List<Long> speakerIds) {}

--- a/src/main/java/com/study/sessionboard/presentation/dto/session/SessionUpdateResponse.java
+++ b/src/main/java/com/study/sessionboard/presentation/dto/session/SessionUpdateResponse.java
@@ -1,0 +1,5 @@
+package com.study.sessionboard.presentation.dto.session;
+
+import java.time.OffsetDateTime;
+
+public record SessionUpdateResponse(Long id, OffsetDateTime updatedAt) {}

--- a/src/main/java/com/study/sessionboard/presentation/session/SessionController.java
+++ b/src/main/java/com/study/sessionboard/presentation/session/SessionController.java
@@ -1,0 +1,68 @@
+package com.study.sessionboard.presentation.session;
+
+import com.study.sessionboard.application.session.SessionService;
+import com.study.sessionboard.domain.session.SessionStatus;
+import com.study.sessionboard.presentation.dto.session.SessionCreateRequest;
+import com.study.sessionboard.presentation.dto.session.SessionCreateResponse;
+import com.study.sessionboard.presentation.dto.session.SessionListResponse;
+import com.study.sessionboard.presentation.dto.session.SessionResponse;
+import com.study.sessionboard.presentation.dto.session.SessionUpdateRequest;
+import com.study.sessionboard.presentation.dto.session.SessionUpdateResponse;
+import java.time.OffsetDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/session-board/{generationNumber}/sessions")
+@RequiredArgsConstructor
+public class SessionController {
+
+  private final SessionService sessionService;
+
+  @GetMapping
+  public ResponseEntity<SessionListResponse> getSessions(
+      @PathVariable Integer generationNumber,
+      @RequestParam(required = false) SessionStatus status) {
+    return ResponseEntity.ok(
+        new SessionListResponse(sessionService.getSessions(generationNumber, status)));
+  }
+
+  @GetMapping("/{sessionId}")
+  public ResponseEntity<SessionResponse> getSession(
+      @PathVariable Integer generationNumber, @PathVariable Long sessionId) {
+    return ResponseEntity.ok(sessionService.getSession(sessionId));
+  }
+
+  @PostMapping
+  public ResponseEntity<SessionCreateResponse> createSession(
+      @PathVariable Integer generationNumber, @RequestBody SessionCreateRequest request) {
+    Long id = sessionService.createSession(generationNumber, request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(new SessionCreateResponse(id));
+  }
+
+  @PutMapping("/{sessionId}")
+  public ResponseEntity<SessionUpdateResponse> updateSession(
+      @PathVariable Integer generationNumber,
+      @PathVariable Long sessionId,
+      @RequestBody SessionUpdateRequest request) {
+    OffsetDateTime updatedAt = sessionService.updateSession(sessionId, request);
+    return ResponseEntity.ok(new SessionUpdateResponse(sessionId, updatedAt));
+  }
+
+  @DeleteMapping("/{sessionId}")
+  public ResponseEntity<Void> deleteSession(
+      @PathVariable Integer generationNumber, @PathVariable Long sessionId) {
+    sessionService.deleteSession(sessionId);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/study/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/study/shared/exception/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@ import com.study.qna.domain.exception.TagNotFoundException;
 import com.study.qna.domain.exception.VoteAlreadyExistsException;
 import com.study.qna.domain.exception.VoteNotFoundException;
 import com.study.qna.domain.exception.VoteSelfNotAllowedException;
+import com.study.sessionboard.application.session.exception.SessionNotFoundException;
 import com.study.shared.s3.S3Exception;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -118,6 +119,11 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(VoteNotFoundException.class)
   public ResponseEntity<Map<String, Object>> handleVoteNotFound(VoteNotFoundException e) {
+    return errorResponse(HttpStatus.NOT_FOUND, e.getMessage());
+  }
+
+  @ExceptionHandler(SessionNotFoundException.class)
+  public ResponseEntity<Map<String, Object>> handleSessionNotFound(SessionNotFoundException e) {
     return errorResponse(HttpStatus.NOT_FOUND, e.getMessage());
   }
 

--- a/src/test/java/com/study/sessionboard/integration/SessionIntegrationTest.java
+++ b/src/test/java/com/study/sessionboard/integration/SessionIntegrationTest.java
@@ -1,0 +1,152 @@
+package com.study.sessionboard.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.study.config.TestcontainersConfig;
+import com.study.profile.domain.generation.Generation;
+import com.study.profile.infrastructure.GenerationRepository;
+import com.study.sessionboard.domain.session.Session;
+import com.study.sessionboard.domain.session.SessionStatus;
+import com.study.sessionboard.infrastructure.session.SessionRepository;
+import com.study.sessionboard.presentation.dto.session.SessionCreateRequest;
+import com.study.sessionboard.presentation.dto.session.SessionUpdateRequest;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestcontainersConfig.class)
+class SessionIntegrationTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+  @Autowired private SessionRepository sessionRepository;
+  @Autowired private GenerationRepository generationRepository;
+
+  private Generation testGeneration;
+
+  @BeforeEach
+  void setUp() {
+    testGeneration = Generation.create(13, LocalDate.now(), null, true);
+    generationRepository.save(testGeneration);
+  }
+
+  @Test
+  @DisplayName("세션 생성 성공")
+  @WithMockUser
+  void createSession_Success() throws Exception {
+    SessionCreateRequest request =
+        new SessionCreateRequest(
+            "W1", "세션 제목", SessionStatus.SCHEDULED, OffsetDateTime.now(), List.of());
+
+    mockMvc
+        .perform(
+            post("/api/session-board/13/sessions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").exists());
+  }
+
+  @Test
+  @DisplayName("세션 목록 조회 성공")
+  @WithMockUser
+  void getSessions_Success() throws Exception {
+    Session session =
+        Session.create(testGeneration, "W1", "세션 1", SessionStatus.DONE, OffsetDateTime.now());
+    sessionRepository.save(session);
+
+    mockMvc
+        .perform(get("/api/session-board/13/sessions"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.sessions").isArray())
+        .andExpect(jsonPath("$.sessions[0].title").value("세션 1"));
+  }
+
+  @Test
+  @DisplayName("세션 단건 조회 성공")
+  @WithMockUser
+  void getSession_Success() throws Exception {
+    Session session =
+        Session.create(testGeneration, "W1", "세션 1", SessionStatus.DONE, OffsetDateTime.now());
+    Session saved = sessionRepository.save(session);
+
+    mockMvc
+        .perform(get("/api/session-board/13/sessions/" + saved.getId()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.title").value("세션 1"))
+        .andExpect(jsonPath("$.weekLabel").value("W1"));
+  }
+
+  @Test
+  @DisplayName("세션 단건 조회 실패 - 존재하지 않는 세션")
+  @WithMockUser
+  void getSession_NotFound() throws Exception {
+    mockMvc
+        .perform(get("/api/session-board/13/sessions/9999"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.status").value(404))
+        .andExpect(jsonPath("$.message").value("해당 세션을 찾을 수 없습니다. ID: 9999"));
+  }
+
+  @Test
+  @DisplayName("세션 수정 성공")
+  @WithMockUser
+  void updateSession_Success() throws Exception {
+    Session session =
+        Session.create(testGeneration, "W1", "세션 1", SessionStatus.SCHEDULED, OffsetDateTime.now());
+    Session saved = sessionRepository.save(session);
+
+    SessionUpdateRequest request =
+        new SessionUpdateRequest("W2", "수정된 제목", SessionStatus.ONGOING, null, List.of());
+
+    mockMvc
+        .perform(
+            put("/api/session-board/13/sessions/" + saved.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(saved.getId()))
+        .andExpect(jsonPath("$.updatedAt").exists());
+
+    Session updated = sessionRepository.findById(saved.getId()).orElseThrow();
+    assertThat(updated.getTitle()).isEqualTo("수정된 제목");
+    assertThat(updated.getWeekLabel()).isEqualTo("W2");
+    assertThat(updated.getStatus()).isEqualTo(SessionStatus.ONGOING);
+  }
+
+  @Test
+  @DisplayName("세션 삭제 성공")
+  @WithMockUser
+  void deleteSession_Success() throws Exception {
+    Session session =
+        Session.create(testGeneration, "W1", "세션 1", SessionStatus.SCHEDULED, OffsetDateTime.now());
+    Session saved = sessionRepository.save(session);
+
+    mockMvc
+        .perform(delete("/api/session-board/13/sessions/" + saved.getId()))
+        .andExpect(status().isNoContent());
+
+    assertThat(sessionRepository.findById(saved.getId())).isEmpty();
+  }
+}


### PR DESCRIPTION
[구현 내용]
- 1-1 ~ 1-5 세션 CRUD API 구현 완료

[수정 및 개선 사항]
- 생성 로직 예외 처리: DB에 존재하지 않는 스피커 ID를 입력 시 생성되지 않도록 검증 로직 추가 (IllegalArgumentException)
- Cascade 옵션 추가: 세션 삭제 시 스피커 매핑 데이터(session_speaker)도 함께 삭제되도록 Session 엔티티에 cascade = CascadeType.ALL, orphanRemoval = true 옵션 적용
- 예외 응답 코드 변경: API 명세서에 맞춰, 세션을 찾을 수 없을 때 400이 아닌 404 Not Found가 반환되도록 SessionNotFoundException 커스텀 예외 생성 및 GlobalExceptionHandler 적용

[테스트]
- 포스트맨을 통한 1-1 ~ 1-5 API 정상 동작 및 예외 상황(400, 404, 삭제 권한 등) 테스트 완료