### PR TITLE
🪽 refactor(profile): 팀 이미지 컬렉션 Set → List 변경 및 등록 순서 보장

### DIFF
--- a/src/main/java/com/study/profile/domain/team/TeamProfile.java
+++ b/src/main/java/com/study/profile/domain/team/TeamProfile.java
@@ -13,10 +13,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -74,9 +76,9 @@ public class TeamProfile {
   @Column(name = "updated_at", nullable = false)
   private Instant updatedAt; // 마지막 수정 시각
 
-  // 시현 N+1 수정: List(Bag) → Set 전환 — MultipleBagFetchException 및 JOIN FETCH 중복 방지
   @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
-  private Set<TeamImage> images = new HashSet<>();
+  @OrderBy("id ASC")
+  private List<TeamImage> images = new ArrayList<>();
 
   @OneToMany(mappedBy = "team")
   private Set<TeamMember> members = new HashSet<>();


### PR DESCRIPTION
## WHY                                                                                                                                                                                                       
  팀 이미지가 Set으로 관리되어 등록 순서가 보장되지 않았습니다.

  ## WHAT
  - TeamProfile.images 타입 Set → List 변경
  - @OrderBy("id ASC") 추가로 등록 순서 보장

  ## HOW
  - List는 techStacks(Set)와 달리 단일 Bag이라 MultipleBagFetchException 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the team image storage mechanism to ensure consistent ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->