### PR TITLE
feat: 세션 보드 이벤트 발행 추가

### DIFF
--- a/src/main/java/com/study/sessionboard/application/event/EventPostService.java
+++ b/src/main/java/com/study/sessionboard/application/event/EventPostService.java
@@ -24,7 +24,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import com.study.shared.extevent.sessionboard.SessionEventCommentCreated;
+import com.study.shared.extevent.sessionboard.SessionEventCommentDeleted;
+import com.study.shared.extevent.sessionboard.SessionEventPostCreated;
+import com.study.shared.extevent.sessionboard.SessionEventPostDeleted;
+import com.study.shared.extevent.sessionboard.SessionEventPostLiked;
+import com.study.shared.extevent.sessionboard.SessionEventPostUnliked;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -42,6 +49,7 @@ public class EventPostService {
   private final MemberRepository memberRepository;
   private final MemberService memberService;
   private final GenerationService generationService;
+  private final ApplicationEventPublisher eventPublisher;
 
   public PageWrapper<EventPostSummaryResponse> getEventPosts(
       Integer generationNumber, EventPostType type, Pageable pageable) { // generation number로 시현 수정
@@ -106,7 +114,9 @@ public class EventPostService {
             request.body(),
             request.tags() != null ? request.tags().toArray(new String[0]) : null);
 
-    return eventPostRepository.save(post).getId();
+    Long postId = eventPostRepository.save(post).getId();
+    eventPublisher.publishEvent(new SessionEventPostCreated(userId, postId));
+    return postId;
   }
 
   @Transactional
@@ -139,6 +149,7 @@ public class EventPostService {
     }
 
     eventPostRepository.delete(post);
+    eventPublisher.publishEvent(new SessionEventPostDeleted(userId, eventPostId));
   }
 
   @Transactional
@@ -152,13 +163,17 @@ public class EventPostService {
     Optional<EventPostLike> existing =
         eventPostLikeRepository.findByMemberIdAndPostId(member.getId(), postId);
 
+    Long postOwnerId = post.getAuthor().getUser().getId();
+
     if (existing.isPresent()) {
       eventPostLikeRepository.delete(existing.get());
       post.decrementLikeCount();
+      eventPublisher.publishEvent(new SessionEventPostUnliked(userId, postId, postOwnerId));
       return new LikeToggleResponse(false, post.getLikeCount());
     } else {
       eventPostLikeRepository.save(EventPostLike.of(member, post));
       post.incrementLikeCount();
+      eventPublisher.publishEvent(new SessionEventPostLiked(userId, postId, postOwnerId));
       return new LikeToggleResponse(true, post.getLikeCount());
     }
   }
@@ -197,6 +212,7 @@ public class EventPostService {
     EventPostComment comment = EventPostComment.of(post, author, request.content());
     eventPostCommentRepository.save(comment);
     post.incrementCommentCount();
+    eventPublisher.publishEvent(new SessionEventCommentCreated(userId, postId, comment.getId()));
 
     return CommentResponse.of(comment, List.of());
   }
@@ -226,8 +242,10 @@ public class EventPostService {
       throw new EventPostException(EventPostErrorCode.FORBIDDEN);
     }
 
+    Long commentPostId = comment.getPost().getId();
     eventPostCommentRepository.delete(comment);
     comment.getPost().decrementCommentCount();
+    eventPublisher.publishEvent(new SessionEventCommentDeleted(userId, commentPostId, commentId));
   }
 
   @Transactional
@@ -248,6 +266,7 @@ public class EventPostService {
     EventPostComment reply = EventPostComment.ofReply(post, author, parent, request.content());
     eventPostCommentRepository.save(reply);
     post.incrementCommentCount();
+    eventPublisher.publishEvent(new SessionEventCommentCreated(userId, postId, reply.getId()));
 
     return CommentResponse.of(reply, List.of());
   }
@@ -279,7 +298,9 @@ public class EventPostService {
       throw new EventPostException(EventPostErrorCode.FORBIDDEN);
     }
 
+    Long replyPostId = reply.getPost().getId();
     eventPostCommentRepository.delete(reply);
     reply.getPost().decrementCommentCount();
+    eventPublisher.publishEvent(new SessionEventCommentDeleted(userId, replyPostId, replyId));
   }
 }

--- a/src/main/java/com/study/sessionboard/application/session/SessionService.java
+++ b/src/main/java/com/study/sessionboard/application/session/SessionService.java
@@ -12,9 +12,14 @@ import com.study.sessionboard.infrastructure.session.SessionNoteRepository;
 import com.study.sessionboard.infrastructure.session.SessionRepository;
 import com.study.sessionboard.infrastructure.session.SessionSpeakerRepository;
 import com.study.sessionboard.presentation.dto.session.*;
