### PR TITLE
feat(qna): 답변 채택 교체 및 채택 취소 기능 구현

### DIFF
--- a/src/main/java/com/study/qna/application/AnswerService.java
+++ b/src/main/java/com/study/qna/application/AnswerService.java
@@ -11,6 +11,7 @@ import com.study.qna.application.dto.response.common.MemberSummaryResponse;
 import com.study.qna.domain.Answer;
 import com.study.qna.domain.Question;
 import com.study.qna.domain.QuestionStatus;
+import com.study.qna.domain.exception.AnswerNotAcceptedException;
 import com.study.qna.domain.exception.AnswerNotFoundException;
 import com.study.qna.domain.exception.ForbiddenQnaActionException;
 import com.study.qna.domain.exception.QuestionAlreadyClosedException;
@@ -115,10 +116,7 @@ public class AnswerService {
       throw new ForbiddenQnaActionException();
     }
 
-    if (question.getStatus() == QuestionStatus.RESOLVED) {
-      throw new QuestionAlreadyClosedException(question.getId());
-    }
-
+    // 기존 채택 답변이 있으면 자동 취소 (중복 채택 교체 허용)
     answerRepository.findByQuestionId(question.getId()).stream()
         .filter(a -> a.isAccepted() && !a.getId().equals(answerId))
         .findFirst()
@@ -136,6 +134,31 @@ public class AnswerService {
     if (question.getStatus() == QuestionStatus.OPEN) {
       question.resolve();
     }
+
+    return AnswerDetailResponse.from(answer, buildAuthor(answer.getUserId()));
+  }
+
+  @Transactional
+  public AnswerDetailResponse cancelAcceptAnswer(Long answerId, Long userId) {
+    Answer answer =
+        answerRepository
+            .findById(answerId)
+            .orElseThrow(() -> new AnswerNotFoundException(answerId));
+
+    Question question = answer.getQuestion();
+
+    if (!question.isAuthor(userId)) {
+      throw new ForbiddenQnaActionException();
+    }
+
+    if (!answer.isAccepted()) {
+      throw new AnswerNotAcceptedException(answerId);
+    }
+
+    answer.cancelAccept();
+    question.reopen();
+    eventPublisher.publishEvent(
+        new QnaAnswerUnaccepted(answer.getUserId(), question.getId(), answerId));
 
     return AnswerDetailResponse.from(answer, buildAuthor(answer.getUserId()));
   }

--- a/src/main/java/com/study/qna/domain/Question.java
+++ b/src/main/java/com/study/qna/domain/Question.java
@@ -100,6 +100,10 @@ public class Question {
     this.status = QuestionStatus.RESOLVED;
   }
 
