### PR TITLE
feat: 팀 목록 N+1 개선 및 어드민 유저 응답에 memberId 추가

### DIFF
--- a/docs/profile/profile-api.md
+++ b/docs/profile/profile-api.md
@@ -1025,7 +1025,7 @@ GET /profile/ranking
 | ✅   | `GET` | `/profile/members/{memberId}` | 멤버 상세 | 세인 |
 | ✅   | `GET` | `/profile/generations` | 기수 목록 | 세인 |
 | ✅   | `POST` | `/profile/generations` | 기수 생성 (관리자) | 세인 |
-| ✅   | `GET` | `/profile/generations/{generationNumber}` | 기수 상세 | 세인 |
+| [x] | `GET` | `/profile/generations/{generationNumber}` | 기수 상세 | 세인 |
 | ✅   | `PATCH` | `/profile/generations/{generationNumber}` | 기수 수정 (관리자) | 세인 |
 | ✅   | `GET` | `/profile/generations/{generationNumber}/members` | 기수 멤버 목록 | 세인 |
 | ✅   | `POST` | `/profile/generations/{generationNumber}/members` | 기수에 멤버 등록 (관리자) | 세인 |
@@ -1046,7 +1046,7 @@ GET /profile/ranking
 | ✅   | `PUT` | `/profile/teams/{teamId}/members/{memberId}/roles` | 팀원 역할 수정 (팀장 또는 본인) | 시현 |
 | ✅   | `DELETE` | `/profile/teams/{teamId}/members/{memberId}` | 팀원 강퇴 (팀장) | 시현 |
 | ✅   | `DELETE` | `/profile/teams/{teamId}/members/me` | 팀 탈퇴 | 시현 |
-| ✅   | `GET` | `/profile/members/{memberId}/stats` | 멤버 활동 통계 | 근엽 |
-| ✅   | `GET` | `/profile/members/{memberId}/activities` | 멤버 작성형 활동 목록 | 근엽 |
-| ✅   | `GET` | `/profile/members/me/reactions` | 내 반응형 활동 목록 | 근엽 |
-| ✅   | `GET` | `/profile/ranking` | 기여도 랭킹 | 근엽 |
+| ✅ | `GET` | `/profile/members/{memberId}/stats` | 멤버 활동 통계 | 근엽 |
+| ✅ | `GET` | `/profile/members/{memberId}/activities` | 멤버 작성형 활동 목록 | 근엽 |
+| ✅ | `GET` | `/profile/members/me/reactions` | 내 반응형 활동 목록 | 근엽 |
+| ✅ | `GET` | `/profile/ranking` | 기여도 랭킹 | 근엽 |

