### PR TITLE
✨feat(profile): 팀·멤버 프로필 이미지 S3 연동

### DIFF
--- a/src/main/java/com/study/profile/application/MemberService.java
+++ b/src/main/java/com/study/profile/application/MemberService.java
@@ -19,10 +19,13 @@ import com.study.profile.infrastructure.MemberGenerationRepository;
 import com.study.profile.infrastructure.MemberRepository;
 import com.study.profile.infrastructure.MemberTechStackRepository;
 import com.study.profile.infrastructure.TechStackRepository;
+import com.study.shared.s3.DomainS3Client;
+import com.study.shared.s3.PresignedUrlResponse;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.PersistenceContext;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,18 +42,21 @@ public class MemberService {
   private final UserRepository userRepository;
   private final TechStackRepository techStackRepository;
   private final MemberTechStackRepository memberTechStackRepository;
+  private final DomainS3Client memberS3Client;
 
   public MemberService(
       MemberRepository memberRepository,
       MemberGenerationRepository memberGenerationRepository,
       UserRepository userRepository,
       TechStackRepository techStackRepository,
-      MemberTechStackRepository memberTechStackRepository) {
+      MemberTechStackRepository memberTechStackRepository,
+      @Qualifier("profileS3Client") DomainS3Client memberS3Client) {
     this.memberRepository = memberRepository;
     this.memberGenerationRepository = memberGenerationRepository;
     this.userRepository = userRepository;
     this.techStackRepository = techStackRepository;
     this.memberTechStackRepository = memberTechStackRepository;
+    this.memberS3Client = memberS3Client;
   }
 
   public Member getMemberToUserId(Long userId) {
@@ -173,15 +179,34 @@ public class MemberService {
         memberRepository
             .findByUserId(userId)
             .orElseThrow(() -> new IllegalArgumentException("프로필을 찾을 수 없습니다."));
+
+    String profileImageUrl = member.getProfileImageUrl();
+    if (req.profileImageKey() != null) {
+      if (profileImageUrl != null) deleteFromS3(profileImageUrl);
+      profileImageUrl = memberS3Client.validateAndGetUrl(req.profileImageKey());
+    }
+
     member.update(
         req.name(),
         req.sessionType(),
         req.department(),
-        req.profileImageUrl(),
+        profileImageUrl,
         req.githubUrl(),
         req.displayedEmail(),
         req.intro(),
         req.linksJson());
     return MemberUpdateResponse.from(member);
+  }
+
+  public PresignedUrlResponse issueProfileImagePresignedUrl(Long userId, String filename) {
+    return memberS3Client
+        .issuePresignedUrls(userId, List.of(filename), "members/" + userId)
+        .get(0);
+  }
+
+  private void deleteFromS3(String imageUrl) {
+    int idx = imageUrl.indexOf(".amazonaws.com/");
+    if (idx < 0) return;
+    memberS3Client.delete(imageUrl.substring(idx + ".amazonaws.com/".length()));
   }
 }

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -6,6 +6,7 @@ import com.study.profile.application.dto.TeamDto.MyTeamResponse;
 import com.study.profile.application.dto.TeamDto.TeamCreateRequest;
 import com.study.profile.application.dto.TeamDto.TeamCreateResponse;
 import com.study.profile.application.dto.TeamDto.TeamDetailResponse;
+import com.study.profile.application.dto.TeamDto.TeamImagePresignedUrlRequest;
 import com.study.profile.application.dto.TeamDto.TeamJoinRequest;
 import com.study.profile.application.dto.TeamDto.TeamJoinResponse;
 import com.study.profile.application.dto.TeamDto.TeamLeadTransferRequest;
@@ -17,6 +18,8 @@ import com.study.profile.application.dto.TeamDto.TeamMemberSummary;
 import com.study.profile.application.dto.TeamDto.TeamUpdateRequest;
 import com.study.profile.application.dto.TeamDto.TeamUpdateResponse;
 import com.study.profile.application.dto.TeamDto.TechStackSummary;
+import com.study.shared.s3.DomainS3Client;
+import com.study.shared.s3.PresignedUrlResponse;
 import com.study.profile.domain.generation.Generation;
 import com.study.profile.domain.member.Member;
 import com.study.profile.domain.team.TeamImage;
@@ -38,13 +41,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 @Service
-@RequiredArgsConstructor
 public class TeamService {
 
   @PersistenceContext private EntityManager entityManager;
@@ -54,6 +57,22 @@ public class TeamService {
   private final MemberRepository memberRepository;
   private final GenerationRepository generationRepository;
   private final TechStackRepository techStackRepository;
+  private final DomainS3Client profileS3Client;
+
+  public TeamService(
+      TeamRepository teamRepository,
+      TeamMemberRepository teamMemberRepository,
+      MemberRepository memberRepository,
+      GenerationRepository generationRepository,
+      TechStackRepository techStackRepository,
+      @Qualifier("profileS3Client") DomainS3Client profileS3Client) {
+    this.teamRepository = teamRepository;
+    this.teamMemberRepository = teamMemberRepository;
+    this.memberRepository = memberRepository;
+    this.generationRepository = generationRepository;
+    this.techStackRepository = techStackRepository;
+    this.profileS3Client = profileS3Client;
+  }
 
   @Transactional
   public TeamCreateResponse createTeam(TeamCreateRequest req, Long userId) {
@@ -88,8 +107,9 @@ public class TeamService {
             inviteCode,
             inviteCodeExpiresAt);
 
-    // 5. 이미지 추가
-    team.updateImages(req.imageUrls());
+    // 5. 이미지 추가 (S3 key → 검증 후 공개 URL 변환)
+    List<String> imageUrls = resolveImageUrls(req.imageKeys());
+    team.updateImages(imageUrls);
 
     // 6. 기술 스택 추가
     if (req.techStackIds() != null && !req.techStackIds().isEmpty()) {
@@ -145,7 +165,21 @@ public class TeamService {
             ? team.getGithubUrl()
             : (req.githubUrl().isBlank() ? null : req.githubUrl()));
 
-    team.updateImages(req.imageUrls());
+    // keepImageUrls 또는 addImageKeys 중 하나라도 있으면 이미지 갱신
+    if (req.keepImageUrls() != null || req.addImageKeys() != null) {
+      List<String> keep = req.keepImageUrls() != null ? req.keepImageUrls() : List.of();
+      List<String> added = resolveImageUrls(req.addImageKeys());
+
+      // 유지 목록에 없는 기존 이미지 S3에서 삭제
+      team.getImages().stream()
+          .map(TeamImage::getImageUrl)
+          .filter(url -> !keep.contains(url))
+          .forEach(this::deleteFromS3);
+
+      List<String> finalUrls = new java.util.ArrayList<>(keep);
+      if (added != null) finalUrls.addAll(added);
+      team.updateImages(finalUrls);
+    }
 
     if (req.techStackIds() != null) {
       List<TechStack> techStacks =
@@ -351,6 +385,7 @@ public class TeamService {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "팀장만 삭제할 수 있습니다.");
     }
 
+    team.getImages().forEach(img -> deleteFromS3(img.getImageUrl()));
     teamMemberRepository.deleteByTeamId(teamId);
     teamRepository.delete(team);
   }
@@ -503,5 +538,22 @@ public class TeamService {
         techStacks,
         memberCount,
         thumbUrl);
+  }
+
+  public List<PresignedUrlResponse> issuePresignedUrls(
+      TeamImagePresignedUrlRequest req, Long userId) {
+    return profileS3Client.issuePresignedUrls(userId, req.filenames());
+  }
+
+  private List<String> resolveImageUrls(List<String> imageKeys) {
+    if (imageKeys == null) return null;
+    return imageKeys.stream().map(profileS3Client::validateAndGetUrl).toList();
+  }
+
+  private void deleteFromS3(String imageUrl) {
+    int idx = imageUrl.indexOf(".amazonaws.com/");
+    if (idx < 0) return;
+    String key = imageUrl.substring(idx + ".amazonaws.com/".length());
+    profileS3Client.delete(key);
   }
 }

--- a/src/main/java/com/study/profile/application/TeamService.java
+++ b/src/main/java/com/study/profile/application/TeamService.java
@@ -542,7 +542,7 @@ public class TeamService {
 
   public List<PresignedUrlResponse> issuePresignedUrls(
       TeamImagePresignedUrlRequest req, Long userId) {
-    return profileS3Client.issuePresignedUrls(userId, req.filenames());
+    return profileS3Client.issuePresignedUrls(userId, req.filenames(), "teams/temp/" + userId);
   }
 
   private List<String> resolveImageUrls(List<String> imageKeys) {

--- a/src/main/java/com/study/profile/application/dto/MemberUpdateRequest.java
+++ b/src/main/java/com/study/profile/application/dto/MemberUpdateRequest.java
@@ -8,7 +8,7 @@ public record MemberUpdateRequest(
     @NotBlank String name,
     @NotNull SessionType sessionType,
     String department,
-    String profileImageUrl,
+    String profileImageKey,
     String githubUrl,
     String displayedEmail,
     String intro,

--- a/src/main/java/com/study/profile/application/dto/TeamDto.java
+++ b/src/main/java/com/study/profile/application/dto/TeamDto.java
@@ -5,13 +5,15 @@ import java.util.List;
 
 public class TeamDto {
 
+  public record TeamImagePresignedUrlRequest(List<String> filenames) {}
+
   public record TeamCreateRequest(
       String name,
       String description,
       String projectUrl,
       String githubUrl,
       Integer generationNumber,
-      List<String> imageUrls,
+      List<String> imageKeys,
       List<Long> techStackIds) {}
 
   public record TeamCreateResponse(Long id, String inviteCode, Instant inviteCodeExpiresAt) {}
@@ -22,7 +24,8 @@ public class TeamDto {
       String projectUrl,
       String githubUrl,
       Integer generationNumber,
-      List<String> imageUrls,
+      List<String> keepImageUrls,
+      List<String> addImageKeys,
       List<Long> techStackIds) {}
 
   public record TeamUpdateResponse(Long id, Instant updatedAt) {}

--- a/src/main/java/com/study/profile/config/ProfileConfig.java
+++ b/src/main/java/com/study/profile/config/ProfileConfig.java
@@ -1,0 +1,22 @@
+package com.study.profile.config;
+
+import com.study.shared.ratelimit.RateLimitService;
+import com.study.shared.s3.DomainS3Client;
+import com.study.shared.s3.S3Properties;
+import com.study.shared.s3.S3Service;
+import com.study.shared.s3.S3UploadValidator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ProfileConfig {
+
+  @Bean
+  public DomainS3Client profileS3Client(
+      S3Service s3Service,
+      S3UploadValidator validator,
+      RateLimitService rateLimitService,
+      S3Properties props) {
+    return new DomainS3Client(props.bucket().profile(), s3Service, validator, rateLimitService);
+  }
+}

--- a/src/main/java/com/study/profile/presentation/MemberController.java
+++ b/src/main/java/com/study/profile/presentation/MemberController.java
@@ -16,12 +16,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
+import com.study.shared.s3.PresignedUrlResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -57,6 +59,17 @@ public class MemberController {
   public ResponseEntity<List<TechStackItemDto>> updateMyTechStacks(
       @RequestBody List<MemberTechStackUpdateRequest> req, @CurrentUser CustomUserDetails user) {
     return ResponseEntity.ok(memberService.updateMyTechStacks(user.userId(), req));
+  }
+
+  @Operation(
+      summary = "프로필 이미지 presigned URL 발급",
+      description = "S3에 직접 업로드할 presigned PUT URL을 발급합니다. 반환된 key를 프로필 수정 요청의 profileImageKey에 포함하세요.")
+  @PostMapping("/me/profile-image/presigned-url")
+  @PreAuthorize("hasAnyRole('PRESIDENT', 'ADMIN', 'MEMBER')")
+  public ResponseEntity<PresignedUrlResponse> issueProfileImagePresignedUrl(
+      @RequestParam String filename, @CurrentUser CustomUserDetails user) {
+    return ResponseEntity.ok(
+        memberService.issueProfileImagePresignedUrl(user.userId(), filename));
   }
 
   @PatchMapping("/me")

--- a/src/main/java/com/study/profile/presentation/TeamController.java
+++ b/src/main/java/com/study/profile/presentation/TeamController.java
@@ -7,6 +7,7 @@ import com.study.profile.application.dto.TeamDto.InviteCodeResponse;
 import com.study.profile.application.dto.TeamDto.TeamCreateRequest;
 import com.study.profile.application.dto.TeamDto.TeamCreateResponse;
 import com.study.profile.application.dto.TeamDto.TeamDetailResponse;
+import com.study.profile.application.dto.TeamDto.TeamImagePresignedUrlRequest;
 import com.study.profile.application.dto.TeamDto.TeamJoinRequest;
 import com.study.profile.application.dto.TeamDto.TeamJoinResponse;
 import com.study.profile.application.dto.TeamDto.TeamLeadTransferRequest;
@@ -16,6 +17,7 @@ import com.study.profile.application.dto.TeamDto.TeamMemberRoleUpdateRequest;
 import com.study.profile.application.dto.TeamDto.TeamMemberRoleUpdateResponse;
 import com.study.profile.application.dto.TeamDto.TeamUpdateRequest;
 import com.study.profile.application.dto.TeamDto.TeamUpdateResponse;
+import com.study.shared.s3.PresignedUrlResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -141,6 +143,17 @@ public class TeamController {
       @PathVariable Long teamId, @CurrentUser CustomUserDetails user) {
     teamService.deleteTeam(teamId, user.userId());
     return ResponseEntity.noContent().build();
+  }
+
+  @Operation(
+      summary = "팀 이미지 presigned URL 발급",
+      description =
+          "S3에 직접 업로드할 presigned PUT URL을 발급합니다. 반환된 key를 팀 생성/수정 요청의 imageKeys에 포함하세요.")
+  @PostMapping("/images/presigned-urls")
+  @PreAuthorize("hasAnyRole('ADMIN', 'MEMBER')")
+  public ResponseEntity<List<PresignedUrlResponse>> issuePresignedUrls(
+      @RequestBody TeamImagePresignedUrlRequest req, @CurrentUser CustomUserDetails user) {
+    return ResponseEntity.ok(teamService.issuePresignedUrls(req, user.userId()));
   }
 
   @Operation(

--- a/src/main/java/com/study/shared/s3/DomainS3Client.java
+++ b/src/main/java/com/study/shared/s3/DomainS3Client.java
@@ -64,6 +64,16 @@ public final class DomainS3Client {
     return s3Service.generatePresignedPutUrls(bucket, filenames);
   }
 
+  /** prefix 지정 버전 — S3 키를 {prefix}/{UUID}.{ext} 형태로 생성. */
+  public List<PresignedUrlResponse> issuePresignedUrls(
+      Long userId, List<String> filenames, String prefix) {
+    if (!rateLimitService.tryConsume(userId)) {
+      throw new S3Exception(S3ErrorCode.UPLOAD_RATE_LIMITED);
+    }
+    validator.validateFilenames(filenames);
+    return s3Service.generatePresignedPutUrls(bucket, prefix, filenames);
+  }
+
   /**
    * 업로드 완료된 파일 검증 후 공개 URL 반환.
    *

--- a/src/main/java/com/study/shared/s3/S3Properties.java
+++ b/src/main/java/com/study/shared/s3/S3Properties.java
@@ -13,7 +13,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record S3Properties(
     BucketProperties bucket, long presignedUrlExpiration, UploadConstraints upload) {
 
-  public record BucketProperties(String event, String session) {}
+  public record BucketProperties(String event, String session, String profile) {}
 
   /**
    * 업로드 제약 설정.

--- a/src/main/java/com/study/shared/s3/S3Service.java
+++ b/src/main/java/com/study/shared/s3/S3Service.java
@@ -61,6 +61,19 @@ public class S3Service {
         .toList();
   }
 
+  /** prefix 지정 버전 — 경로를 {prefix}/{UUID}.{ext} 형태로 생성. */
+  public List<PresignedUrlResponse> generatePresignedPutUrls(
+      String bucket, String prefix, List<String> filenames) {
+    return filenames.stream()
+        .map(
+            filename -> {
+              String key = generateKey(prefix, filename);
+              String presignedUrl = presignPutUrl(bucket, key, null, presignedUrlExpiration);
+              return new PresignedUrlResponse(presignedUrl, key);
+            })
+        .toList();
+  }
+
   /**
    * 단건 presigned PUT URL 생성 (Content-Type 고정).
    *
@@ -110,12 +123,17 @@ public class S3Service {
    * <p>형식: {@code images/{UUID}.{ext}}
    */
   public String generateKey(String filename) {
-    String ext = "";
+    return "images/" + UUID.randomUUID() + extractExt(filename);
+  }
+
+  /** prefix 지정 버전 — 형식: {@code {prefix}/{UUID}.{ext}} */
+  public String generateKey(String prefix, String filename) {
+    return prefix + "/" + UUID.randomUUID() + extractExt(filename);
+  }
+
+  private String extractExt(String filename) {
     int dotIndex = filename.lastIndexOf('.');
-    if (dotIndex >= 0) {
-      ext = filename.substring(dotIndex);
-    }
-    return "images/" + UUID.randomUUID() + ext;
+    return dotIndex >= 0 ? filename.substring(dotIndex) : "";
   }
 
   // ----------------------------------------------------------------

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,6 +49,7 @@ spring:
         bucket:
           event: ${S3_BUCKET_EVENT}       # 이벤트 게시글 이미지 버킷
           session: ${S3_BUCKET_SESSION}   # 세션보드 이미지 버킷
+          profile: ${S3_BUCKET_PROFILE}   # 프로필 팀 이미지 버킷
         presigned-url-expiration: ${S3_PRESIGNED_URL_EXPIRATION:180}  # 초 단위, 기본 3분
         upload:
           max-file-size-bytes: 10485760   # 10MB

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,7 +49,7 @@ spring:
         bucket:
           event: ${S3_BUCKET_EVENT}       # 이벤트 게시글 이미지 버킷
           session: ${S3_BUCKET_SESSION}   # 세션보드 이미지 버킷
-          profile: ${S3_BUCKET_PROFILE}   # 프로필 팀 이미지 버킷
+          profile: ${S3_BUCKET_PROFILE}   # 프로필 이미지 버킷 (팀·멤버 공용)
         presigned-url-expiration: ${S3_PRESIGNED_URL_EXPIRATION:180}  # 초 단위, 기본 3분
         upload:
           max-file-size-bytes: 10485760   # 10MB


### PR DESCRIPTION
 ## WHY
  팀 프로필 프로젝트 사진 및 멤버 개인 프로필 이미지를 실제 파일로 업로드할 수 있도록 S3 연동

  ## WHAT
  - 팀 이미지 / 멤버 프로필 이미지 S3 presigned URL 업로드 방식 적용
  - 프로필 전용 S3 버킷(`S3_BUCKET_PROFILE`) 추가 — 팀·멤버 공용
  - 팀 이미지 부분 삭제·추가 지원 (`keepImageUrls` + `addImageKeys`)

  ## HOW
  - `ProfileConfig` — `profileS3Client` DomainS3Client 빈 등록
  - `POST /api/profile/teams/images/presigned-urls` — 팀 이미지 presigned URL 발급 (경로: `teams/temp/{userId}/`)
  - `POST /api/profile/members/me/profile-image/presigned-url` — 멤버 프사 presigned URL 발급 (경로: `members/{userId}/`)
  - `TeamUpdateRequest` — `imageUrls` → `keepImageUrls` + `addImageKeys` 분리
  - `MemberUpdateRequest` — `profileImageUrl` → `profileImageKey` (S3 key 전달)
  - 팀 삭제·이미지 교체 시 기존 S3 파일 자동 삭제