+  public void reopen() {
+    this.status = QuestionStatus.OPEN;
+  }
+
   public void addTag(Tag tag) {
     boolean exists =
         this.questionTags.stream()

--- a/src/main/java/com/study/qna/domain/exception/AnswerNotAcceptedException.java
+++ b/src/main/java/com/study/qna/domain/exception/AnswerNotAcceptedException.java
@@ -1,0 +1,8 @@
+package com.study.qna.domain.exception;
+
+public class AnswerNotAcceptedException extends QnaException {
+
+  public AnswerNotAcceptedException(Long id) {
+    super("채택된 답변이 아닙니다: " + id);
+  }
+}

--- a/src/main/java/com/study/qna/presentation/AnswerController.java
+++ b/src/main/java/com/study/qna/presentation/AnswerController.java
@@ -55,6 +55,12 @@ public class AnswerController {
     return ResponseEntity.ok(answerService.acceptAnswer(answerId, user.userId()));
   }
 
+  @DeleteMapping("/answers/{answerId}/accept")
+  public ResponseEntity<AnswerDetailResponse> cancelAcceptAnswer(
+      @PathVariable Long answerId, @CurrentUser CustomUserDetails user) {
+    return ResponseEntity.ok(answerService.cancelAcceptAnswer(answerId, user.userId()));
+  }
+
   @DeleteMapping("/answers/{answerId}")
   public ResponseEntity<Void> deleteAnswer(
       @PathVariable Long answerId, @CurrentUser CustomUserDetails user) {

--- a/src/main/java/com/study/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/study/shared/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import com.study.auth.domain.exception.UserNotActiveException;
 import com.study.profile.domain.exception.MemberNotFoundException;
 import com.study.profile.domain.exception.TechStackNameDuplicateException;
 import com.study.profile.domain.exception.TechStackNotFoundException;
+import com.study.qna.domain.exception.AnswerNotAcceptedException;
 import com.study.qna.domain.exception.AnswerNotFoundException;
 import com.study.qna.domain.exception.CommentNotFoundException;
 import com.study.qna.domain.exception.ForbiddenQnaActionException;
@@ -68,6 +69,12 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(AnswerNotFoundException.class)
   public ResponseEntity<Map<String, Object>> handleAnswerNotFound(AnswerNotFoundException e) {
     return errorResponse(HttpStatus.NOT_FOUND, e.getMessage());
+  }
+
+  @ExceptionHandler(AnswerNotAcceptedException.class)
+  public ResponseEntity<Map<String, Object>> handleAnswerNotAccepted(
+      AnswerNotAcceptedException e) {
+    return errorResponse(HttpStatus.CONFLICT, e.getMessage());
   }
 
   @ExceptionHandler(CommentNotFoundException.class)

--- a/src/test/java/com/study/qna/application/AnswerServiceTest.java
+++ b/src/test/java/com/study/qna/application/AnswerServiceTest.java
@@ -315,15 +315,20 @@ class AnswerServiceTest {
     }
 
     @Test
-    @DisplayName("이미 RESOLVED 질문 → QuestionAlreadyClosedException")
-    void alreadyResolved_throws() {
+    @DisplayName("이미 RESOLVED 질문 → 채택 교체 허용, 질문 상태 RESOLVED 유지")
+    void alreadyResolved_allowsReaccept() {
       Question question = resolvedQuestion(QUESTION_ID, USER_ID);
       Answer answer = answerWithId(ANSWER_ID, OTHER_USER_ID, question);
 
       when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(answer));
+      when(answerRepository.findByQuestionId(QUESTION_ID)).thenReturn(List.of(answer));
+      stubAuthorSingle(OTHER_USER_ID);
 
-      assertThatThrownBy(() -> answerService.acceptAnswer(ANSWER_ID, USER_ID))
-          .isInstanceOf(QuestionAlreadyClosedException.class);
+      AnswerDetailResponse res = answerService.acceptAnswer(ANSWER_ID, USER_ID);
+
+      assertThat(res.accepted()).isTrue();
+      assertThat(question.getStatus()).isEqualTo(QuestionStatus.RESOLVED);
+      verify(eventPublisher).publishEvent(any(QnaAnswerAccepted.class));
     }
 
     @Test
@@ -332,6 +337,60 @@ class AnswerServiceTest {
       when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.empty());
 
       assertThatThrownBy(() -> answerService.acceptAnswer(ANSWER_ID, USER_ID))
+          .isInstanceOf(AnswerNotFoundException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("cancelAcceptAnswer")
+  class CancelAcceptAnswer {
+
+    @Test
+    @DisplayName("채택 취소 → accepted false, 질문 OPEN 복구, QnaAnswerUnaccepted 발행")
+    void normal_cancelsAndReopens() {
+      Question question = resolvedQuestion(QUESTION_ID, USER_ID);
+      Answer answer = acceptedAnswerWithId(ANSWER_ID, OTHER_USER_ID, question);
+
+      when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(answer));
+      stubAuthorSingle(OTHER_USER_ID);
+
+      AnswerDetailResponse res = answerService.cancelAcceptAnswer(ANSWER_ID, USER_ID);
+
+      assertThat(res.accepted()).isFalse();
+      assertThat(question.getStatus()).isEqualTo(QuestionStatus.OPEN);
+      verify(eventPublisher).publishEvent(any(QnaAnswerUnaccepted.class));
+    }
+
+    @Test
+    @DisplayName("채택되지 않은 답변 취소 → AnswerNotAcceptedException")
+    void notAccepted_throws() {
+      Question question = questionWithId(QUESTION_ID, USER_ID);
+      Answer answer = answerWithId(ANSWER_ID, OTHER_USER_ID, question);
+
+      when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(answer));
+
+      assertThatThrownBy(() -> answerService.cancelAcceptAnswer(ANSWER_ID, USER_ID))
+          .isInstanceOf(com.study.qna.domain.exception.AnswerNotAcceptedException.class);
+    }
+
+    @Test
+    @DisplayName("질문 작성자가 아닌 경우 → ForbiddenQnaActionException")
+    void notQuestionAuthor_throws() {
+      Question question = questionWithId(QUESTION_ID, USER_ID);
+      Answer answer = acceptedAnswerWithId(ANSWER_ID, OTHER_USER_ID, question);
+
+      when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(answer));
+
+      assertThatThrownBy(() -> answerService.cancelAcceptAnswer(ANSWER_ID, OTHER_USER_ID))
+          .isInstanceOf(ForbiddenQnaActionException.class);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 답변 → AnswerNotFoundException")
+    void answerNotFound_throws() {
+      when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.empty());
+
+      assertThatThrownBy(() -> answerService.cancelAcceptAnswer(ANSWER_ID, USER_ID))
           .isInstanceOf(AnswerNotFoundException.class);
     }
   }


### PR DESCRIPTION
## 개요
  채택 교체(다른 답변으로 재채택)와 채택 취소 기능을 구현합니다.

  ## 변경 사항

  ### 채택 교체
  기존에는 질문이 `RESOLVED` 상태이면 `QuestionAlreadyClosedException`을 던져
  다른 답변으로 교체 채택이 불가능했습니다.
  `RESOLVED` 체크를 제거하여 교체를 허용하고, 기존 채택 답변은 자동으로 취소됩니다.

  ### 채택 취소 (신규)
  `DELETE /api/v1/answers/{answerId}/accept` 엔드포인트를 추가합니다.
  - 질문 작성자만 취소 가능 (다른 사용자 → 403)
  - 채택되지 않은 답변에 취소 요청 → 409
  - 취소 시 질문 상태가 `RESOLVED → OPEN`으로 복구됨

  ## 변경 파일
  | 파일 | 내용 |
  |------|------|
  | `Question.java` | `reopen()` 메서드 추가 |
  | `AnswerNotAcceptedException.java` | 신규 예외 클래스 (409) |
  | `AnswerService.java` | `acceptAnswer()` 수정, `cancelAcceptAnswer()` 추가 |
  | `AnswerController.java` | `DELETE /answers/{answerId}/accept` 추가 |
  | `GlobalExceptionHandler.java` | `AnswerNotAcceptedException` 핸들러 등록 |

  ## API 변경 요약
  | 메서드 | 엔드포인트 | 설명 |
  |--------|-----------|------|
  | `POST` | `/api/v1/answers/{answerId}/accept` | 채택 (교체 허용) |
  | `DELETE` | `/api/v1/answers/{answerId}/accept` | 채택 취소 |