+import com.study.shared.extevent.sessionboard.SessionSpeakerRegistered;
+import com.study.shared.extevent.sessionboard.SessionSpeakerUnregistered;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +35,7 @@ public class SessionService {
   private final RetroRepository retroRepository;
   private final GenerationRepository generationRepository;
   private final MemberRepository memberRepository;
+  private final ApplicationEventPublisher eventPublisher;
 
   public List<SessionResponse> getSessions(Integer generationNumber, SessionStatus status) {
     if (!generationRepository.existsById(generationNumber)) {
@@ -79,6 +85,8 @@ public class SessionService {
       speakers.forEach(
           member -> {
             savedSession.addSpeaker(SessionSpeaker.of(savedSession, member));
+            eventPublisher.publishEvent(
+                new SessionSpeakerRegistered(member.getUser().getId(), savedSession.getId()));
           });
     }
 
@@ -96,6 +104,11 @@ public class SessionService {
     session.update(request.weekLabel(), request.title(), request.status(), request.startedAt());
 
     if (request.speakerIds() != null) {
+      Set<Long> existingUserIds =
+          session.getSpeakers().stream()
+              .map(s -> s.getMember().getUser().getId())
+              .collect(Collectors.toSet());
+
       session.getSpeakers().clear();
       List<Member> speakers = memberRepository.findAllById(request.speakerIds());
 
@@ -103,10 +116,22 @@ public class SessionService {
         throw new IllegalArgumentException("존재하지 않는 스피커 ID가 포함되어 있습니다.");
       }
 
-      speakers.forEach(
-          member -> {
-            session.addSpeaker(SessionSpeaker.of(session, member));
-          });
+      Set<Long> newUserIds =
+          speakers.stream().map(m -> m.getUser().getId()).collect(Collectors.toSet());
+
+      speakers.forEach(member -> session.addSpeaker(SessionSpeaker.of(session, member)));
+
+      existingUserIds.stream()
+          .filter(id -> !newUserIds.contains(id))
+          .forEach(
+              uid ->
+                  eventPublisher.publishEvent(new SessionSpeakerUnregistered(uid, sessionId)));
+
+      newUserIds.stream()
+          .filter(id -> !existingUserIds.contains(id))
+          .forEach(
+              uid ->
+                  eventPublisher.publishEvent(new SessionSpeakerRegistered(uid, sessionId)));
     }
 
     return OffsetDateTime.now(); // Updated at is not in the entity, using current time for response


### PR DESCRIPTION
## feat: sessionboard 통합 이벤트 발행 구현

  ### 개요

  `shared/extevent/sessionboard`에 정의된 8개 이벤트 record를 실제로 발행하도록
  `EventPostService`와 `SessionService`에 `publishEvent` 호출을 추가했습니다.
  
  ---

  ### 변경 파일

  - `sessionboard/application/event/EventPostService.java`
  - `sessionboard/application/session/SessionService.java`

  ---

  ### 발행 이벤트

  **`EventPostService`**

  | 메서드 | 이벤트 | 발행 시점 |
  |---|---|---|
  | `createEventPost` | `SessionEventPostCreated(userId, postId)` | `save` 직후 |
  | `deleteEventPost` | `SessionEventPostDeleted(userId, postId)` | `delete` 직후 |
  | `toggleLike` | `SessionEventPostLiked(userId, postId, postOwnerId)` | 좋아요 켜질 때 |
  | `toggleLike` | `SessionEventPostUnliked(userId, postId, postOwnerId)` | 좋아요 꺼질 때 |
  | `createComment` | `SessionEventCommentCreated(userId, postId, commentId)` | `save` 직후 |
  | `deleteComment` | `SessionEventCommentDeleted(userId, postId, commentId)` | `delete` 직후 |
  | `createReply` | `SessionEventCommentCreated(userId, postId, replyId)` | `save` 직후 |
  | `deleteReply` | `SessionEventCommentDeleted(userId, postId, replyId)` | `delete` 직후 |

  > 대댓글(`createReply`, `deleteReply`)도 댓글과 동일한 이벤트 타입 사용. commentId 자리에 replyId가 들어감.

  **`SessionService`**

  | 메서드 | 이벤트 | 발행 조건 |
  |---|---|---|
  | `createSession` | `SessionSpeakerRegistered(userId, sessionId)` | 발표자 목록 순회 시 각각 발행 |
  | `updateSession` | `SessionSpeakerRegistered(userId, sessionId)` | 새로 추가된 발표자 |
  | `updateSession` | `SessionSpeakerUnregistered(userId, sessionId)` | 제거된 발표자 |

  > `updateSession`은 기존 speakerIds와 새 speakerIds를 diff해서 변경분에만 이벤트 발행.
  > `speakerIds == null`이면 발표자 변경 없으므로 이벤트 발행 안 함.

  ---

  ### 컨벤션 준수

  - 모든 발행은 `@Transactional` 메서드 내 `save`/`delete` 직후
  - 이벤트 의미 검증은 consumer 책임 (producer는 단순 발행만)
  - payload는 식별자만 (`userId`, `postId`, `commentId` 등)

  ---

  ### 연관 문서

  - `shared/extevent/sessionboard/README.md`
  - `docs/conventions/통합-이벤트.md`