### PR TITLE
feat(qna): QnA 활동 통합 이벤트 발행 구현

### DIFF
--- a/src/main/java/com/study/qna/application/QuestionService.java
+++ b/src/main/java/com/study/qna/application/QuestionService.java
@@ -14,12 +14,16 @@ import com.study.qna.domain.Tag;
 import com.study.qna.domain.exception.ForbiddenQnaActionException;
 import com.study.qna.domain.exception.QuestionNotFoundException;
 import com.study.qna.domain.exception.TagNotFoundException;
+import com.study.qna.infrastructure.AnswerRepository;
 import com.study.qna.infrastructure.QuestionRepository;
 import com.study.qna.infrastructure.TagRepository;
+import com.study.shared.extevent.qna.QnaQuestionCreated;
+import com.study.shared.extevent.qna.QnaQuestionDeleted;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +36,9 @@ public class QuestionService {
 
   private final QuestionRepository questionRepository;
   private final TagRepository tagRepository;
+  private final AnswerRepository answerRepository;
+  private final AnswerService answerService;
+  private final ApplicationEventPublisher eventPublisher;
 
   public List<QuestionSummaryResponse> getQuestions(QuestionSearchCondition condition) {
     return questionRepository.searchQuestions(condition).stream()
@@ -62,6 +69,7 @@ public class QuestionService {
     }
 
     Question saved = questionRepository.save(question);
+    eventPublisher.publishEvent(new QnaQuestionCreated(userId, saved.getId()));
     return toDetailResponse(saved);
   }
 
@@ -121,7 +129,12 @@ public class QuestionService {
       throw new ForbiddenQnaActionException();
     }
 
+    // DB CASCADE 방지: 답변과 그 댓글을 서비스 레벨에서 먼저 삭제해 이벤트 발행
+    answerRepository.findByQuestionId(questionId)
+        .forEach(answerService::deleteAnswerCascade);
+
     questionRepository.delete(question);
+    eventPublisher.publishEvent(new QnaQuestionDeleted(userId, questionId));
   }
 
   private List<Tag> fetchAndValidateTags(List<Long> tagIds) {


### PR DESCRIPTION
## 개요

  profile 팀 활동 통합 PR에서 요청된 QnA 이벤트 발행을 구현합니다.
  `QuestionService`에 누락된 이벤트 발행과 질문 삭제 시 cascade 처리를 추가했습니다.

  ## 변경 사항

  **`QuestionService.java`**

  - `ApplicationEventPublisher`, `AnswerRepository`, `AnswerService` 의존성 추가
  - `createQuestion` — 저장 직후 `QnaQuestionCreated` 발행
  - `deleteQuestion` — 답변·댓글 서비스 레벨 cascade 삭제 후 `QnaQuestionDeleted` 발행

  ## 이벤트 발행 현황

  | 이벤트 | 위치 | 상태 |
  |---|---|---|
  | `QnaQuestionCreated` | `QuestionService.createQuestion` | ✅ 이번 PR |
  | `QnaQuestionDeleted` | `QuestionService.deleteQuestion` | ✅ 이번 PR |
  | `QnaAnswerCreated` | `AnswerService.createAnswer` | ✅ 기구현 |
  | `QnaAnswerDeleted` | `AnswerService.deleteAnswer` | ✅ 기구현 |
  | `QnaAnswerAccepted` | `AnswerService.acceptAnswer` | ✅ 기구현 |
  | `QnaAnswerUnaccepted` | `AnswerService.cancelAcceptAnswer` | ✅ 기구현 |
  | `QnaCommentCreated` | `CommentService.createComment` | ✅ 기구현 |
  | `QnaCommentDeleted` | `CommentService.deleteComment` | ✅ 기구현 |

  ## Cascade 처리

  PR에서 요청된 "Service cascade" 구현 내용입니다.

  질문 삭제 시 DB CASCADE에 의존하면 답변·댓글의 `Deleted` 이벤트가 발행되지 않아 활동 점수가 회수되지 않는 문제가
  있음 -> 코드 단에서 직접 순서대로 지우며 이벤트를 발햄함

  1. 질문에 달린 답변 목록을 조회
  2. 각 답변에 대해:
     2-1. 그 답변에 달린 댓글들을 먼저 삭제 → QnaCommentDeleted 이벤트 발행 (근엽 -3점)
     2-2. 그 답변을 삭제 → QnaAnswerDeleted 이벤트 발행 (근엽 -10점)
  3. 질문 삭제 → QnaQuestionDeleted 이벤트 발행

  deleteQuestion
    └─ answerRepository.findByQuestionId → 답변 목록
        └─ answerService.deleteAnswerCascade(answer) for each
            ├─ 해당 답변의 댓글 삭제 + QnaCommentDeleted 발행
            └─ 답변 삭제 + QnaAnswerDeleted 발행
    └─ 질문 삭제 + QnaQuestionDeleted 발행

  Service에서 자식을 먼저 삭제하므로 부모 삭제 시 DB CASCADE는 0 rows로 안전합니다.