### PR TITLE
fix(qna): 질문 상세 조회 500 에러 수정 - readOnly 트랜잭션 내 UPDATE 충돌

### DIFF
--- a/src/main/java/com/study/qna/application/QuestionService.java
+++ b/src/main/java/com/study/qna/application/QuestionService.java
@@ -39,6 +39,7 @@ public class QuestionService {
         .toList();
   }
 
+  @Transactional
   public QuestionDetailResponse getQuestion(Long questionId) {
     Question question =
         questionRepository


### PR DESCRIPTION
## 문제
  `GET /api/v1/questions/{questionId}` 호출 시 500 Internal Server Error 발생.

  ## 원인
  `QuestionService`는 클래스 레벨에 `@Transactional(readOnly = true)`가 선언되어 있음.
  `getQuestion()`은 별도 오버라이드 없이 이를 상속하므로 readOnly 트랜잭션 안에서 실행됨.
  내부에서 `questionRepository.incrementViewCount()` (`UPDATE` 쿼리)를 호출할 때
  PostgreSQL이 읽기 전용 트랜잭션에서 DML을 거부해 예외 발생.

  ERROR: cannot execute UPDATE in a read-only transaction

  ## 수정
  `getQuestion()`에 `@Transactional`을 명시적으로 추가해 쓰기 가능한 트랜잭션으로 오버라이드.

  ## 변경 파일
  - `qna/application/QuestionService.java` — `getQuestion()`에 `@Transactional` 추가