### PR TITLE
chore: postgres 5432 외부 공개 + 배포 후 dangling 이미지 정리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,3 +52,7 @@ jobs:
             cd /home/ubuntu
             docker compose down
             docker compose --env-file .env up -d --wait
+
+            # 배포마다 새 :latest를 pull하면 이전 이미지가 태그를 잃고 dangling으로 쌓인다.
+            # 디스크가 차기 전에 매 배포 후 정리. 사용 중인 이미지(:latest, postgres:17)는 보존된다.
+            docker image prune -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,10 @@ services:
     image: postgres:17
     container_name: postgres
     restart: unless-stopped
+    # 외부(pgAdmin 등)에서 직접 접속하기 위해 호스트 5432로 공개.
+    # 인터넷 노출이므로 접근 통제는 EC2 보안그룹에서 관리한다.
+    ports:
+      - "5432:5432"
     environment:
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_PASSWORD: ${DB_PASSWORD}


### PR DESCRIPTION
## 왜

두 가지를 한 PR로 묶음. 둘 다 운영 인프라 정합성 문제.

### 1. postgres 5432 외부 공개 (docker-compose.yml)
- pgAdmin 등에서 DB에 직접 접속할 수 있도록 `postgres` 서비스에 `ports: "5432:5432"` 추가.
- **이미 EC2에는 손으로 적용**해뒀으나, 배포 워크플로가 `scp`로 로컬 레포의 `docker-compose.yml`을 EC2에 덮어쓰기 때문에, 레포에 반영하지 않으면 **다음 배포에서 공개가 풀린다.** 이 PR이 그 드리프트를 막음.
- 인터넷 노출이므로 접근 통제는 **EC2 보안그룹**(인바운드 5432)에서 관리.

### 2. 배포 후 dangling 이미지 정리 (deploy.yml)
- 현재 배포는 매번 `docker pull ...:latest` → 이전 이미지가 태그를 잃고 **dangling으로 누적** → 디스크가 계속 참.
- `up -d --wait` 직후 `docker image prune -f` 추가. **dangling만** 제거하므로 사용 중인 `:latest`·`postgres:17`은 보존.

## 변경 파일
- `docker-compose.yml` — postgres `ports` 추가
- `.github/workflows/deploy.yml` — `docker image prune -f` 추가

## 리뷰 포인트
- `prune -f`(dangling) vs `-af`(미사용 태그 전체): 후자는 캐시 base 이미지까지 날려 빌드가 느려질 수 있어 `-f` 선택.
- 5432 전체 공개는 의도된 결정(스터디 데이터). 추후 IP 화이트리스트/DB 비번 강화는 별도 이슈.