### PR TITLE
refactor(qna): over-fetching 개선 — findById → existsById 교체 및 fetch join 적용

### DIFF
--- a/src/main/java/com/study/qna/application/CommentService.java
+++ b/src/main/java/com/study/qna/application/CommentService.java
@@ -29,7 +29,7 @@ public class CommentService {
   private final ApplicationEventPublisher eventPublisher;
 
   public List<CommentResponse> getComments(Long answerId) {
-    answerRepository.findById(answerId).orElseThrow(() -> new AnswerNotFoundException(answerId));
+    if (!answerRepository.existsById(answerId)) throw new AnswerNotFoundException(answerId);
     return commentRepository.findByAnswer_IdOrderByCreatedAtAsc(answerId).stream()
         .map(
             comment ->
@@ -78,7 +78,7 @@ public class CommentService {
   public void deleteComment(Long commentId, Long userId) {
     Comment comment =
         commentRepository
-            .findById(commentId)
+            .findByIdWithAnswerAndQuestion(commentId)
             .orElseThrow(() -> new CommentNotFoundException(commentId));
 
     if (!comment.isAuthor(userId)) {

--- a/src/main/java/com/study/qna/application/VoteService.java
+++ b/src/main/java/com/study/qna/application/VoteService.java
@@ -45,7 +45,7 @@ public class VoteService {
 
   @Transactional
   public void cancelVote(Long answerId, Long userId) {
-    answerRepository.findById(answerId).orElseThrow(() -> new AnswerNotFoundException(answerId));
+    if (!answerRepository.existsById(answerId)) throw new AnswerNotFoundException(answerId);
 
     Vote vote =
         voteRepository
@@ -58,7 +58,7 @@ public class VoteService {
   }
 
   public MyVoteResponse getMyVote(Long answerId, Long userId) {
-    answerRepository.findById(answerId).orElseThrow(() -> new AnswerNotFoundException(answerId));
+    if (!answerRepository.existsById(answerId)) throw new AnswerNotFoundException(answerId);
 
     return voteRepository
         .findByAnswer_IdAndUserId(answerId, userId)

--- a/src/main/java/com/study/qna/infrastructure/CommentRepository.java
+++ b/src/main/java/com/study/qna/infrastructure/CommentRepository.java
@@ -2,11 +2,17 @@ package com.study.qna.infrastructure;
 
 import com.study.qna.domain.Comment;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository("qnaCommentRepository")
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
   List<Comment> findByAnswer_IdOrderByCreatedAtAsc(Long answerId);
+
+  @Query("SELECT c FROM QnaComment c JOIN FETCH c.answer a JOIN FETCH a.question WHERE c.id = :id")
+  Optional<Comment> findByIdWithAnswerAndQuestion(@Param("id") Long id);
 }

--- a/src/test/java/com/study/qna/application/CommentServiceTest.java
+++ b/src/test/java/com/study/qna/application/CommentServiceTest.java
@@ -76,7 +76,7 @@ class CommentServiceTest {
     @Test
     @DisplayName("존재하지 않는 답변 조회 → AnswerNotFoundException")
     void answerNotFound_throwsAnswerNotFoundException() {
-      when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.empty());
+      when(answerRepository.existsById(ANSWER_ID)).thenReturn(false);
 
       assertThatThrownBy(() -> commentService.getComments(ANSWER_ID))
           .isInstanceOf(AnswerNotFoundException.class);
@@ -85,10 +85,7 @@ class CommentServiceTest {
     @Test
     @DisplayName("댓글 없으면 빈 리스트 반환")
     void noComments_returnsEmptyList() {
-      Question question = makeQuestion(QUESTION_ID);
-      Answer answer = makeAnswer(ANSWER_ID, question);
-
-      when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(answer));
+      when(answerRepository.existsById(ANSWER_ID)).thenReturn(true);
       when(commentRepository.findByAnswer_IdOrderByCreatedAtAsc(ANSWER_ID)).thenReturn(List.of());
 
       List<CommentResponse> result = commentService.getComments(ANSWER_ID);
@@ -118,6 +115,7 @@ class CommentServiceTest {
 
       assertThat(result.id()).isEqualTo(COMMENT_ID);
       verify(commentRepository).save(any());
+      verify(answerRepository).incrementCommentCount(ANSWER_ID);
       verify(eventPublisher).publishEvent(any(QnaCommentCreated.class));
     }
 
@@ -198,7 +196,7 @@ class CommentServiceTest {
       Answer answer = makeAnswer(ANSWER_ID, question);
       Comment comment = makeComment(COMMENT_ID, answer, USER_ID);
 
-      when(commentRepository.findById(COMMENT_ID)).thenReturn(Optional.of(comment));
+      when(commentRepository.findByIdWithAnswerAndQuestion(COMMENT_ID)).thenReturn(Optional.of(comment));
 
       commentService.deleteComment(COMMENT_ID, USER_ID);
 
@@ -214,7 +212,7 @@ class CommentServiceTest {
       Answer answer = makeAnswer(ANSWER_ID, question);
       Comment comment = makeComment(COMMENT_ID, answer, OTHER_USER_ID);
 
-      when(commentRepository.findById(COMMENT_ID)).thenReturn(Optional.of(comment));
+      when(commentRepository.findByIdWithAnswerAndQuestion(COMMENT_ID)).thenReturn(Optional.of(comment));
 
       assertThatThrownBy(() -> commentService.deleteComment(COMMENT_ID, USER_ID))
           .isInstanceOf(ForbiddenQnaActionException.class);
@@ -225,7 +223,7 @@ class CommentServiceTest {
     @Test
     @DisplayName("존재하지 않는 댓글 삭제 → CommentNotFoundException")
     void notFound_throwsCommentNotFoundException() {
-      when(commentRepository.findById(COMMENT_ID)).thenReturn(Optional.empty());
+      when(commentRepository.findByIdWithAnswerAndQuestion(COMMENT_ID)).thenReturn(Optional.empty());
 
       assertThatThrownBy(() -> commentService.deleteComment(COMMENT_ID, USER_ID))
           .isInstanceOf(CommentNotFoundException.class);


### PR DESCRIPTION
## 변경사항

### over-fetching 개선 (findById → existsById)
존재 확인만 하는 곳에서 불필요하게 엔티티 전체를 조회하던 문제를 수정했습니다.

- `CommentService.getComments()` — findById → existsById
- `VoteService.cancelVote()` — findById → existsById
- `VoteService.getMyVote()` — findById → existsById

**수정 전**
```java
answerRepository.findById(answerId).orElseThrow(() -> new AnswerNotFoundException(answerId));
// SELECT id, content, accepted, vote_count, ... FROM answer WHERE id = ?
```

**수정 후**
```java
if (!answerRepository.existsById(answerId)) throw new AnswerNotFoundException(answerId);
// SELECT count(*) FROM answer WHERE id = ?
```

### Lazy Loading 연쇄 개선 (fetch join 적용)
`deleteComment`에서 Comment → Answer → Question을 각각 조회하던 문제를 수정했습니다.

- `CommentRepository`에 `findByIdWithAnswerAndQuestion` 추가
- `CommentService.deleteComment()`에서 해당 메서드 사용

**수정 전**: 쿼리 3번 (Comment 조회 → Answer lazy load → Question lazy load)
**수정 후**: 쿼리 1번 (fetch join으로 한 번에 조회)