### PR TITLE
feat(profile) : 기술 스택 (등록 / 수정 / 삭제 / 조회) 구현

### DIFF
--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -394,6 +394,7 @@ POST /profile/generations/{generationId}/members
 > **담당: 시현**
 >
 > 기술 스택은 시드 데이터로 제공된다 (`tech_stack_seed.json`). 일반 사용자는 읽기만 가능하고, 관리자만 추가/수정/삭제할 수 있다.
+>
 
 ### 3-1. 기술 스택 목록 조회
 
@@ -403,9 +404,9 @@ GET /profile/tech-stacks
 
 **Query Parameters**
 
-| 파라미터 | 타입 | 필수 | 설명 |
-|----------|------|------|------|
-| `category` | `TechStackCategory` | 아니오 | 카테고리 필터 |
+| 파라미터 | 타입 | 필수 | 기본값 | 설명                                              |
+|----------|------|------|--------|-------------------------------------------------|
+| `category` | `string` | 아니오 | `all` | 분류 필터. `all`이면 전체. 그 외 값은 `TechStackCategory` 값 |
 
 **Response `200 OK`**
 ```json
@@ -436,31 +437,66 @@ POST /profile/tech-stacks
 }
 ```
 
-| 필드 | 타입 | 필수 | 제약 |
-|------|------|------|------|
-| `name` | `string` | 예 | 중복 불가 |
-| `category` | `TechStackCategory` | 예 | — |
-| `logoUrl` | `string` | 아니오 | — |
+| 필드 | 타입 | 필수 | 제약                               |
+|------|------|------|----------------------------------|
+| `name` | `string` | 예 | 중복 불가                            |
+| `category` | `TechStackCategory` | 예 | TechStackCategory 값 가능           |
+| `logoUrl` | `string` | 아니오 | 외부 CDN 주소를 그대로 저장 (없으면 로고 없는 스택) |
 
 **Response `201 Created`**
 ```json
 { "id": 120 }
 ```
 
+**에러**
+
+| 에러 | HTTP | 메시지                 |
+|------|------|---------------------|
+| 이름 중복 | `409` | 이미 존재하는 기술 스택 이름입니다 |
+| 검증 실패 | `400` | 값이 누락되었습니다          |
+
 ---
 
 ### 3-3. 기술 스택 수정 (관리자)
 
 ```
-PATCH /profile/tech-stacks/{techStackId}
+PUT /profile/tech-stacks/{techStackId}
 ```
 
-**Request Body** — 3-2와 동일 구조
+**Path Parameter**
+
+| 파라미터 | 타입 | 설명 |
+|----------|------|------|
+| `techStackId` | `number` | 수정할 기술 스택 id |
+
+> 기존 목록을 전체 교체한다.
+
+```json
+{
+  "name": "Bun",
+  "category": "framework",
+  "logoUrl": "https://..."
+}
+```
+
+| 필드 | 타입 | 필수 | 제약                     |
+|------|------|------|------------------------|
+| `name` | `string` | 예 | 다른 기술 스택과 중복 불가        |
+| `category` | `TechStackCategory` | 예 | TechStackCategory 값 가능 |
+| `logoUrl` | `string` | 아니오 | -                      |
 
 **Response `200 OK`**
 ```json
 { "id": 1 }
 ```
+
+**에러**
+
+| 에러       | HTTP | 메시지              |
+|----------|------|------------------|
+| 수정 대상 없음 | `404` | 기술 스택을 찾을 수 없습니다 |
+| 이름 중복    | `409` | 이미 존재하는이름입니다     |
+| 검증 실패    | `400` | 값이 누락되었습니다       |
 
 ---
 
@@ -470,7 +506,22 @@ PATCH /profile/tech-stacks/{techStackId}
 DELETE /profile/tech-stacks/{techStackId}
 ```
 
+**Path Parameter**
+
+| 파라미터 | 타입 | 설명 |
+|----------|------|------|
+| `techStackId` | `number` | 삭제할 기술 스택 id |
+
+
+> 이 기술을 보유한 멤버·팀의 연결(`member_tech_stack`, `team_tech_stack`)도 함께 삭제된다. 
+
 **Response `204 No Content`**
+
+**에러**
+
+| 에러 | HTTP | 메시지 |
+|------|------|--------|
+| 기술 스택 없음 | `404` | 기술 스택을 찾을 수 없습니다 |
 
 ---
 
@@ -482,6 +533,14 @@ DELETE /profile/tech-stacks/{techStackId}
 ```
 GET /profile/members/{memberId}/tech-stacks
 ```
+
+> 특정 멤버가 보유한 기술 스택 목록. 로그인한 멤버면 조회 가능.
+
+**Path Parameter**
+
+| 파라미터 | 타입 | 설명 |
+|----------|------|------|
+| `memberId` | `number` | 조회할 멤버 id |
 
 **Response `200 OK`**
 ```json