--- a/src/main/java/com/study/auth/application/UserAdminService.java
+++ b/src/main/java/com/study/auth/application/UserAdminService.java
@@ -6,6 +6,8 @@ import com.study.auth.infrastructure.UserRepository;
 import com.study.auth.presentation.dto.UserResponse;
 import com.study.profile.infrastructure.MemberRepository;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -21,33 +23,41 @@ public class UserAdminService {
 
   @Transactional(readOnly = true)
   public List<UserResponse> getUsers(String status) {
+    List<User> users;
     if (status == null || status.isBlank()) {
-      return userRepository.findAllByOrderBySignupRequestedAtDesc().stream()
-          .map(this::toResponse)
-          .toList();
+      users = userRepository.findAllByOrderBySignupRequestedAtDesc();
+    } else {
+      try {
+        UserStatus userStatus = UserStatus.valueOf(status.trim().toUpperCase());
+        users = userRepository.findAllByStatusOrderBySignupRequestedAtDesc(userStatus);
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("유효하지 않은 status 값입니다. 허용 값: PENDING, ACTIVE, REJECTED");
+      }
     }
-    try {
-      UserStatus userStatus = UserStatus.valueOf(status.trim().toUpperCase());
-      return userRepository.findAllByStatusOrderBySignupRequestedAtDesc(userStatus).stream()
-          .map(this::toResponse)
-          .toList();
-    } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException("유효하지 않은 status 값입니다. 허용 값: PENDING, ACTIVE, REJECTED");
-    }
+
+    // 시현 N+1 수정: 유저별 member 개별 조회 → findAllByUserIdIn 한 번으로 통합
+    List<Long> userIds = users.stream().map(User::getId).toList();
+    Map<Long, Long> memberIdByUserId =
+        memberRepository.findAllByUserIdIn(userIds).stream()
+            .collect(Collectors.toMap(m -> m.getUser().getId(), m -> m.getId()));
+
+    return users.stream().map(u -> toResponse(u, memberIdByUserId.get(u.getId()))).toList();
   }
 
   @Transactional
   public UserResponse approveUser(Long userId, Long adminId) {
     User user = findOrThrow(userId);
     user.approve(adminId);
-    return toResponse(userRepository.save(user));
+    Long memberId = memberRepository.findByUserId(userId).map(m -> m.getId()).orElse(null);
+    return toResponse(userRepository.save(user), memberId);
   }
 
   @Transactional
   public UserResponse rejectUser(Long userId) {
     User user = findOrThrow(userId);
     user.reject();
-    return toResponse(userRepository.save(user));
+    Long memberId = memberRepository.findByUserId(userId).map(m -> m.getId()).orElse(null);
+    return toResponse(userRepository.save(user), memberId);
   }
 
   private User findOrThrow(Long userId) {
@@ -57,8 +67,7 @@ public class UserAdminService {
             () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다: " + userId));
   }
 
-  private UserResponse toResponse(User user) {
-    Long memberId = memberRepository.findByUserId(user.getId()).map(m -> m.getId()).orElse(null);
+  private UserResponse toResponse(User user, Long memberId) {
     return new UserResponse(
         user.getId(),
         memberId,

--- a/src/main/java/com/study/auth/application/UserAdminService.java
+++ b/src/main/java/com/study/auth/application/UserAdminService.java
@@ -4,6 +4,7 @@ import com.study.auth.domain.User;
 import com.study.auth.domain.UserStatus;
 import com.study.auth.infrastructure.UserRepository;
 import com.study.auth.presentation.dto.UserResponse;
+import com.study.profile.infrastructure.MemberRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,6 +17,7 @@ import org.springframework.web.server.ResponseStatusException;
 public class UserAdminService {
 
   private final UserRepository userRepository;
+  private final MemberRepository memberRepository;
 
   @Transactional(readOnly = true)
   public List<UserResponse> getUsers(String status) {
@@ -56,8 +58,10 @@ public class UserAdminService {
   }
 
   private UserResponse toResponse(User user) {
+    Long memberId = memberRepository.findByUserId(user.getId()).map(m -> m.getId()).orElse(null);
     return new UserResponse(
         user.getId(),
+        memberId,
         user.getLoginEmail(),
         user.getRole().name(),
         user.getStatus().name(),

--- a/src/main/java/com/study/auth/presentation/dto/UserResponse.java
+++ b/src/main/java/com/study/auth/presentation/dto/UserResponse.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 
 public record UserResponse(
     Long id,
+    Long memberId,
     String email,
     String role,
     String status,

--- a/src/main/java/com/study/auth/presentation/dto/UserResponse.java
+++ b/src/main/java/com/study/auth/presentation/dto/UserResponse.java
@@ -2,6 +2,7 @@ package com.study.auth.presentation.dto;
 
 import java.time.Instant;
 
+// 시현 N+1 수정: memberId 추가 — 어드민 페이지에서 멤버 프로필 직접 링크용
 public record UserResponse(
     Long id,
     Long memberId,

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -359,8 +359,8 @@ public class TeamService {
   public List<TeamListResponse> getTeams(Integer generationNumber) {
     List<TeamProfile> teams =
         generationNumber != null
-            ? teamRepository.findByGenerationNumber(generationNumber)
-            : teamRepository.findAll();
+            ? teamRepository.findByGenerationNumberWithDetails(generationNumber)
+            : teamRepository.findAllWithDetails();
 
     return teams.stream().map(this::toListResponse).toList();
   }

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -454,6 +454,7 @@ public class TeamService {
                                   ts.getLogoUrl()))
                       .toList();
               List<String> roles = tm.getRoles().stream().map(r -> r.getRole().name()).toList();
+              // 시현 N+1 수정: Set 전환으로 get(0) 불가 → stream().findFirst()로 변경
               String thumbUrl =
                   team.getImages().stream().findFirst().map(TeamImage::getImageUrl).orElse(null);
               return new MyTeamResponse(
@@ -484,6 +485,7 @@ public class TeamService {
                         ts.getId(), ts.getName(), ts.getCategory().name(), ts.getLogoUrl()))
             .toList();
 
+    // 시현 N+1 수정: Set 전환으로 get(0) 불가 → stream().findFirst()로 변경
     String thumbUrl = team.getImages().stream().findFirst().map(TeamImage::getImageUrl).orElse(null);
 
     int memberCount =

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -455,7 +455,7 @@ public class TeamService {
                       .toList();
               List<String> roles = tm.getRoles().stream().map(r -> r.getRole().name()).toList();
               String thumbUrl =
-                  team.getImages().isEmpty() ? null : team.getImages().get(0).getImageUrl();
+                  team.getImages().stream().findFirst().map(TeamImage::getImageUrl).orElse(null);
               return new MyTeamResponse(
                   team.getId(),
                   team.getName(),
@@ -484,7 +484,7 @@ public class TeamService {
                         ts.getId(), ts.getName(), ts.getCategory().name(), ts.getLogoUrl()))
             .toList();
 
-    String thumbUrl = team.getImages().isEmpty() ? null : team.getImages().get(0).getImageUrl();
+    String thumbUrl = team.getImages().stream().findFirst().map(TeamImage::getImageUrl).orElse(null);
 
     int memberCount =
         (int)

--- a/src/main/java/com/study/profile/domain/team/TeamProfile.java
+++ b/src/main/java/com/study/profile/domain/team/TeamProfile.java
@@ -75,6 +75,7 @@ public class TeamProfile {
   @Column(name = "updated_at", nullable = false)
   private Instant updatedAt; // 마지막 수정 시각
 
+  // 시현 N+1 수정: List(Bag) → Set 전환 — MultipleBagFetchException 및 JOIN FETCH 중복 방지
   @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
   private Set<TeamImage> images = new HashSet<>();
 
@@ -101,7 +102,7 @@ public class TeamProfile {
     }
   }
 
-  // TeamProfile 클래스 안에 추가
+  // 시현 N+1 수정: List(Bag) → Set 전환 — JOIN FETCH 시 techStacks 중복 제거
   @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
   private Set<TeamTechStack> techStacks = new HashSet<>();
 

--- a/src/main/java/com/study/profile/domain/team/TeamProfile.java
+++ b/src/main/java/com/study/profile/domain/team/TeamProfile.java
@@ -18,7 +18,9 @@ import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -74,10 +76,10 @@ public class TeamProfile {
   private Instant updatedAt; // 마지막 수정 시각
 
   @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<TeamImage> images = new ArrayList<>();
+  private Set<TeamImage> images = new HashSet<>();
 
   @OneToMany(mappedBy = "team")
-  private List<TeamMember> members = new ArrayList<>();
+  private Set<TeamMember> members = new HashSet<>();
 
   /**
    * 이미지들을 추가하는 메서드
@@ -101,7 +103,7 @@ public class TeamProfile {
 
   // TeamProfile 클래스 안에 추가
   @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<TeamTechStack> techStacks = new ArrayList<>();
+  private Set<TeamTechStack> techStacks = new HashSet<>();
 
   /** 팀의 사용 기술 스택을 업데이트하는 메서드 */
   public void updateTechStacks(List<TechStack> newStacks) {

--- a/src/main/java/com/study/profile/infrastructure/TeamRepository.java
+++ b/src/main/java/com/study/profile/infrastructure/TeamRepository.java
@@ -4,10 +4,35 @@ import com.study.profile.domain.team.TeamProfile;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface TeamRepository extends JpaRepository<TeamProfile, Long> {
+public interface
+TeamRepository extends JpaRepository<TeamProfile, Long> {
 
   Optional<TeamProfile> findByInviteCode(String inviteCode);
 
-  List<TeamProfile> findByGenerationNumber(Integer generationNumber);
+  // 이전에는 findAll() / findByGenerationNumber()를 사용했음.
+  // TeamProfile의 연관 컬렉션(techStacks, images, members)이 모두 LAZY 로딩이라
+  // toListResponse()에서 각 필드 접근 시마다 SELECT가 추가 발생 → N+1 문제.
+  // 팀 10개면 최대 1(목록) + 10*4(연관 4개) = 41번 쿼리가 나갔음.
+  // JOIN FETCH + DISTINCT로 한 번에 가져오도록 변경.
+  @Query(
+      "SELECT DISTINCT t FROM TeamProfile t "
+          + "LEFT JOIN FETCH t.generation "
+          + "LEFT JOIN FETCH t.techStacks ts "
+          + "LEFT JOIN FETCH ts.techStack "
+          + "LEFT JOIN FETCH t.images "
+          + "LEFT JOIN FETCH t.members")
+  List<TeamProfile> findAllWithDetails();
+
+  @Query(
+      "SELECT DISTINCT t FROM TeamProfile t "
+          + "LEFT JOIN FETCH t.generation "
+          + "LEFT JOIN FETCH t.techStacks ts "
+          + "LEFT JOIN FETCH ts.techStack "
+          + "LEFT JOIN FETCH t.images "
+          + "LEFT JOIN FETCH t.members "
+          + "WHERE t.generation.number = :generationNumber")
+  List<TeamProfile> findByGenerationNumberWithDetails(@Param("generationNumber") Integer generationNumber);
 }


### PR DESCRIPTION

                                                                                                                                                                                                               
  ### WHY                                                                                                                                                                                                      
  - 팀 목록 조회 시 `techStacks`, `images`, `members` 컬렉션이 모두 LAZY 로딩이라, 팀 N개 조회 시 최대 `1 + N*3` 번의 쿼리가 발생하는 N+1 문제가 있었음
  - 어드민 유저 목록에서 각 유저마다 `memberRepository.findByUserId()` 를 개별 호출하는 N+1 문제도 존재                                                                                                        
  - 어드민 페이지에서 활성화된 멤버의 이메일을 클릭하면 해당 멤버 프로필 페이지로 이동해야 하는데, 응답에 `memberId` 가 없어서 링크를 구성할 수 없었음                                                         
                                              
  ### WHAT                                                                                                                                                                                                     
  - `TeamRepository` 에 `findAllWithDetails()` / `findByGenerationNumberWithDetails()` 쿼리 추가 (JOIN FETCH + DISTINCT)                                                                                       
  - `TeamProfile` 컬렉션 타입을 `List` → `Set` 으로 변경 (MultipleBagFetchException 방지)                                                                                                                      
  - `UserAdminService.getUsers()` 에서 유저별 멤버 개별 조회 → `findAllByUserIdIn()` 한 번으로 통합                                                                                                            
  - `UserResponse` 에 `memberId` 필드 추가                                                                                                                                                                     
                                                                                                                                                                                                               
  ### HOW                                                                                                                                                                                                      
  - `LEFT JOIN FETCH` 를 여러 컬렉션에 동시 적용 시 Hibernate `MultipleBagFetchException` 발생 → 컬렉션을 `Set` 으로 교체해 해결                                                                               
  - `Collectors.toMap(m -> m.getUser().getId(), m -> m.getId())` 로 `userId → memberId` 맵 구성 후 스트림에서 O(1) 조회                                                                                        
      