### PR TITLE
Infra/deployment: 로깅 레벨,  `/actuator/health` 접근 권한

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,4 +25,4 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 60s
+      start_period: 120s

--- a/src/main/java/com/study/shared/config/SecurityConfig.java
+++ b/src/main/java/com/study/shared/config/SecurityConfig.java
@@ -61,7 +61,8 @@ public class SecurityConfig {
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
                         "/swagger-ui.html",
-                        "/error")
+                        "/error",
+                        "/actuator/health")
                     .permitAll()
                     .requestMatchers(
                         org.springframework.http.HttpMethod.GET,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,5 +71,5 @@ jwt:
 # === 로깅 ===
 logging:
   level:
-    org.hibernate.SQL: debug     # Hibernate가 실행하는 SQL을 로그에 출력
-    org.springframework.security: trace
+    org.hibernate.SQL: warn
+    org.springframework.security: warn


### PR DESCRIPTION
## Why
운영 환경에서 과도한 로깅 레벨 설정 및 `/actuator/health` 접근 권한 미설정으로 아래 문제가 있음

- `org.hibernate.SQL: debug` → 모든 SQL 쿼리 출력으로 로그 볼륨 증가 및 쿼리 파라미터 노출 위험
- `org.springframework.security: trace` → 인증/인가 내부 흐름 전체 출력으로 토큰, 사용자 정보 등 민감 데이터 노출 위험
- `/actuator/health` 미인증 접근 차단 → Docker healthcheck 실패 → 컨테이너 `unhealthy` 상태

## What
- 운영 환경 로깅 레벨 하향 조정
- `/actuator/health` 엔드포인트 인증 없이 접근 허용

## How
- `org.hibernate.SQL`: `debug` → `warn`
- `org.springframework.security`: `trace` → `warn`
- Security 설정에 `.requestMatchers("/actuator/health").permitAll()` 추가