@@ -495,6 +554,12 @@ GET /profile/members/{memberId}/tech-stacks
   }
 ]
 ```
+
+**에러**
+
+| 에러 | HTTP | 메시지 |
+|------|------|--------|
+| 멤버 없음 | `404` | 멤버를 찾을 수 없습니다 |
 
 ---
 
@@ -1017,7 +1082,7 @@ GET /profile/ranking
 ## 엔드포인트 요약
 
 | 구현  | 메서드 | 경로 | 설명 | 담당 |
-|-----|--------|------|------|------|
+|-----|--------|------|------|----|
 | ✅   | `GET` | `/profile/members/me` | 내 프로필 조회 | 세인 |
 | ✅   | `PATCH` | `/profile/members/me` | 내 프로필 수정 | 세인 |
 | ✅   | `GET` | `/profile/members/me/teams` | 내가 속한 팀 목록 | 시현 |
@@ -1030,10 +1095,10 @@ GET /profile/ranking
 | ✅   | `GET` | `/profile/generations/{generationNumber}/members` | 기수 멤버 목록 | 세인 |
 | ✅   | `POST` | `/profile/generations/{generationNumber}/members` | 기수에 멤버 등록 (관리자) | 세인 |
 | ✅   | `GET` | `/profile/tech-stacks` | 기술 스택 목록 | 시현 |
-| [ ] | `POST` | `/profile/tech-stacks` | 기술 스택 등록 (관리자) | 시현 |
-| [ ] | `PATCH` | `/profile/tech-stacks/{techStackId}` | 기술 스택 수정 (관리자) | 시현 |
-| [ ] | `DELETE` | `/profile/tech-stacks/{techStackId}` | 기술 스택 삭제 (관리자) | 시현 |
-| [ ] | `GET` | `/profile/members/{memberId}/tech-stacks` | 멤버 기술 스택 조회 | 시현 |
+| ✅   | `POST` | `/profile/tech-stacks` | 기술 스택 등록 (관리자) | 근엽 |
+| ✅   | `PUT` | `/profile/tech-stacks/{techStackId}` | 기술 스택 수정 (관리자) | 근엽 |
+| ✅   | `DELETE` | `/profile/tech-stacks/{techStackId}` | 기술 스택 삭제 (관리자) | 근엽 |
+| ✅   | `GET` | `/profile/members/{memberId}/tech-stacks` | 멤버 기술 스택 조회 | 근엽 |
 | ✅   | `PUT` | `/profile/members/me/tech-stacks` | 내 기술 스택 수정 | 시현 |
 | ✅   | `GET` | `/profile/teams` | 팀 목록 | 시현 |
 | ✅   | `POST` | `/profile/teams` | 팀 생성 | 시현 |

--- a/src/main/java/com/study/profile/application/MemberService.java
+++ b/src/main/java/com/study/profile/application/MemberService.java
@@ -10,6 +10,7 @@ import com.study.profile.application.dto.MemberTechStackUpdateRequest;
 import com.study.profile.application.dto.MemberUpdateRequest;
 import com.study.profile.application.dto.MemberUpdateResponse;
 import com.study.profile.application.dto.TechStackItemDto;
+import com.study.profile.domain.exception.MemberNotFoundException;
 import com.study.profile.domain.member.Member;
 import com.study.profile.domain.member.SessionType;
 import com.study.profile.domain.techstack.MemberTechStack;
@@ -111,6 +112,20 @@ public class MemberService {
             .map(MemberGenerationDto::from)
             .toList();
     return MemberDto.from(member, generations);
+  }
+
+  /**
+   * 특정 멤버의 기술 스택 목록 조회 (§4-1).
+   *
+   * <p>멤버가 없으면 404. {@code member.getTechStacks()}는 LAZY라 이 readOnly 트랜잭션 안에서 초기화한 뒤 반환한다. 별도 정렬은
+   * 하지 않는다 — 멤버 기술 스택을 노출하는 다른 응답(§1-1, §1-4, §4-2)과 동일하게 저장 순서를 따른다.
+   */
+  public List<TechStackItemDto> getMemberTechStacks(Long memberId) {
+    Member member =
+        memberRepository
+            .findById(memberId)
+            .orElseThrow(() -> new MemberNotFoundException(memberId));
+    return member.getTechStacks().stream().map(TechStackItemDto::from).toList();
   }
 
   public List<MemberSummaryDto> getMembers(Integer generationId, SessionType sessionType) {

--- a/src/main/java/com/study/profile/application/TechStackService.java
+++ b/src/main/java/com/study/profile/application/TechStackService.java
@@ -1,7 +1,12 @@
 package com.study.profile.application;
 
+import com.study.profile.application.dto.TechStackCreateRequest;
+import com.study.profile.application.dto.TechStackDto.IdResponse;
 import com.study.profile.application.dto.TechStackDto.TechStackListResponse;
 import com.study.profile.application.dto.TechStackDto.TechStackResponse;
+import com.study.profile.domain.exception.TechStackNameDuplicateException;
+import com.study.profile.domain.exception.TechStackNotFoundException;
+import com.study.profile.domain.techstack.TechStack;
 import com.study.profile.domain.techstack.TechStackCategory;
 import com.study.profile.infrastructure.TechStackRepository;
 import java.util.List;
@@ -24,32 +29,78 @@ public class TechStackService {
   //     JPA가 변경 감지(dirty checking)를 생략해서 성능이 약간 좋아진다.
   @Transactional(readOnly = true)
   public TechStackListResponse getTechStacks(String category) {
-    List<TechStackResponse> list;
+    // "all"(또는 미지정)이면 전체, 그 외엔 해당 분류만 필터링한다.
+    //   전체 조회 후 Java에서 거른다 — PostgreSQL 커스텀 ENUM을 WHERE 절에 직접 쓰면 타입 불일치가 나고,
+    //   tech_stack은 마스터 데이터라 수백 건 이하라 성능 문제 없음.
+    boolean all = category == null || category.isBlank() || category.equalsIgnoreCase("all");
 
-    // 11. 전체 목록을 한 번에 조회한 뒤 Java에서 필터링
-    //     PostgreSQL 커스텀 ENUM 타입(tech_stack_category)을 WHERE 절에 직접 쓰면
-    //     타입 불일치 오류가 발생하므로 애플리케이션 레벨에서 필터링한다.
-    //     tech_stack 테이블은 마스터 데이터라 수백 건 이하이므로 성능 문제 없음.
-    if (category == null || category.isBlank()) {
-      list =
-          techStackRepository.findAllByOrderByNameAsc().stream()
-              .map(TechStackResponse::from)
-              .toList();
-    } else {
-      // 12. 잘못된 category 값이면 IllegalArgumentException → 400 Bad Request
-      TechStackCategory cat;
+    TechStackCategory filter = null;
+    if (!all) {
       try {
-        cat = TechStackCategory.valueOf(category.toLowerCase());
+        filter = TechStackCategory.valueOf(category.toLowerCase());
       } catch (IllegalArgumentException e) {
         throw new IllegalArgumentException("유효하지 않은 category 값입니다: " + category);
       }
-      list =
-          techStackRepository.findAllByOrderByNameAsc().stream()
-              .filter(ts -> ts.getCategory() == cat)
-              .map(TechStackResponse::from)
-              .toList();
     }
 
+    final TechStackCategory cat = filter;
+    List<TechStackResponse> list =
+        techStackRepository.findAllByOrderByNameAsc().stream()
+            .filter(ts -> cat == null || ts.getCategory() == cat)
+            .map(TechStackResponse::from)
+            .toList();
+
     return new TechStackListResponse(list);
+  }
+
+  /**
+   * 기술 스택 등록 (관리자 — §3-2).
+   *
+   * <p>이름 중복은 미리 막아 친절한 409 메시지를 준다 (DB unique 제약에만 맡기면 "중복된 요청입니다"로 뭉뚱그려짐). 생성은 도메인 정적 팩토리 {@code
+   * TechStack.create}에 위임한다.
+   */
+  @Transactional
+  public IdResponse create(TechStackCreateRequest req) {
+    if (techStackRepository.existsByName(req.name())) {
+      throw new TechStackNameDuplicateException(req.name());
+    }
+    TechStack techStack = TechStack.create(req.name(), req.category(), req.logoUrl());
+    return new IdResponse(techStackRepository.save(techStack).getId());
+  }
+
+  /**
+   * 기술 스택 수정 (관리자 — §3-3).
+   *
+   * <p>요청 body는 name/category/logoUrl 전체를 받아 통째로 교체한다 (전체 교체 시맨틱 — 일부만 보내면 안 보낸 필드는 비워진다). 변경은 도메인
+   * 메서드 {@code techStack.update}에 위임하고, 트랜잭션 종료 시 변경 감지(dirty checking)로 자동 반영된다 (save/merge 호출 안
+   * 함).
+   *
+   * <p>{@code existsByNameAndIdNot}은 자기 자신을 제외하므로, 이름을 그대로 두든 바꾸든 "남의 이름과 겹칠 때"만 409를 던진다.
+   */
+  @Transactional
+  public IdResponse update(Long id, TechStackCreateRequest req) {
+    TechStack techStack =
+        techStackRepository.findById(id).orElseThrow(() -> new TechStackNotFoundException(id));
+    if (techStackRepository.existsByNameAndIdNot(req.name(), id)) {
+      throw new TechStackNameDuplicateException(req.name());
+    }
+    techStack.update(req.name(), req.category(), req.logoUrl());
+    return new IdResponse(techStack.getId());
+  }
+
+  /**
+   * 기술 스택 삭제 (관리자 — §3-4).
+   *
+   * <p>하드 삭제다. DB의 ON DELETE CASCADE에 의해 이 기술 스택을 보유한 멤버(member_tech_stack)·팀(team_tech_stack) 연결도
+   * 함께 삭제된다. 즉 사용 중이어도 막지 않는다.
+   *
+   * <p>TODO(후속): 사용 중(보유 멤버·팀 존재)이면 삭제를 막고 409를 주는 정책도 검토 가능. 현재는 명세대로 하드 삭제.
+   */
+  @Transactional
+  public void delete(Long id) {
+    if (!techStackRepository.existsById(id)) {
+      throw new TechStackNotFoundException(id);
+    }
+    techStackRepository.deleteById(id);
   }
 }

--- a/src/main/java/com/study/profile/application/dto/TechStackCreateRequest.java
+++ b/src/main/java/com/study/profile/application/dto/TechStackCreateRequest.java
@@ -1,0 +1,20 @@
+package com.study.profile.application.dto;
+
+import com.study.profile.domain.techstack.TechStackCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 기술 스택 등록/수정 요청 DTO (§3-2, §3-3 공용).
+ *
+ * <p>logoUrl은 외부 CDN(devicon 등) 주소를 그대로 받는다 — 기술 스택 로고는 사용자 업로드 이미지가 아니라 정해진 아이콘 라이브러리 링크이므로 S3 업로드
+ * 흐름을 타지 않는다.
+ */
+public record TechStackCreateRequest(
+    @Schema(example = "Bun") @NotBlank String name,
+    @Schema(example = "framework") @NotNull TechStackCategory category,
+    @Schema(
+            example =
+                "https://raw.githubusercontent.com/devicons/devicon/master/icons/bun/bun-original.svg")
+        String logoUrl) {}

--- a/src/main/java/com/study/profile/application/dto/TechStackDto.java
+++ b/src/main/java/com/study/profile/application/dto/TechStackDto.java
@@ -27,4 +27,7 @@ public class TechStackDto {
   // 7. 목록 응답 전용 DTO — List<TechStackResponse> 를 감싸서
   //    JSON 응답이 { "techStacks": [...] } 형태로 나오게 한다.
   public record TechStackListResponse(List<TechStackResponse> techStacks) {}
+
+  /** 등록/수정 응답 — 생성·수정된 기술 스택의 id만 반환 (§3-2, §3-3). */
+  public record IdResponse(Long id) {}
 }

--- a/src/main/java/com/study/profile/domain/exception/TechStackNameDuplicateException.java
+++ b/src/main/java/com/study/profile/domain/exception/TechStackNameDuplicateException.java
@@ -1,0 +1,8 @@
+package com.study.profile.domain.exception;
+
+/** 이미 존재하는 이름으로 기술 스택을 등록/수정하려 할 때. 409로 매핑. */
+public class TechStackNameDuplicateException extends ProfileException {
+  public TechStackNameDuplicateException(String name) {
+    super("이미 존재하는 기술 스택 이름입니다: " + name);
+  }
+}

--- a/src/main/java/com/study/profile/domain/exception/TechStackNotFoundException.java
+++ b/src/main/java/com/study/profile/domain/exception/TechStackNotFoundException.java
@@ -1,0 +1,8 @@
+package com.study.profile.domain.exception;
+
+/** 기술 스택을 찾을 수 없을 때 (잘못된 techStackId). 404로 매핑. */
+public class TechStackNotFoundException extends ProfileException {
+  public TechStackNotFoundException(Long id) {
+    super("기술 스택을 찾을 수 없습니다: " + id);
+  }
+}

--- a/src/main/java/com/study/profile/infrastructure/TechStackRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/TechStackRepository.java
@@ -11,4 +11,10 @@ public interface TechStackRepository extends JpaRepository<TechStack, Long> {
   //    OrderByNameAsc     → ORDER BY name ASC
   //    → 결과: 전체 스택을 이름 오름차순으로 조회
   List<TechStack> findAllByOrderByNameAsc();
+
+  // 같은 이름의 기술 스택이 이미 있는지 (등록 시 중복 차단용 — §3-2)
+  boolean existsByName(String name);
+
+  // 자기 자신(id)을 제외하고 같은 이름이 있는지 (수정 시 남의 이름과 중복 차단용 — §3-3)
+  boolean existsByNameAndIdNot(String name, Long id);
 }

--- a/src/main/java/com/study/profile/presentation/MemberController.java
+++ b/src/main/java/com/study/profile/presentation/MemberController.java
@@ -77,4 +77,11 @@ public class MemberController {
   public ResponseEntity<MemberDto> getMemberById(@PathVariable Long memberId) {
     return ResponseEntity.ok(memberService.getMemberById(memberId));
   }
+
+  @Operation(summary = "멤버 기술 스택 조회", description = "특정 멤버가 보유한 기술 스택 목록을 반환합니다.")
+  @GetMapping("/{memberId}/tech-stacks")
+  @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
+  public ResponseEntity<List<TechStackItemDto>> getMemberTechStacks(@PathVariable Long memberId) {
+    return ResponseEntity.ok(memberService.getMemberTechStacks(memberId));
+  }
 }

--- a/src/main/java/com/study/profile/presentation/TechStackController.java
+++ b/src/main/java/com/study/profile/presentation/TechStackController.java
@@ -1,10 +1,24 @@
 package com.study.profile.presentation;
 
 import com.study.profile.application.TechStackService;
+import com.study.profile.application.dto.TechStackCreateRequest;
+import com.study.profile.application.dto.TechStackDto.IdResponse;
 import com.study.profile.application.dto.TechStackDto.TechStackListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 // 13. Controller — HTTP 요청의 진입점
 //     클라이언트(프론트엔드)가 보낸 요청을 받아서 Service에 넘기고,
 //     Service가 돌려준 결과를 HTTP 응답으로 내보내는 역할만 한다.
+@Tag(name = "기술 스택", description = "기술 스택 카탈로그 조회·등록·수정·삭제 API")
 @RestController // @Controller + @ResponseBody. 반환값을 JSON으로 자동 변환한다.
 @RequestMapping("/api/profile/tech-stacks") // 이 컨트롤러가 처리할 URL prefix
 @RequiredArgsConstructor
@@ -22,12 +37,60 @@ public class TechStackController {
   // 14. @GetMapping — GET /api/profile/tech-stacks 요청을 이 메서드가 처리한다.
   //     @RequestParam(required = false) — URL 뒤에 ?category=language 처럼 붙는 쿼리 파라미터.
   //     required = false 이므로 생략 가능 → 생략하면 category가 null로 들어온다.
+  @Operation(
+      summary = "기술 스택 목록 조회",
+      description = "category로 분류 필터. all(기본값)이면 전체 기술 스택을 이름순으로 반환합니다.")
   @GetMapping
   public ResponseEntity<TechStackListResponse> getTechStacks(
-      @RequestParam(required = false) String category) {
-
-    // 15. ResponseEntity.ok() — HTTP 200 OK 상태코드와 함께 body를 응답한다.
-    //     Service에서 받은 TechStackListResponse가 JSON으로 변환되어 클라이언트에 전달된다.
+      @Parameter(
+              description = "기술 분류 필터 — all = 전체 기술 스택",
+              required = true,
+              schema =
+                  @Schema(
+                      allowableValues = {
+                        "all",
+                        "language",
+                        "framework",
+                        "ai",
+                        "design",
+                        "tool",
+                        "infra",
+                        "etc"
+                      },
+                      defaultValue = "all"))
+          @RequestParam(required = false, defaultValue = "all")
+          String category) {
     return ResponseEntity.ok(techStackService.getTechStacks(category));
+  }
+
+  @Operation(
+      summary = "기술 스택 등록 (관리자)",
+      description = "name 중복 시 409. logoUrl은 외부 CDN 주소를 그대로 받습니다.")
+  @PostMapping
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<IdResponse> createTechStack(
+      @Valid @RequestBody TechStackCreateRequest req) {
+    return ResponseEntity.status(HttpStatus.CREATED).body(techStackService.create(req));
+  }
+
+  @Operation(
+      summary = "기술 스택 수정 (관리자)",
+      description =
+          "name/category/logoUrl 전체를 통째로 교체합니다 (일부만 보내면 안 보낸 필드는 비워짐). 다른 기술과 이름 중복 시 409.")
+  @PutMapping("/{techStackId}")
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<IdResponse> updateTechStack(
+      @PathVariable Long techStackId, @Valid @RequestBody TechStackCreateRequest req) {
+    return ResponseEntity.ok(techStackService.update(techStackId, req));
+  }
+
+  @Operation(
+      summary = "기술 스택 삭제 (관리자)",
+      description = "하드 삭제. 이 기술을 보유한 멤버·팀 연결도 함께 삭제됩니다(ON DELETE CASCADE).")
+  @DeleteMapping("/{techStackId}")
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<Void> deleteTechStack(@PathVariable Long techStackId) {
+    techStackService.delete(techStackId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/study/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/study/shared/exception/GlobalExceptionHandler.java
@@ -6,6 +6,8 @@ import com.study.auth.domain.exception.InvalidTokenException;
 import com.study.auth.domain.exception.TokenReusedException;
 import com.study.auth.domain.exception.UserNotActiveException;
 import com.study.profile.domain.exception.MemberNotFoundException;
+import com.study.profile.domain.exception.TechStackNameDuplicateException;
+import com.study.profile.domain.exception.TechStackNotFoundException;
 import com.study.qna.domain.exception.AnswerNotFoundException;
 import com.study.qna.domain.exception.CommentNotFoundException;
 import com.study.qna.domain.exception.ForbiddenQnaActionException;
@@ -80,6 +82,17 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(MemberNotFoundException.class)
   public ResponseEntity<Map<String, Object>> handleMemberNotFound(MemberNotFoundException e) {
     return errorResponse(HttpStatus.NOT_FOUND, e.getMessage());
+  }
+
+  @ExceptionHandler(TechStackNotFoundException.class)
+  public ResponseEntity<Map<String, Object>> handleTechStackNotFound(TechStackNotFoundException e) {
+    return errorResponse(HttpStatus.NOT_FOUND, e.getMessage());
+  }
+
+  @ExceptionHandler(TechStackNameDuplicateException.class)
+  public ResponseEntity<Map<String, Object>> handleTechStackNameDuplicate(
+      TechStackNameDuplicateException e) {
+    return errorResponse(HttpStatus.CONFLICT, e.getMessage());
   }
 
   @ExceptionHandler(TagAlreadyExistsException.class)

--- a/src/test/java/com/study/profile/application/MemberServiceTest.java
+++ b/src/test/java/com/study/profile/application/MemberServiceTest.java
@@ -6,9 +6,15 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock; // 이 부분이 핵심입니다!
 import static org.mockito.Mockito.when;
 
+import com.study.profile.application.dto.TechStackItemDto;
+import com.study.profile.domain.exception.MemberNotFoundException;
 import com.study.profile.domain.member.Member;
+import com.study.profile.domain.techstack.MemberTechStack;
+import com.study.profile.domain.techstack.TechStack;
+import com.study.profile.domain.techstack.TechStackCategory;
 import com.study.profile.infrastructure.MemberRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
@@ -53,5 +60,38 @@ class MemberServiceTest {
         () -> {
           memberService.getMemberToUserId(999L);
         });
+  }
+
+  @Test
+  @DisplayName("멤버 기술 스택 조회 성공 시 보유 목록을 TechStackItemDto로 반환한다")
+  void getMemberTechStacks_Success() {
+    // given
+    Member member = mock(Member.class);
+    TechStack ts = TechStack.create("Java", TechStackCategory.language, "https://logo");
+    ReflectionTestUtils.setField(ts, "id", 1L);
+    MemberTechStack mts = mock(MemberTechStack.class);
+    when(mts.getTechStack()).thenReturn(ts);
+    when(mts.getProficiency()).thenReturn(4);
+    when(member.getTechStacks()).thenReturn(List.of(mts));
+    when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+
+    // when
+    List<TechStackItemDto> result = memberService.getMemberTechStacks(1L);
+
+    // then
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).techStackId()).isEqualTo(1L);
+    assertThat(result.get(0).name()).isEqualTo("Java");
+    assertThat(result.get(0).proficiency()).isEqualTo(4);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 memberId로 기술 스택 조회 시 MemberNotFoundException이 발생한다")
+  void getMemberTechStacks_Fail_NotFound() {
+    // given
+    when(memberRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+    // when & then
+    assertThrows(MemberNotFoundException.class, () -> memberService.getMemberTechStacks(999L));
   }
 }

--- a/src/test/java/com/study/profile/application/TechStackServiceTest.java
+++ b/src/test/java/com/study/profile/application/TechStackServiceTest.java
@@ -1,0 +1,146 @@
+package com.study.profile.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.study.profile.application.dto.TechStackCreateRequest;
+import com.study.profile.application.dto.TechStackDto.IdResponse;
+import com.study.profile.domain.exception.TechStackNameDuplicateException;
+import com.study.profile.domain.exception.TechStackNotFoundException;
+import com.study.profile.domain.techstack.TechStack;
+import com.study.profile.domain.techstack.TechStackCategory;
+import com.study.profile.infrastructure.TechStackRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class TechStackServiceTest {
+
+  @Mock private TechStackRepository techStackRepository;
+
+  @InjectMocks private TechStackService techStackService;
+
+  private TechStack techStackWithId(Long id, String name, TechStackCategory category) {
+    TechStack techStack = TechStack.create(name, category, "https://logo");
+    ReflectionTestUtils.setField(techStack, "id", id);
+    return techStack;
+  }
+
+  // ---------- 등록 (§3-2) ----------
+
+  @Test
+  @DisplayName("기술 스택 등록 성공 시 저장된 id를 반환한다")
+  void create_Success() {
+    // given
+    TechStackCreateRequest req =
+        new TechStackCreateRequest("Bun", TechStackCategory.framework, "https://logo");
+    when(techStackRepository.existsByName("Bun")).thenReturn(false);
+    when(techStackRepository.save(any(TechStack.class)))
+        .thenReturn(techStackWithId(100L, "Bun", TechStackCategory.framework));
+
+    // when
+    IdResponse result = techStackService.create(req);
+
+    // then
+    assertThat(result.id()).isEqualTo(100L);
+    verify(techStackRepository).save(any(TechStack.class));
+  }
+
+  @Test
+  @DisplayName("이미 존재하는 이름으로 등록 시 TechStackNameDuplicateException이 발생한다")
+  void create_Fail_DuplicateName() {
+    // given
+    TechStackCreateRequest req =
+        new TechStackCreateRequest("Java", TechStackCategory.language, "https://logo");
+    when(techStackRepository.existsByName("Java")).thenReturn(true);
+
+    // when & then
+    assertThrows(TechStackNameDuplicateException.class, () -> techStackService.create(req));
+    verify(techStackRepository, never()).save(any(TechStack.class));
+  }
+
+  // ---------- 수정 (§3-3) ----------
+
+  @Test
+  @DisplayName("기술 스택 수정 성공 시 도메인 메서드로 값이 교체되고 id를 반환한다")
+  void update_Success() {
+    // given
+    TechStack existing = techStackWithId(5L, "Java", TechStackCategory.language);
+    TechStackCreateRequest req =
+        new TechStackCreateRequest("Kotlin", TechStackCategory.language, "https://new");
+    when(techStackRepository.findById(5L)).thenReturn(Optional.of(existing));
+    when(techStackRepository.existsByNameAndIdNot("Kotlin", 5L)).thenReturn(false);
+
+    // when
+    IdResponse result = techStackService.update(5L, req);
+
+    // then
+    assertThat(result.id()).isEqualTo(5L);
+    assertThat(existing.getName()).isEqualTo("Kotlin"); // 도메인 메서드로 교체됨 (dirty checking)
+    assertThat(existing.getLogoUrl()).isEqualTo("https://new");
+    verify(techStackRepository, never()).save(any(TechStack.class)); // merge/save 호출 안 함
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 id로 수정 시 TechStackNotFoundException이 발생한다")
+  void update_Fail_NotFound() {
+    // given
+    TechStackCreateRequest req =
+        new TechStackCreateRequest("Kotlin", TechStackCategory.language, "https://new");
+    when(techStackRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+    // when & then
+    assertThrows(TechStackNotFoundException.class, () -> techStackService.update(999L, req));
+  }
+
+  @Test
+  @DisplayName("수정하려는 이름이 다른 기술 스택과 중복되면 TechStackNameDuplicateException이 발생한다")
+  void update_Fail_DuplicateName() {
+    // given
+    TechStack existing = techStackWithId(5L, "Java", TechStackCategory.language);
+    TechStackCreateRequest req =
+        new TechStackCreateRequest("Python", TechStackCategory.language, "https://new");
+    when(techStackRepository.findById(5L)).thenReturn(Optional.of(existing));
+    when(techStackRepository.existsByNameAndIdNot("Python", 5L)).thenReturn(true);
+
+    // when & then
+    assertThrows(TechStackNameDuplicateException.class, () -> techStackService.update(5L, req));
+  }
+
+  // ---------- 삭제 (§3-4) ----------
+
+  @Test
+  @DisplayName("기술 스택 삭제 성공 시 deleteById를 호출한다")
+  void delete_Success() {
+    // given
+    when(techStackRepository.existsById(5L)).thenReturn(true);
+
+    // when
+    techStackService.delete(5L);
+
+    // then
+    verify(techStackRepository).deleteById(5L);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 id로 삭제 시 TechStackNotFoundException이 발생하고 deleteById를 호출하지 않는다")
+  void delete_Fail_NotFound() {
+    // given
+    when(techStackRepository.existsById(999L)).thenReturn(false);
+
+    // when & then
+    assertThrows(TechStackNotFoundException.class, () -> techStackService.delete(999L));
+    verify(techStackRepository, never()).deleteById(anyLong());
+  }
+}


### PR DESCRIPTION
# WHY

기술 스택 관리자 CRUD + 멤버 기술 스택 조회 구현입니다.

- 3-2 기술 스택 등록 — 관리자가 카탈로그에 새 기술을 추가
- 3-3 기술 스택 수정 — 관리자가 기존 기술의 이름/분류/로고 변경
- 3-4 기술 스택 삭제 — 관리자가 기술을 카탈로그에서 제거
- 4-1 멤버 기술 스택 조회 — 특정 멤버가 보유한 기술 목록

# WHAT

#### 1. endpoint 4개

| § | URL | 권한 | 응답 |
|---|---|---|---|
| 3-2 | `POST /api/profile/tech-stacks` | ADMIN | `201 { id }` |
| 3-3 | `PUT /api/profile/tech-stacks/{techStackId}` | ADMIN | `200 { id }` |
| 3-4 | `DELETE /api/profile/tech-stacks/{techStackId}` | ADMIN | `204` |
| 4-1 | `GET /api/profile/members/{memberId}/tech-stacks` | MEMBER+ | 보유 기술 스택 목록 |


#### 2. 수정은 PUT 전체 교체

(3-3 : 기술 스택 수정)은 name/category/logoUrl 전체를 받아 기본값을 바탕으로 전체 교체합니다. 

# HOW

**도메인 모델 패턴**
- 등록/수정은 `TechStack.create` / `TechStack.update` 도메인 메서드에 위임
- 수정은 변경 감지(dirty checking)로 반영 — `save`/`merge` 호출 안 함

**예외 카탈로그 (ProfileException 기반)**
- `TechStackNotFoundException` → 404 (없는 id로 수정·삭제)
- `TechStackNameDuplicateException` → 409 (이름 중복)
- 이름 중복은 `existsByName` / `existsByNameAndIdNot`로 미리 체크해 친절한 메시지 반환 (DB unique 제약에만 맡기면 "중복된 요청입니다"로 뭉뚱그려짐)

**삭제 정책**
- 하드 삭제 — DB `ON DELETE CASCADE`로 해당 기술을 보유한 멤버(`member_tech_stack`)·팀(`team_tech_stack`) 연결도 함께 삭제. 

# Test

### Swagger 수동 검증 

- [x] `POST /tech-stacks` — 201 + id
- [x] 이름 중복 → 409, 잘못된 category → 400
- [x] `PUT /tech-stacks/{id}` — 200, 없는 id → 404
- [x] `GET /members/{memberId}/tech-stacks` — 200 (보유 목록)
- [x] `DELETE /tech-stacks/{id}` — 204, 재시도 → 404
- [x] 권한 가드 — 토큰 없이 POST/PUT/DELETE → 401
- [x] category 필터 — all(전체) / 분류별 / 잘못된 값 400

### DB

- 새 테이블·컬럼 없음 (tech_stack / member_tech_stack 기존 사용) 
- [x] 테스트 데이터 정리 완료 (tech_stack 건수 테스트 전과 동일)
