### PR TITLE
fix: 배포 트리거를 tag push로 수정

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,8 @@ name: Build and Push
 
 on:
   push:
-    branches:
-      - dev
+    tags:
+      - 'v*'                    # 태그 트리거
 
 jobs:
   build:
@@ -27,7 +27,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=sha,prefix=,format=short
+            type=semver,pattern={{version}}   # (ex. v0.2.0 이미지 ghcr에 보존)
             type=raw,value=latest
 
       - uses: docker/build-push-action@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,8 +5,7 @@ on:
     workflows: ["Build and Push"]
     types:
       - completed
-    branches:
-      - dev
+      # branches 조건 제거
 
 jobs:
   deploy:


### PR DESCRIPTION
## Why
배포 트리거를 브랜치 push에서 태그 push로 변경해 sync-main 릴리즈 흐름과 1:1로 맞춤
태그 = 릴리즈 = 배포가 명확하게 연결되도록

## What
- Build and Push 트리거: `dev` 브랜치 push → `v*` 태그 push
- 이미지 태그: `type=sha` → `type=semver` (ghcr에 버전별 이미지 보존)
- Deploy `branches: [dev]` 조건 제거 (태그 트리거와 호환)

## How
\```
git push origin v0.2.0
  → Build and Push (ghcr에 v0.2.0, latest 이미지 푸시)
  → Deploy (EC2에 latest 이미지 배포)
\```